### PR TITLE
fix: correct split-repo-post-process.sh regex replacement

### DIFF
--- a/bin/split-repo-post-process.sh
+++ b/bin/split-repo-post-process.sh
@@ -78,7 +78,7 @@ if grep -q "/owl-bot-staging/\$1/\$2" "${PACKAGE_PATH}/.OwlBot.yaml"
 then
   echo "OwlBot config is copying each folder"
   gsed -i 's/\.\*-nodejs\/(.*)/.*-nodejs/' "${PACKAGE_PATH}/.OwlBot.yaml"
-  gsed -i "s/dest: \/owl-bot-staging\/\$1\/\$2/dest: \/owl-bot-staging\/${PACKAGE_NAME}\/\$1/" "${PACKAGE_PATH}/.OwlBot.yaml"
+  gsed -i "s/dest: \/owl-bot-staging\/\$1\/\$2/dest: \/owl-bot-staging\/${PACKAGE_NAME}/" "${PACKAGE_PATH}/.OwlBot.yaml"
 else
   gsed -i "s/dest: \/owl-bot-staging/dest: \/owl-bot-staging\/${PACKAGE_NAME}/" "${PACKAGE_PATH}/.OwlBot.yaml"
 fi


### PR DESCRIPTION
This PR fixes a bug in the monorepo's split-repo post-processing script `bin/split-repo-post-process.sh` which caused newly migrated/split packages to generate duplicate code files inside a literal folder named `$1`.

The script expects a dynamic package structure that doesn't exist in the monorepo's flat generator. The regular expression replacement logic was tested under both standard and scoped package scenarios to verify the fix.