### PR TITLE
fix(gapic-generator): trigger release after eslint config cleanup

### DIFF
--- a/core/generator/gapic-generator-typescript/README.md
+++ b/core/generator/gapic-generator-typescript/README.md
@@ -167,3 +167,4 @@ We support some cool things such as streaming RPCs, auto-pagination for certain 
 ## Disclaimer
 
 **This is not an official Google product.**
+


### PR DESCRIPTION
(almost) empty commit to trigger PR release for generator version 4.11.15