### PR TITLE
fix: correct repository and homepage links shown on npmjs.com

### DIFF
--- a/containers/node-bootstrap-container/package.json
+++ b/containers/node-bootstrap-container/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/googleapis/google-cloud-node.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "containers/node-bootstrap-container"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/core/dev-packages/jsdoc-fresh/package.json
+++ b/core/dev-packages/jsdoc-fresh/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/jsdoc-fresh",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/jsdoc-fresh",
   "devDependencies": {
     "gts": "^5.0.0",
     "typescript": "^5.1.6"

--- a/core/dev-packages/jsdoc-fresh/package.json
+++ b/core/dev-packages/jsdoc-fresh/package.json
@@ -14,8 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/jsdoc-fresh",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/dev-packages/jsdoc-fresh"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/core/dev-packages/jsdoc-region-tag/package.json
+++ b/core/dev-packages/jsdoc-region-tag/package.json
@@ -32,7 +32,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/jsdoc-region-tag",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/jsdoc-region-tag",
   "dependencies": {
     "glob": "^7.1.6"
   },

--- a/core/dev-packages/jsdoc-region-tag/package.json
+++ b/core/dev-packages/jsdoc-region-tag/package.json
@@ -18,8 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "directory": "dev-packages/jsdoc-region-tag",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/dev-packages/jsdoc-region-tag"
   },
   "keywords": [
     "region",

--- a/core/dev-packages/pack-n-play/package.json
+++ b/core/dev-packages/pack-n-play/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "directory": "dev-packages/pack-n-play",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/dev-packages/pack-n-play"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/core/dev-packages/pack-n-play/package.json
+++ b/core/dev-packages/pack-n-play/package.json
@@ -60,5 +60,5 @@
       "build/test"
     ]
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/pack-n-play"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/pack-n-play"
 }

--- a/core/generator/gapic-generator-typescript/package.json
+++ b/core/generator/gapic-generator-typescript/package.json
@@ -10,8 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gapic-generator-typescript",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/generator/gapic-generator-typescript"
   },
   "license": "Apache-2.0",
   "author": "Google LLC",

--- a/core/generator/gapic-generator-typescript/package.json
+++ b/core/generator/gapic-generator-typescript/package.json
@@ -3,7 +3,7 @@
   "version": "4.11.14",
   "type": "module",
   "description": "Google API Client Library Generator for TypeScript, written in TypeScript.",
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gapic-generator-typescript",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/generator/gapic-generator-typescript",
   "private": true,
   "bugs": {
     "url": "https://github.com/googleapis/gapic-generator-typescript/issues"

--- a/core/packages/gax/package.json
+++ b/core/packages/gax/package.json
@@ -104,7 +104,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gax",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gax",
   "engines": {
     "node": ">=18"
   },

--- a/core/packages/gax/package.json
+++ b/core/packages/gax/package.json
@@ -96,8 +96,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gax",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/gax"
   },
   "author": "Google API Authors",
   "license": "Apache-2.0",

--- a/core/packages/gax/samples/package.json
+++ b/core/packages/gax/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/gax-nodejs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/gax/samples"
+  },
   "private": true,
   "scripts": {
     "test": "c8 mocha system-test"

--- a/core/packages/gaxios/package.json
+++ b/core/packages/gaxios/package.json
@@ -38,8 +38,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gaxios",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/gaxios"
   },
   "keywords": [
     "google"

--- a/core/packages/gaxios/package.json
+++ b/core/packages/gaxios/package.json
@@ -101,5 +101,5 @@
     "https-proxy-agent": "^7.0.1",
     "node-fetch": "^3.3.2"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gaxios"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gaxios"
 }

--- a/core/packages/gcp-metadata/package.json
+++ b/core/packages/gcp-metadata/package.json
@@ -70,5 +70,5 @@
   "engines": {
     "node": ">=18"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gcp-metadata"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gcp-metadata"
 }

--- a/core/packages/gcp-metadata/package.json
+++ b/core/packages/gcp-metadata/package.json
@@ -4,8 +4,8 @@
   "description": "Get the metadata from a Google Cloud Platform environment",
   "repository": {
     "type": "git",
-    "directory": "packages/gcp-metadata",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/gcp-metadata"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/core/packages/gcp-metadata/samples/package.json
+++ b/core/packages/gcp-metadata/samples/package.json
@@ -8,7 +8,11 @@
   "files": [
     "*.js"
   ],
-  "repository": "googleapis/gcp-metadata",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/gcp-metadata/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha"

--- a/core/packages/google-auth-library-nodejs/package.json
+++ b/core/packages/google-auth-library-nodejs/package.json
@@ -10,8 +10,8 @@
   "types": "./build/src/index.d.ts",
   "repository": {
     "type": "git",
-    "directory": "packages/google-auth-library-nodejs",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/google-auth-library-nodejs"
   },
   "keywords": [
     "google",

--- a/core/packages/google-auth-library-nodejs/package.json
+++ b/core/packages/google-auth-library-nodejs/package.json
@@ -86,5 +86,5 @@
     "prelint": "cd samples; npm link ../; npm install"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/google-auth-library-nodejs"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/google-auth-library-nodejs"
 }

--- a/core/packages/logging-utils/package.json
+++ b/core/packages/logging-utils/package.json
@@ -40,7 +40,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/logging-utils",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/logging-utils",
   "engines": {
     "node": ">=14"
   }

--- a/core/packages/logging-utils/package.json
+++ b/core/packages/logging-utils/package.json
@@ -24,8 +24,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "directory": "dev-packages/logging-utils",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/logging-utils"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/core/packages/logging-utils/samples/package.json
+++ b/core/packages/logging-utils/samples/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "logging-utils/samples"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/logging-utils/samples"
   },
   "engines": {
     "node": ">=14"

--- a/core/packages/nodejs-googleapis-common/package.json
+++ b/core/packages/nodejs-googleapis-common/package.json
@@ -4,8 +4,8 @@
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "repository": {
     "type": "git",
-    "directory": "packages/nodejs-googleapis-common",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/nodejs-googleapis-common"
   },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/core/packages/nodejs-googleapis-common/package.json
+++ b/core/packages/nodejs-googleapis-common/package.json
@@ -89,5 +89,5 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/nodejs-googleapis-common"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/nodejs-googleapis-common"
 }

--- a/core/packages/nodejs-googleapis-common/samples/package.json
+++ b/core/packages/nodejs-googleapis-common/samples/package.json
@@ -9,7 +9,11 @@
     "*.js",
     "!test/"
   ],
-  "repository": "googleapis/nodejs-googleapis-common",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/nodejs-googleapis-common/samples"
+  },
   "private": true,
   "scripts": {
     "test": "echo \"There are no sample tests 👻\""

--- a/core/packages/nodejs-proto-files/package.json
+++ b/core/packages/nodejs-proto-files/package.json
@@ -63,5 +63,5 @@
     "sinon": "21.0.3",
     "typescript": "5.8.3"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/nodejs-proto-files"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/nodejs-proto-files"
 }

--- a/core/packages/nodejs-proto-files/package.json
+++ b/core/packages/nodejs-proto-files/package.json
@@ -9,8 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/nodejs-proto-files",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/nodejs-proto-files"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/core/packages/nodejs-proto-files/samples/package.json
+++ b/core/packages/nodejs-proto-files/samples/package.json
@@ -8,7 +8,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-proto-files",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/nodejs-proto-files/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha"

--- a/core/packages/proto3-json-serializer-nodejs/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/package.json
@@ -55,5 +55,6 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/proto3-json-serializer-nodejs"
 }

--- a/core/packages/proto3-json-serializer-nodejs/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/package.json
@@ -3,8 +3,8 @@
   "version": "3.0.5",
   "repository": {
     "type": "git",
-    "directory": "packages/proto3-json-serializer-nodejs",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/proto3-json-serializer-nodejs"
   },
   "description": "Support for proto3 JSON serialiazation/deserialization for protobuf.js",
   "main": "build/src/index.js",

--- a/core/packages/proto3-json-serializer-nodejs/samples/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/proto3-json-serializer-nodejs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/proto3-json-serializer-nodejs/samples"
+  },
   "private": true,
   "scripts": {
     "test": "c8 mocha system-test"

--- a/core/packages/retry-request/package.json
+++ b/core/packages/retry-request/package.json
@@ -47,5 +47,5 @@
     "mocha": "^11.1.0",
     "typescript": "5.8.3"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/retry-request"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/retry-request"
 }

--- a/core/packages/retry-request/package.json
+++ b/core/packages/retry-request/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "directory": "packages/retry-request",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/retry-request"
   },
   "scripts": {
     "docs": "jsdoc -c .jsdoc.js",

--- a/core/packages/teeny-request/package.json
+++ b/core/packages/teeny-request/package.json
@@ -25,8 +25,8 @@
   ],
   "repository": {
     "type": "git",
-    "directory": "packages/teeny-request",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/teeny-request"
   },
   "keywords": [
     "request",

--- a/core/packages/teeny-request/package.json
+++ b/core/packages/teeny-request/package.json
@@ -38,7 +38,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/teeny-request/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/teeny-request",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/teeny-request",
   "dependencies": {
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.1",

--- a/core/packages/tools/package.json
+++ b/core/packages/tools/package.json
@@ -40,8 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/tools",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/tools"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",

--- a/core/packages/tools/package.json
+++ b/core/packages/tools/package.json
@@ -61,7 +61,7 @@
   "bugs": {
     "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/tools",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/tools",
   "engines": {
     "node": ">=18"
   }

--- a/core/packages/typeless-sample-bot/package.json
+++ b/core/packages/typeless-sample-bot/package.json
@@ -63,5 +63,6 @@
     "overrides": {
       "@sinonjs/fake-timers": "15.2.1"
     }
-  }
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/typeless-sample-bot"
 }

--- a/core/packages/typeless-sample-bot/package.json
+++ b/core/packages/typeless-sample-bot/package.json
@@ -7,7 +7,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/google-cloud-node",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/typeless-sample-bot"
+  },
   "bin": "./build/src/bin/typeless-sample-bot.js",
   "main": "./build/src/app.js",
   "type": "module",

--- a/handwritten/google-cloud-dns/samples/package.json
+++ b/handwritten/google-cloud-dns/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-dns",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-dns/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/googleapis/google-cloud-node.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "keywords": [
     "google",

--- a/packages/google-analytics-admin/samples/package.json
+++ b/packages/google-analytics-admin/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-analytics-admin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-analytics-admin/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-asset/samples/package.json
+++ b/packages/google-cloud-asset/samples/package.json
@@ -9,7 +9,11 @@
   "files": [
     "*.js"
   ],
-  "repository": "googleapis/nodejs-asset",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-asset/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha --timeout 600000"

--- a/packages/google-cloud-automl/samples/package.json
+++ b/packages/google-cloud-automl/samples/package.json
@@ -6,7 +6,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-automl",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-automl/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha --timeout 9000000"

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/package.json
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/googleapis/google-cloud-node.git",
     "directory": "packages/google-cloud-beyondcorp-clientconnectorservices"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-beyondcorp-clientgateways",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-beyondcorp-clientconnectorservices",
   "license": "Apache-2.0",
   "author": "Google LLC",
   "main": "build/src/index.js",

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/package.json
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/googleapis/google-cloud-node.git",
-    "directory": "packages/google-cloud-beyondcorp-clientgateways"
+    "directory": "packages/google-cloud-beyondcorp-clientconnectorservices"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-beyondcorp-clientgateways",
   "license": "Apache-2.0",

--- a/packages/google-cloud-bigquery-datatransfer/samples/package.json
+++ b/packages/google-cloud-bigquery-datatransfer/samples/package.json
@@ -8,7 +8,11 @@
   "files": [
     "*.js"
   ],
-  "repository": "googleapis/nodejs-bigquery-data-transfer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-bigquery-datatransfer/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha --timeout 60000"

--- a/packages/google-cloud-billing-budgets/samples/package.json
+++ b/packages/google-cloud-billing-budgets/samples/package.json
@@ -7,7 +7,11 @@
     "resources"
   ],
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-billing-budgets",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-billing-budgets/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-certificatemanager/samples/package.json
+++ b/packages/google-cloud-certificatemanager/samples/package.json
@@ -6,7 +6,11 @@
     "*.js"
   ],
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-secret-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-certificatemanager/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-compute/samples/package.json
+++ b/packages/google-cloud-compute/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-compute",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-compute/samples"
+  },
   "private": true,
   "files": [
     "*.js"

--- a/packages/google-cloud-datacatalog/samples/package.json
+++ b/packages/google-cloud-datacatalog/samples/package.json
@@ -6,7 +6,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-datacatalog",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-datacatalog/samples"
+  },
   "private": true,
   "files": [
     "*.js"

--- a/packages/google-cloud-dataproc/samples/package.json
+++ b/packages/google-cloud-dataproc/samples/package.json
@@ -8,7 +8,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-dataproc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-dataproc/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha test --timeout 600000"

--- a/packages/google-cloud-dialogflow/samples/package.json
+++ b/packages/google-cloud-dialogflow/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-dialogflow",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-dialogflow/samples"
+  },
   "files": [
     "*.js",
     "resources"

--- a/packages/google-cloud-iot/samples/package.json
+++ b/packages/google-cloud-iot/samples/package.json
@@ -9,7 +9,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-iot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-iot/samples"
+  },
   "private": true,
   "scripts": {
     "test": "echo tests deprecated"

--- a/packages/google-cloud-kms/samples/package.json
+++ b/packages/google-cloud-kms/samples/package.json
@@ -6,7 +6,11 @@
     "*.js"
   ],
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-kms",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-kms/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-language/samples/package.json
+++ b/packages/google-cloud-language/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-language",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-language/samples"
+  },
   "private": true,
   "files": [
     "*.js",

--- a/packages/google-cloud-mediatranslation/package.json
+++ b/packages/google-cloud-mediatranslation/package.json
@@ -4,8 +4,8 @@
   "description": "Mediatranslation client for Node.js",
   "repository": {
     "type": "git",
-    "directory": "packages/media-translatation",
-    "url": "https://github.com/googleapis/google-cloud-node.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-mediatranslation"
   },
   "license": "Apache-2.0",
   "author": "Google LLC",

--- a/packages/google-cloud-monitoring/samples/package.json
+++ b/packages/google-cloud-monitoring/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-monitoring",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-monitoring/samples"
+  },
   "files": [
     "*.js"
   ],

--- a/packages/google-cloud-oslogin/samples/package.json
+++ b/packages/google-cloud-oslogin/samples/package.json
@@ -8,7 +8,11 @@
   "files": [
     "*.js"
   ],
-  "repository": "googleapis/nodejs-os-login",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-oslogin/samples"
+  },
   "private": true,
   "scripts": {
     "test": "mocha"

--- a/packages/google-cloud-redis/samples/package.json
+++ b/packages/google-cloud-redis/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-redis",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-redis/samples"
+  },
   "private": true,
   "scripts": {
     "test": "c8 mocha system-test"

--- a/packages/google-cloud-resourcemanager/samples/package.json
+++ b/packages/google-cloud-resourcemanager/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-resource-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-resourcemanager/samples"
+  },
   "files": [
     "*.js"
   ],

--- a/packages/google-cloud-secretmanager/samples/package.json
+++ b/packages/google-cloud-secretmanager/samples/package.json
@@ -6,7 +6,11 @@
     "*.js"
   ],
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-secret-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-secretmanager/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-speech/samples/package.json
+++ b/packages/google-cloud-speech/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-speech",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-speech/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-talent/samples/package.json
+++ b/packages/google-cloud-talent/samples/package.json
@@ -6,7 +6,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-talent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-talent/samples"
+  },
   "private": true,
   "files": [
     "*.js"

--- a/packages/google-cloud-texttospeech/samples/package.json
+++ b/packages/google-cloud-texttospeech/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-text-to-speech",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-texttospeech/samples"
+  },
   "files": [
     "*.js"
   ],

--- a/packages/google-cloud-translate/samples/package.json
+++ b/packages/google-cloud-translate/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-translate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-translate/samples"
+  },
   "files": [
     "!test/"
   ],

--- a/packages/google-cloud-videointelligence/samples/package.json
+++ b/packages/google-cloud-videointelligence/samples/package.json
@@ -7,7 +7,11 @@
     "resources"
   ],
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-video-intelligence",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-videointelligence/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-vmmigration/samples/package.json
+++ b/packages/google-cloud-vmmigration/samples/package.json
@@ -6,7 +6,11 @@
     "*.js"
   ],
   "author": "Google LLC",
-  "repository": "googleapis/nodejs-secret-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-vmmigration/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-cloud-workflows/package.json
+++ b/packages/google-cloud-workflows/package.json
@@ -64,7 +64,7 @@
   "engines": {
     "node": ">=18"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-workflows-executions",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-workflows",
   "overrides": {
     "@sinonjs/fake-timers": "15.2.1"
   },

--- a/packages/google-cloud-workflows/package.json
+++ b/packages/google-cloud-workflows/package.json
@@ -4,8 +4,8 @@
   "description": "Workflows client for Node.js",
   "repository": {
     "type": "git",
-    "directory": "packages/google-cloud-workflows-executions",
-    "url": "https://github.com/googleapis/google-cloud-node.git"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-workflows"
   },
   "license": "Apache-2.0",
   "author": "Google LLC",

--- a/packages/google-container/samples/package.json
+++ b/packages/google-container/samples/package.json
@@ -5,7 +5,11 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-cloud-container",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-container/samples"
+  },
   "private": true,
   "files": [
     "*.js"

--- a/packages/google-devtools-cloudbuild/samples/package.json
+++ b/packages/google-devtools-cloudbuild/samples/package.json
@@ -7,7 +7,11 @@
     "resources"
   ],
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-cloudbuild",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-devtools-cloudbuild/samples"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/google-devtools-containeranalysis/samples/package.json
+++ b/packages/google-devtools-containeranalysis/samples/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-containeranalysis",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-devtools-containeranalysis/samples"
+  },
   "files": [
     "*.js"
   ],

--- a/packages/google-privacy-dlp/samples/package.json
+++ b/packages/google-privacy-dlp/samples/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
-  "repository": "googleapis/nodejs-dlp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-privacy-dlp/samples"
+  },
   "files": [
     "*.js"
   ],


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-node/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #8249

## Changes

### repository fields

- Fix `git+https://` → `https://` URL prefix in root and `containers/` package.json files
- Update all `core/` packages from stale `google-cloud-node-core.git` URL to `google-cloud-node.git` with correct `core/…` directory paths
- Fix three wrong `directory` values in `packages/` (`beyondcorp-clientconnectorservices` pointed to `clientgateways`, `mediatranslation` had a typo, `workflows` pointed to `workflows-executions`)
- Convert 37 string `repository` fields in `samples/` and other packages to proper objects with the correct monorepo URL and directory

### homepage fields

- Update all `core/` packages from stale `google-cloud-node-core` homepage URLs to `google-cloud-node` with correct `core/…` paths
- Fix two wrong homepage paths (`beyondcorp-clientconnectorservices` pointed to `clientgateways`, `workflows` pointed to `workflows-executions`)
- Add missing homepage to `proto3-json-serializer-nodejs`, `managedkafka/v1`, `google-maps-fleetengine/v1`, and `typeless-sample-bot`

No functional code was changed — only `package.json` metadata.