### PR TITLE
chore: fix system tests using pack-n-play when running JS

### DIFF
--- a/packages/google-ads-admanager/system-test/install.ts
+++ b/packages/google-ads-admanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-ads-datamanager/system-test/install.ts
+++ b/packages/google-ads-datamanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-ai-generativelanguage/system-test/install.ts
+++ b/packages/google-ai-generativelanguage/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-analytics-admin/system-test/install.ts
+++ b/packages/google-analytics-admin/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-analytics-data/system-test/install.ts
+++ b/packages/google-analytics-data/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-api-apikeys/system-test/install.ts
+++ b/packages/google-api-apikeys/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-api-cloudquotas/system-test/install.ts
+++ b/packages/google-api-cloudquotas/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-api-servicecontrol/system-test/install.ts
+++ b/packages/google-api-servicecontrol/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-api-servicemanagement/system-test/install.ts
+++ b/packages/google-api-servicemanagement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-api-serviceusage/system-test/install.ts
+++ b/packages/google-api-serviceusage/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-appengine/system-test/install.ts
+++ b/packages/google-appengine/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-apps-events-subscriptions/system-test/install.ts
+++ b/packages/google-apps-events-subscriptions/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-apps-meet/system-test/install.ts
+++ b/packages/google-apps-meet/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-area120-tables/system-test/install.ts
+++ b/packages/google-area120-tables/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-chat/system-test/install.ts
+++ b/packages/google-chat/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-accessapproval/system-test/install.ts
+++ b/packages/google-cloud-accessapproval/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-advisorynotifications/system-test/install.ts
+++ b/packages/google-cloud-advisorynotifications/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-aiplatform/system-test/install.ts
+++ b/packages/google-cloud-aiplatform/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-alloydb/system-test/install.ts
+++ b/packages/google-cloud-alloydb/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apigateway/system-test/install.ts
+++ b/packages/google-cloud-apigateway/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apigeeconnect/system-test/install.ts
+++ b/packages/google-cloud-apigeeconnect/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apigeeregistry/system-test/install.ts
+++ b/packages/google-cloud-apigeeregistry/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apigeeregistry/system-test/install.ts
+++ b/packages/google-cloud-apigeeregistry/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apihub/system-test/install.ts
+++ b/packages/google-cloud-apihub/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apiregistry/system-test/install.ts
+++ b/packages/google-cloud-apiregistry/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-apphub/system-test/install.ts
+++ b/packages/google-cloud-apphub/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-asset/system-test/install.ts
+++ b/packages/google-cloud-asset/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-assuredworkloads/system-test/install.ts
+++ b/packages/google-cloud-assuredworkloads/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-auditmanager/system-test/install.ts
+++ b/packages/google-cloud-auditmanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-automl/system-test/install.ts
+++ b/packages/google-cloud-automl/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-backupdr/system-test/install.ts
+++ b/packages/google-cloud-backupdr/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-baremetalsolution/system-test/install.ts
+++ b/packages/google-cloud-baremetalsolution/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-batch/system-test/install.ts
+++ b/packages/google-cloud-batch/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-beyondcorp-appconnections/system-test/install.ts
+++ b/packages/google-cloud-beyondcorp-appconnections/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-beyondcorp-appconnectors/system-test/install.ts
+++ b/packages/google-cloud-beyondcorp-appconnectors/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-beyondcorp-appgateways/system-test/install.ts
+++ b/packages/google-cloud-beyondcorp-appgateways/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/system-test/install.ts
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-beyondcorp-clientgateways/system-test/install.ts
+++ b/packages/google-cloud-beyondcorp-clientgateways/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-analyticshub/system-test/install.ts
+++ b/packages/google-cloud-bigquery-analyticshub/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-connection/system-test/install.ts
+++ b/packages/google-cloud-bigquery-connection/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-dataexchange/system-test/install.ts
+++ b/packages/google-cloud-bigquery-dataexchange/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-datapolicies/system-test/install.ts
+++ b/packages/google-cloud-bigquery-datapolicies/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-datatransfer/system-test/install.ts
+++ b/packages/google-cloud-bigquery-datatransfer/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-migration/system-test/install.ts
+++ b/packages/google-cloud-bigquery-migration/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-bigquery-reservation/system-test/install.ts
+++ b/packages/google-cloud-bigquery-reservation/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-billing-budgets/system-test/install.ts
+++ b/packages/google-cloud-billing-budgets/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-billing/system-test/install.ts
+++ b/packages/google-cloud-billing/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-binaryauthorization/system-test/install.ts
+++ b/packages/google-cloud-binaryauthorization/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-capacityplanner/system-test/install.ts
+++ b/packages/google-cloud-capacityplanner/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-certificatemanager/system-test/install.ts
+++ b/packages/google-cloud-certificatemanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-ces/system-test/install.ts
+++ b/packages/google-cloud-ces/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-channel/system-test/install.ts
+++ b/packages/google-cloud-channel/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-chronicle/system-test/install.ts
+++ b/packages/google-cloud-chronicle/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-cloudcontrolspartner/system-test/install.ts
+++ b/packages/google-cloud-cloudcontrolspartner/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-clouddms/system-test/install.ts
+++ b/packages/google-cloud-clouddms/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-cloudsecuritycompliance/system-test/install.ts
+++ b/packages/google-cloud-cloudsecuritycompliance/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-commerce-consumer-procurement/system-test/install.ts
+++ b/packages/google-cloud-commerce-consumer-procurement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-compute/system-test/install.ts
+++ b/packages/google-cloud-compute/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-confidentialcomputing/system-test/install.ts
+++ b/packages/google-cloud-confidentialcomputing/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-config/system-test/install.ts
+++ b/packages/google-cloud-config/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-configdelivery/system-test/install.ts
+++ b/packages/google-cloud-configdelivery/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-connectors/system-test/install.ts
+++ b/packages/google-cloud-connectors/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-contactcenterinsights/system-test/install.ts
+++ b/packages/google-cloud-contactcenterinsights/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-contentwarehouse/system-test/install.ts
+++ b/packages/google-cloud-contentwarehouse/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/system-test/install.ts
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datacatalog-lineage/system-test/install.ts
+++ b/packages/google-cloud-datacatalog-lineage/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datacatalog/system-test/install.ts
+++ b/packages/google-cloud-datacatalog/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dataform/system-test/install.ts
+++ b/packages/google-cloud-dataform/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datafusion/system-test/install.ts
+++ b/packages/google-cloud-datafusion/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datalabeling/system-test/install.ts
+++ b/packages/google-cloud-datalabeling/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dataplex/system-test/install.ts
+++ b/packages/google-cloud-dataplex/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dataproc/system-test/install.ts
+++ b/packages/google-cloud-dataproc/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dataqna/system-test/install.ts
+++ b/packages/google-cloud-dataqna/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-datastream/system-test/install.ts
+++ b/packages/google-cloud-datastream/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-deploy/system-test/install.ts
+++ b/packages/google-cloud-deploy/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-developerconnect/system-test/install.ts
+++ b/packages/google-cloud-developerconnect/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-devicestreaming/system-test/install.ts
+++ b/packages/google-cloud-devicestreaming/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dialogflow-cx/system-test/install.ts
+++ b/packages/google-cloud-dialogflow-cx/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-dialogflow/system-test/install.ts
+++ b/packages/google-cloud-dialogflow/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-discoveryengine/system-test/install.ts
+++ b/packages/google-cloud-discoveryengine/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-documentai/system-test/install.ts
+++ b/packages/google-cloud-documentai/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-domains/system-test/install.ts
+++ b/packages/google-cloud-domains/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-edgecontainer/system-test/install.ts
+++ b/packages/google-cloud-edgecontainer/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-edgenetwork/system-test/install.ts
+++ b/packages/google-cloud-edgenetwork/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-essentialcontacts/system-test/install.ts
+++ b/packages/google-cloud-essentialcontacts/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-eventarc-publishing/system-test/install.ts
+++ b/packages/google-cloud-eventarc-publishing/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-eventarc/system-test/install.ts
+++ b/packages/google-cloud-eventarc/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-filestore/system-test/install.ts
+++ b/packages/google-cloud-filestore/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-financialservices/system-test/install.ts
+++ b/packages/google-cloud-financialservices/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-functions/system-test/install.ts
+++ b/packages/google-cloud-functions/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gdchardwaremanagement/system-test/install.ts
+++ b/packages/google-cloud-gdchardwaremanagement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-geminidataanalytics/system-test/install.ts
+++ b/packages/google-cloud-geminidataanalytics/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gkebackup/system-test/install.ts
+++ b/packages/google-cloud-gkebackup/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gkeconnect-gateway/system-test/install.ts
+++ b/packages/google-cloud-gkeconnect-gateway/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gkehub/system-test/install.ts
+++ b/packages/google-cloud-gkehub/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gkemulticloud/system-test/install.ts
+++ b/packages/google-cloud-gkemulticloud/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gkerecommender/system-test/install.ts
+++ b/packages/google-cloud-gkerecommender/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-gsuiteaddons/system-test/install.ts
+++ b/packages/google-cloud-gsuiteaddons/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-hypercomputecluster/system-test/install.ts
+++ b/packages/google-cloud-hypercomputecluster/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-iap/system-test/install.ts
+++ b/packages/google-cloud-iap/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-ids/system-test/install.ts
+++ b/packages/google-cloud-ids/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-iot/system-test/install.ts
+++ b/packages/google-cloud-iot/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-kms-inventory/system-test/install.ts
+++ b/packages/google-cloud-kms-inventory/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-kms/system-test/install.ts
+++ b/packages/google-cloud-kms/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-language/system-test/install.ts
+++ b/packages/google-cloud-language/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-licensemanager/system-test/install.ts
+++ b/packages/google-cloud-licensemanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-lifesciences/system-test/install.ts
+++ b/packages/google-cloud-lifesciences/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-locationfinder/$1/system-test/install.ts
+++ b/packages/google-cloud-locationfinder/$1/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-locationfinder/system-test/install.ts
+++ b/packages/google-cloud-locationfinder/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-lustre/system-test/install.ts
+++ b/packages/google-cloud-lustre/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-maintenance-api/system-test/install.ts
+++ b/packages/google-cloud-maintenance-api/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-managedidentities/system-test/install.ts
+++ b/packages/google-cloud-managedidentities/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-managedkafka-schemaregistry/system-test/install.ts
+++ b/packages/google-cloud-managedkafka-schemaregistry/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-managedkafka/system-test/install.ts
+++ b/packages/google-cloud-managedkafka/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-managedkafka/v1/system-test/install.ts
+++ b/packages/google-cloud-managedkafka/v1/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-mediatranslation/system-test/install.ts
+++ b/packages/google-cloud-mediatranslation/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-memcache/system-test/install.ts
+++ b/packages/google-cloud-memcache/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-memorystore/system-test/install.ts
+++ b/packages/google-cloud-memorystore/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-metastore/system-test/install.ts
+++ b/packages/google-cloud-metastore/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-migrationcenter/system-test/install.ts
+++ b/packages/google-cloud-migrationcenter/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-modelarmor/system-test/install.ts
+++ b/packages/google-cloud-modelarmor/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-monitoring/system-test/install.ts
+++ b/packages/google-cloud-monitoring/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-netapp/system-test/install.ts
+++ b/packages/google-cloud-netapp/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-networkconnectivity/system-test/install.ts
+++ b/packages/google-cloud-networkconnectivity/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-networkmanagement/system-test/install.ts
+++ b/packages/google-cloud-networkmanagement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-networksecurity/system-test/install.ts
+++ b/packages/google-cloud-networksecurity/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-networkservices/system-test/install.ts
+++ b/packages/google-cloud-networkservices/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-notebooks/system-test/install.ts
+++ b/packages/google-cloud-notebooks/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-oracledatabase/system-test/install.ts
+++ b/packages/google-cloud-oracledatabase/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-orchestration-airflow-service/system-test/install.ts
+++ b/packages/google-cloud-orchestration-airflow-service/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-orgpolicy/system-test/install.ts
+++ b/packages/google-cloud-orgpolicy/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-osconfig/system-test/install.ts
+++ b/packages/google-cloud-osconfig/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-oslogin/system-test/install.ts
+++ b/packages/google-cloud-oslogin/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-parallelstore/system-test/install.ts
+++ b/packages/google-cloud-parallelstore/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-parametermanager/system-test/install.ts
+++ b/packages/google-cloud-parametermanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-phishingprotection/system-test/install.ts
+++ b/packages/google-cloud-phishingprotection/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-policysimulator/system-test/install.ts
+++ b/packages/google-cloud-policysimulator/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-policytroubleshooter-iam/system-test/install.ts
+++ b/packages/google-cloud-policytroubleshooter-iam/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-policytroubleshooter/system-test/install.ts
+++ b/packages/google-cloud-policytroubleshooter/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-privatecatalog/system-test/install.ts
+++ b/packages/google-cloud-privatecatalog/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-privilegedaccessmanager/system-test/install.ts
+++ b/packages/google-cloud-privilegedaccessmanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-rapidmigrationassessment/system-test/install.ts
+++ b/packages/google-cloud-rapidmigrationassessment/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-recaptchaenterprise/system-test/install.ts
+++ b/packages/google-cloud-recaptchaenterprise/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-recommender/system-test/install.ts
+++ b/packages/google-cloud-recommender/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-redis-cluster/system-test/install.ts
+++ b/packages/google-cloud-redis-cluster/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-redis/system-test/install.ts
+++ b/packages/google-cloud-redis/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-resourcemanager/system-test/install.ts
+++ b/packages/google-cloud-resourcemanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-retail/system-test/install.ts
+++ b/packages/google-cloud-retail/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-run/system-test/install.ts
+++ b/packages/google-cloud-run/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-saasplatform-saasservicemgmt/system-test/install.ts
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-scheduler/system-test/install.ts
+++ b/packages/google-cloud-scheduler/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-secretmanager/system-test/install.ts
+++ b/packages/google-cloud-secretmanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-securesourcemanager/system-test/install.ts
+++ b/packages/google-cloud-securesourcemanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-security-privateca/system-test/install.ts
+++ b/packages/google-cloud-security-privateca/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-security-publicca/system-test/install.ts
+++ b/packages/google-cloud-security-publicca/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-securitycenter/system-test/install.ts
+++ b/packages/google-cloud-securitycenter/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-securitycentermanagement/system-test/install.ts
+++ b/packages/google-cloud-securitycentermanagement/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-servicedirectory/system-test/install.ts
+++ b/packages/google-cloud-servicedirectory/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-servicehealth/system-test/install.ts
+++ b/packages/google-cloud-servicehealth/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-shell/system-test/install.ts
+++ b/packages/google-cloud-shell/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-speech/system-test/install.ts
+++ b/packages/google-cloud-speech/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-sql/system-test/install.ts
+++ b/packages/google-cloud-sql/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-storagebatchoperations/system-test/install.ts
+++ b/packages/google-cloud-storagebatchoperations/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-storageinsights/system-test/install.ts
+++ b/packages/google-cloud-storageinsights/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-support/system-test/install.ts
+++ b/packages/google-cloud-support/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-talent/system-test/install.ts
+++ b/packages/google-cloud-talent/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-telcoautomation/system-test/install.ts
+++ b/packages/google-cloud-telcoautomation/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-texttospeech/system-test/install.ts
+++ b/packages/google-cloud-texttospeech/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-tpu/system-test/install.ts
+++ b/packages/google-cloud-tpu/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-translate/system-test/install.ts
+++ b/packages/google-cloud-translate/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-vectorsearch/system-test/install.ts
+++ b/packages/google-cloud-vectorsearch/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-video-livestream/system-test/install.ts
+++ b/packages/google-cloud-video-livestream/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-video-stitcher/system-test/install.ts
+++ b/packages/google-cloud-video-stitcher/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-video-transcoder/system-test/install.ts
+++ b/packages/google-cloud-video-transcoder/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-videointelligence/system-test/install.ts
+++ b/packages/google-cloud-videointelligence/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-vision/system-test/install.ts
+++ b/packages/google-cloud-vision/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-visionai/system-test/install.ts
+++ b/packages/google-cloud-visionai/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-vmmigration/system-test/install.ts
+++ b/packages/google-cloud-vmmigration/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-vmwareengine/system-test/install.ts
+++ b/packages/google-cloud-vmwareengine/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-vpcaccess/system-test/install.ts
+++ b/packages/google-cloud-vpcaccess/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-webrisk/system-test/install.ts
+++ b/packages/google-cloud-webrisk/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-websecurityscanner/system-test/install.ts
+++ b/packages/google-cloud-websecurityscanner/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-workflows/system-test/install.ts
+++ b/packages/google-cloud-workflows/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-workloadmanager/system-test/install.ts
+++ b/packages/google-cloud-workloadmanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-cloud-workstations/system-test/install.ts
+++ b/packages/google-cloud-workstations/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-container/system-test/install.ts
+++ b/packages/google-container/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-dataflow/system-test/install.ts
+++ b/packages/google-dataflow/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-devtools-artifactregistry/system-test/install.ts
+++ b/packages/google-devtools-artifactregistry/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-devtools-cloudbuild/system-test/install.ts
+++ b/packages/google-devtools-cloudbuild/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-devtools-cloudprofiler/system-test/install.ts
+++ b/packages/google-devtools-cloudprofiler/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-devtools-containeranalysis/system-test/install.ts
+++ b/packages/google-devtools-containeranalysis/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-iam-credentials/system-test/install.ts
+++ b/packages/google-iam-credentials/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-iam/system-test/install.ts
+++ b/packages/google-iam/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-identity-accesscontextmanager/system-test/install.ts
+++ b/packages/google-identity-accesscontextmanager/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-addressvalidation/system-test/install.ts
+++ b/packages/google-maps-addressvalidation/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-areainsights/system-test/install.ts
+++ b/packages/google-maps-areainsights/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-fleetengine-delivery/system-test/install.ts
+++ b/packages/google-maps-fleetengine-delivery/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-fleetengine/system-test/install.ts
+++ b/packages/google-maps-fleetengine/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-fleetengine/v1/system-test/install.ts
+++ b/packages/google-maps-fleetengine/v1/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-geocode/system-test/install.ts
+++ b/packages/google-maps-geocode/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-mapsplatformdatasets/system-test/install.ts
+++ b/packages/google-maps-mapsplatformdatasets/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-navconnect/system-test/install.ts
+++ b/packages/google-maps-navconnect/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-places/system-test/install.ts
+++ b/packages/google-maps-places/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-routeoptimization/system-test/install.ts
+++ b/packages/google-maps-routeoptimization/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-routing/system-test/install.ts
+++ b/packages/google-maps-routing/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-maps-solar/system-test/install.ts
+++ b/packages/google-maps-solar/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-marketingplatform-admin/system-test/install.ts
+++ b/packages/google-marketingplatform-admin/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-monitoring-dashboard/system-test/install.ts
+++ b/packages/google-monitoring-dashboard/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-privacy-dlp/system-test/install.ts
+++ b/packages/google-privacy-dlp/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-css/system-test/install.ts
+++ b/packages/google-shopping-css/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-accounts/system-test/install.ts
+++ b/packages/google-shopping-merchant-accounts/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-conversions/system-test/install.ts
+++ b/packages/google-shopping-merchant-conversions/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-datasources/system-test/install.ts
+++ b/packages/google-shopping-merchant-datasources/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-inventories/system-test/install.ts
+++ b/packages/google-shopping-merchant-inventories/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-issueresolution/system-test/install.ts
+++ b/packages/google-shopping-merchant-issueresolution/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-lfp/system-test/install.ts
+++ b/packages/google-shopping-merchant-lfp/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-notifications/system-test/install.ts
+++ b/packages/google-shopping-merchant-notifications/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-ordertracking/system-test/install.ts
+++ b/packages/google-shopping-merchant-ordertracking/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-products/system-test/install.ts
+++ b/packages/google-shopping-merchant-products/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-promotions/system-test/install.ts
+++ b/packages/google-shopping-merchant-promotions/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-quota/system-test/install.ts
+++ b/packages/google-shopping-merchant-quota/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-reports/system-test/install.ts
+++ b/packages/google-shopping-merchant-reports/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-shopping-merchant-reviews/system-test/install.ts
+++ b/packages/google-shopping-merchant-reviews/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-storage-control/system-test/install.ts
+++ b/packages/google-storage-control/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-storagetransfer/system-test/install.ts
+++ b/packages/google-storagetransfer/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/google-streetview-publish/system-test/install.ts
+++ b/packages/google-streetview-publish/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);

--- a/packages/grafeas/system-test/install.ts
+++ b/packages/grafeas/system-test/install.ts
@@ -40,7 +40,7 @@ describe('📦 pack-n-play test', () => {
       packageDir: process.cwd(),
       sample: {
         description: 'JavaScript user can use the library',
-        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
+        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
     await packNTest(options);


### PR DESCRIPTION
System tests are failing with the following error:
```
Error: Command failed with exit code 1: npx tsc
Step #6 - "run-tests": �[96mindex.ts�[0m:�[93m21�[0m:�[93m23�[0m - �[91merror�[0m�[90m TS2591: �[0mCannot find name 'require'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```
(for example: https://github.com/googleapis/google-cloud-node/pull/7961/checks?check_run_id=70274525122)

At the moment, the system tests are configured to run the JavaScript test as if it were TypeScript:
```
it('JavaScript code', async function() {
    this.timeout(300000);
    const options = {
      packageDir: process.cwd(),
      sample: {
        description: 'JavaScript user can use the library',
        // Running index.js as if it were a TS file.
        ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
      }
    };
    await packNTest(options);
  });
```

This PR simply updates the tests to instead run `index.js` as a CJS artifact:
```
it('JavaScript code', async function() {
    this.timeout(300000);
    const options = {
      packageDir: process.cwd(),
      sample: {
        description: 'JavaScript user can use the library',
        // Modified to run as CJS!
        cjs: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
      }
    };
    await packNTest(options);
  });
```

Note, this was already fix in the generator in https://github.com/googleapis/google-cloud-node/pull/7943. However, the generator release takes some time (i.e. days). This is meant to unblock PRs immediately.

