### PR TITLE
fix: propagate auth client transporter to StsCredentials in clients

### DIFF
--- a/core/packages/google-auth-library-nodejs/src/auth/baseexternalclient.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/baseexternalclient.ts
@@ -313,6 +313,7 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     this.stsCredential = new sts.StsCredentials({
       tokenExchangeEndpoint: this.tokenUrl,
       clientAuthentication: this.clientAuth,
+      transporter: this.transporter,
     });
     this.scopes = opts.get('scopes') || [DEFAULT_OAUTH_SCOPE];
     this.cachedAccessToken = null;

--- a/core/packages/google-auth-library-nodejs/src/auth/downscopedclient.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/downscopedclient.ts
@@ -191,6 +191,7 @@ export class DownscopedClient extends AuthClient {
 
     this.stsCredential = new sts.StsCredentials({
       tokenExchangeEndpoint: `https://sts.${this.universeDomain}/v1/token`,
+      transporter: this.transporter,
     });
 
     this.cachedDownscopedAccessToken = null;

--- a/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
@@ -28,7 +28,7 @@ import {
   OAuthErrorResponse,
   getErrorFromOAuthErrorResponse,
 } from '../src/auth/oauth2common';
-import {GaxiosError} from 'gaxios';
+import {Gaxios, GaxiosError} from 'gaxios';
 import {
   assertGaxiosResponsePresent,
   getAudience,
@@ -86,6 +86,21 @@ describe('BaseExternalAccountClient', () => {
       file: '/var/run/secrets/goog.id/token',
     },
   };
+
+  it('should pass the configured transporter to STS credentials', () => {
+    const transporter = new Gaxios();
+    const client = new TestExternalAccountClient({
+      ...externalAccountOptions,
+      transporter,
+    });
+
+    assert.strictEqual(
+      (client as unknown as {stsCredential: {transporter: Gaxios}})
+        .stsCredential.transporter,
+      transporter,
+    );
+  });
+
   const externalAccountOptionsWithCreds = {
     type: 'external_account',
     audience,

--- a/core/packages/google-auth-library-nodejs/test/test.downscopedclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.downscopedclient.ts
@@ -17,7 +17,7 @@ import {describe, it, beforeEach, afterEach} from 'mocha';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 
-import {GaxiosError, GaxiosPromise} from 'gaxios';
+import {Gaxios, GaxiosError, GaxiosPromise} from 'gaxios';
 import {Credentials} from '../src/auth/credentials';
 import {StsSuccessfulResponse} from '../src/auth/stscredentials';
 import {
@@ -115,6 +115,21 @@ describe('DownscopedClient', () => {
     if (clock) {
       clock.restore();
     }
+  });
+
+  it('should pass the configured transporter to STS credentials', () => {
+    const transporter = new Gaxios();
+    const downscopedClient = new DownscopedClient({
+      authClient: client,
+      credentialAccessBoundary: testClientAccessBoundary,
+      transporter,
+    });
+
+    assert.strictEqual(
+      (downscopedClient as unknown as {stsCredential: {transporter: Gaxios}})
+        .stsCredential.transporter,
+      transporter,
+    );
   });
 
   describe('Constructor', () => {


### PR DESCRIPTION
Fixes #8292
