### PR TITLE
fix(firestore): GC idle REST clients immediately on gRPC transition to prevent zombie pool leaks

### DIFF
--- a/handwritten/firestore/dev/src/pool.ts
+++ b/handwritten/firestore/dev/src/pool.ts
@@ -118,11 +118,39 @@ export class ClientPool<T extends object> {
     let selectedClient: T | null = null;
     let selectedClientRequestCount = -1;
 
+    const previouslyGrpcEnabled = this.grpcEnabled;
     // Transition to grpc when we see the first operation that requires grpc.
     this.grpcEnabled = this.grpcEnabled || requiresGrpc;
 
     // Require a grpc client for this operation if we have transitioned to grpc.
     requiresGrpc = requiresGrpc || this.grpcEnabled;
+
+    if (!previouslyGrpcEnabled && this.grpcEnabled) {
+      // We just transitioned to GRPC. Let's garbage collect any idle REST clients.
+      for (const [client, metadata] of this.activeClients) {
+        if (!metadata.grpcEnabled && metadata.activeRequestCount === 0) {
+          const clientId = this.clientIdByClient.get(client);
+          logger(
+            `ClientPool[${this.instanceId}].acquire`,
+            requestTag,
+            'Garbage collecting idle REST client [%s] after transition to GRPC',
+            clientId,
+          );
+          this.activeClients.delete(client);
+          this.failedClients.delete(client);
+          // Fire-and-forget the destructor, catching errors to prevent unhandled promise rejections.
+          this.clientDestructor(client).catch(err => {
+            logger(
+              `ClientPool[${this.instanceId}].acquire`,
+              requestTag,
+              'Error during garbage collection of REST client [%s]: %s',
+              clientId,
+              err,
+            );
+          });
+        }
+      }
+    }
 
     for (const [client, metadata] of this.activeClients) {
       // Use the "most-full" client that can still accommodate the request

--- a/handwritten/firestore/dev/test/pool.ts
+++ b/handwritten/firestore/dev/test/pool.ts
@@ -370,6 +370,55 @@ describe('Client pool', () => {
     operationPromises[0].resolve();
   });
 
+  it('garbage collects idle REST clients immediately upon transitioning to grpc', async () => {
+    let destructedClientsCount = 0;
+    const clientPool = new ClientPool<{}>(
+      10, // concurrentOperationLimit
+      1,  // maxIdleClients
+      () => {
+        return {};
+      },
+      async () => {
+        destructedClientsCount++;
+      }
+    );
+
+    const operationPromises = deferredPromises(2);
+
+    // 1. Start a REST operation
+    const restOperation = clientPool.run(
+      REQUEST_TAG,
+      USE_REST,
+      () => operationPromises[0].promise,
+    );
+
+    // 2. Resolve the REST operation so the REST client becomes idle
+    operationPromises[0].resolve();
+    await restOperation;
+
+    expect(clientPool.size).to.equal(1);
+    expect(destructedClientsCount).to.equal(0);
+
+    // 3. Start a GRPC operation. This should trigger the transition to GRPC.
+    // The idle REST client should be garbage collected immediately.
+    const grpcOperation = clientPool.run(
+      REQUEST_TAG,
+      USE_GRPC,
+      () => operationPromises[1].promise,
+    );
+
+    expect(destructedClientsCount).to.equal(1);
+    expect(clientPool.size).to.equal(1);
+
+    operationPromises[1].resolve();
+    await grpcOperation;
+
+    // 4. Since the REST client was GC'd, the GRPC client should NOT be GC'd
+    // because the idle capacity is only 10 (<= maxIdleCapacity of 10).
+    expect(clientPool.size).to.equal(1);
+    expect(destructedClientsCount).to.equal(1);
+  });
+
   it('bin packs operations', async () => {
     let clientCount = 0;
     const clientPool = new ClientPool<{count: number}>(2, 0, () => {


### PR DESCRIPTION
This PR fixes a critical bug in `ClientPool` where transitioning the pool to gRPC left idle REST clients permanently leaked in the pool. These leaked REST clients contributed to `idleCapacityCount`, triggering a 'death spiral' where all newly-created and finished gRPC clients were immediately garbage collected, leading to high connection churn and latency regressions.\n\nRegression tests have been added in `pool.ts` and verified.