### PR TITLE
feat(auth): Regional Access Boundaries mTLS endpoint

### DIFF
--- a/core/packages/google-auth-library-nodejs/src/auth/authclient.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/authclient.ts
@@ -21,6 +21,7 @@ import {log as makeLog} from 'google-logging-utils';
 
 import {PRODUCT_NAME, USER_AGENT} from '../shared.cjs';
 import {
+  REGIONAL_ACCESS_BOUNDARY_HEADER,
   RegionalAccessBoundaryData,
   RegionalAccessBoundaryManager,
 } from './regionalaccessboundary';
@@ -449,7 +450,7 @@ export abstract class AuthClient
         headers,
       );
     if (rabHeader) {
-      headers.set('x-allowed-locations', rabHeader);
+      headers.set(REGIONAL_ACCESS_BOUNDARY_HEADER, rabHeader);
     }
   }
 
@@ -468,7 +469,7 @@ export abstract class AuthClient
   ): T {
     const xGoogUserProject = source.get('x-goog-user-project');
     const authorizationHeader = source.get('authorization');
-    const xGoogAllowedLocs = source.get('x-allowed-locations');
+    const xGoogAllowedLocs = source.get(REGIONAL_ACCESS_BOUNDARY_HEADER);
 
     if (xGoogUserProject) {
       target.set('x-goog-user-project', xGoogUserProject);
@@ -479,7 +480,7 @@ export abstract class AuthClient
     }
 
     if (xGoogAllowedLocs) {
-      target.set('x-allowed-locations', xGoogAllowedLocs);
+      target.set(REGIONAL_ACCESS_BOUNDARY_HEADER, xGoogAllowedLocs);
     }
 
     return target;

--- a/core/packages/google-auth-library-nodejs/src/auth/baseexternalclient.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/baseexternalclient.ts
@@ -762,8 +762,8 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     if (wlPoolId && projectNumber) {
       return WORKLOAD_LOOKUP_ENDPOINT.replace(
         '{project_id}',
-        projectNumber,
-      ).replace('{pool_id}', wlPoolId);
+        encodeURIComponent(projectNumber),
+      ).replace('{pool_id}', encodeURIComponent(wlPoolId));
     }
 
     throw new RangeError(

--- a/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {SubjectTokenSupplier} from './identitypoolclient';
-import {isValidFile} from '../util';
 import * as fs from 'fs';
 import {X509Certificate} from 'crypto';
 import * as https from 'https';
@@ -47,21 +46,6 @@ export interface CertificateSubjectTokenSupplierOptions {
  * Represents the "workload" block within the certificate configuration file.
  * @internal
  */
-interface WorkloadCertConfigJson {
-  cert_path: string;
-  key_path: string;
-}
-
-/**
- * Represents the structure of the certificate_config.json file.
- * @internal
- */
-interface CertificateConfigFileJson {
-  version: number;
-  cert_configs: {
-    workload?: WorkloadCertConfigJson;
-  };
-}
 
 /**
  * A subject token supplier that uses a client certificate for authentication.
@@ -113,7 +97,9 @@ export class CertificateSubjectTokenSupplier implements SubjectTokenSupplier {
     // The "subject token" in this context is the processed certificate chain.
 
     // getClientCertAndKey handles path resolution, file reading, and validation
-    ({cert: this.cert, key: this.key} = await getClientCertAndKey(this.certificateConfigPath));
+    ({cert: this.cert, key: this.key} = await getClientCertAndKey(
+      this.certificateConfigPath,
+    ));
 
     return await this.#processChainFromPaths(this.cert);
   }

--- a/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
@@ -22,6 +22,8 @@ import {
   getClientCertAndKey,
 } from './mtlsutils';
 
+export {CertificateSourceUnavailableError, InvalidConfigurationError};
+
 /**
  * Defines options for creating a {@link CertificateSubjectTokenSupplier}.
  */

--- a/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/certificatesubjecttokensupplier.ts
@@ -13,33 +13,15 @@
 // limitations under the License.
 
 import {SubjectTokenSupplier} from './identitypoolclient';
-import {getWellKnownCertificateConfigFileLocation, isValidFile} from '../util';
+import {isValidFile} from '../util';
 import * as fs from 'fs';
-import {createPrivateKey, X509Certificate} from 'crypto';
+import {X509Certificate} from 'crypto';
 import * as https from 'https';
-
-export const CERTIFICATE_CONFIGURATION_ENV_VARIABLE =
-  'GOOGLE_API_CERTIFICATE_CONFIG';
-
-/**
- * Thrown when the certificate source cannot be located or accessed.
- */
-export class CertificateSourceUnavailableError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'CertificateSourceUnavailableError';
-  }
-}
-
-/**
- * Thrown for invalid configuration that is not related to file availability.
- */
-export class InvalidConfigurationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'InvalidConfigurationError';
-  }
-}
+import {
+  CertificateSourceUnavailableError,
+  InvalidConfigurationError,
+  getClientCertAndKey,
+} from './mtlsutils';
 
 /**
  * Defines options for creating a {@link CertificateSubjectTokenSupplier}.
@@ -130,133 +112,10 @@ export class CertificateSubjectTokenSupplier implements SubjectTokenSupplier {
   public async getSubjectToken(): Promise<string> {
     // The "subject token" in this context is the processed certificate chain.
 
-    this.certificateConfigPath = await this.#resolveCertificateConfigFilePath();
-
-    const {certPath, keyPath} = await this.#getCertAndKeyPaths();
-
-    ({cert: this.cert, key: this.key} = await this.#getKeyAndCert(
-      certPath,
-      keyPath,
-    ));
+    // getClientCertAndKey handles path resolution, file reading, and validation
+    ({cert: this.cert, key: this.key} = await getClientCertAndKey(this.certificateConfigPath));
 
     return await this.#processChainFromPaths(this.cert);
-  }
-
-  /**
-   * Resolves the absolute path to the certificate configuration file
-   * by checking the "certificate_config_location" provided in the ADC file,
-   * or the "GOOGLE_API_CERTIFICATE_CONFIG" environment variable
-   * or in the default gcloud path.
-   * @param overridePath An optional path to check first.
-   * @returns The resolved file path.
-   */
-  async #resolveCertificateConfigFilePath(): Promise<string> {
-    // 1. Check for the override path from constructor options.
-    const overridePath = this.certificateConfigPath;
-    if (overridePath) {
-      if (await isValidFile(overridePath)) {
-        return overridePath;
-      }
-      throw new CertificateSourceUnavailableError(
-        `Provided certificate config path is invalid: ${overridePath}`,
-      );
-    }
-
-    // 2. Check the standard environment variable.
-    const envPath = process.env[CERTIFICATE_CONFIGURATION_ENV_VARIABLE];
-    if (envPath) {
-      if (await isValidFile(envPath)) {
-        return envPath;
-      }
-      throw new CertificateSourceUnavailableError(
-        `Path from environment variable "${CERTIFICATE_CONFIGURATION_ENV_VARIABLE}" is invalid: ${envPath}`,
-      );
-    }
-
-    // 3. Check the well-known gcloud config location.
-    const wellKnownPath = getWellKnownCertificateConfigFileLocation();
-    if (await isValidFile(wellKnownPath)) {
-      return wellKnownPath;
-    }
-
-    // 4. If none are found, throw an error.
-    throw new CertificateSourceUnavailableError(
-      'Could not find certificate configuration file. Searched override path, ' +
-        `the "${CERTIFICATE_CONFIGURATION_ENV_VARIABLE}" env var, and the gcloud path (${wellKnownPath}).`,
-    );
-  }
-
-  /**
-   * Reads and parses the certificate config JSON file to extract the certificate and key paths.
-   * @returns An object containing the certificate and key paths.
-   */
-  async #getCertAndKeyPaths(): Promise<{
-    certPath: string;
-    keyPath: string;
-  }> {
-    const configPath = this.certificateConfigPath;
-    let fileContents: string;
-    try {
-      fileContents = await fs.promises.readFile(configPath, 'utf8');
-    } catch (err) {
-      throw new CertificateSourceUnavailableError(
-        `Failed to read certificate config file at: ${configPath}`,
-      );
-    }
-
-    try {
-      const config = JSON.parse(fileContents) as CertificateConfigFileJson;
-      const certPath = config?.cert_configs?.workload?.cert_path;
-      const keyPath = config?.cert_configs?.workload?.key_path;
-
-      if (!certPath || !keyPath) {
-        throw new InvalidConfigurationError(
-          `Certificate config file (${configPath}) is missing required "cert_path" or "key_path" in the workload config.`,
-        );
-      }
-      return {certPath, keyPath};
-    } catch (e) {
-      if (e instanceof InvalidConfigurationError) throw e;
-      throw new InvalidConfigurationError(
-        `Failed to parse certificate config from ${configPath}: ${
-          (e as Error).message
-        }`,
-      );
-    }
-  }
-
-  /**
-   * Reads and parses the cert and key files get their content and check valid format.
-   * @returns An object containing the cert content and key content in buffer format.
-   */
-  async #getKeyAndCert(
-    certPath: string,
-    keyPath: string,
-  ): Promise<{
-    cert: Buffer;
-    key: Buffer;
-  }> {
-    let cert, key;
-    try {
-      cert = await fs.promises.readFile(certPath);
-      new X509Certificate(cert);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new CertificateSourceUnavailableError(
-        `Failed to read certificate file at ${certPath}: ${message}`,
-      );
-    }
-    try {
-      key = await fs.promises.readFile(keyPath);
-      createPrivateKey(key);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new CertificateSourceUnavailableError(
-        `Failed to read private key file at ${keyPath}: ${message}`,
-      );
-    }
-
-    return {cert, key};
   }
 
   /**

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -68,7 +68,7 @@ export enum MtlsEndpointUsagePolicy {
  * @returns The resolved MtlsEndpointUsagePolicy.
  */
 export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
-  const policy = process.env.GOOGLE_API_USE_MTLS_ENDPOINT;
+  const policy = process.env.GOOGLE_API_USE_MTLS_ENDPOINT?.toLowerCase();
   if (policy === 'never') {
     return MtlsEndpointUsagePolicy.NEVER;
   } else if (policy === 'always') {

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -16,6 +16,18 @@ import * as fs from 'fs';
 import {createPrivateKey, X509Certificate} from 'crypto';
 import {getWellKnownCertificateConfigFileLocation, isValidFile} from '../util';
 
+interface WorkloadCertConfigJson {
+  cert_path: string;
+  key_path: string;
+}
+
+interface CertificateConfigFileJson {
+  version: number;
+  cert_configs: {
+    workload?: WorkloadCertConfigJson;
+  };
+}
+
 export const CERTIFICATE_CONFIGURATION_ENV_VARIABLE =
   'GOOGLE_API_CERTIFICATE_CONFIG';
 
@@ -52,7 +64,7 @@ export enum MtlsEndpointUsagePolicy {
 /**
  * Resolves the mTLS endpoint usage policy based on the `GOOGLE_API_USE_MTLS_ENDPOINT`
  * environment variable.
- * 
+ *
  * @returns The resolved MtlsEndpointUsagePolicy.
  */
 export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
@@ -67,14 +79,16 @@ export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
 
 /**
  * Centralized helper method to determine if mutual TLS (mTLS) can be enabled.
- * 
+ *
  * Checks for the environment policy constraints and parses the certificate configuration file.
- * 
+ *
  * @param certConfigPathOverride Optional path to override the certificate configuration file.
  * @returns A promise that resolves to `true` if mTLS can be enabled, `false` otherwise.
  * @throws {Error} If a configuration file is resolved but contains malformed contents or missing files.
  */
-export async function canMtlsBeEnabled(certConfigPathOverride?: string): Promise<boolean> {
+export async function canMtlsBeEnabled(
+  certConfigPathOverride?: string,
+): Promise<boolean> {
   if (process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE === 'false') {
     return false;
   }
@@ -93,10 +107,11 @@ export async function canMtlsBeEnabled(certConfigPathOverride?: string): Promise
 
   // Config file exists / was specified. We must validate it.
   // Any failure here must propagate as a hard error.
-  const {certPath, keyPath} = await getCertAndKeyFilePathsFromConfig(configPath);
+  const {certPath, keyPath} =
+    await getCertAndKeyFilePathsFromConfig(configPath);
   if (!(await isValidFile(certPath)) || !(await isValidFile(keyPath))) {
     throw new Error(
-      `Certificate configuration exists but referenced files are missing: cert_path=${certPath}, key_path=${keyPath}`
+      `Certificate configuration exists but referenced files are missing: cert_path=${certPath}, key_path=${keyPath}`,
     );
   }
   return true;
@@ -105,13 +120,13 @@ export async function canMtlsBeEnabled(certConfigPathOverride?: string): Promise
 /**
  * Resolves the path to the certificate configuration JSON file.
  * Checks the override path, standard environment variable, and well-known location.
- * 
+ *
  * @param certConfigPathOverride Optional override path.
  * @returns The resolved absolute path to the configuration file.
  * @throws {CertificateSourceUnavailableError} If the configuration file cannot be found.
  */
 export async function resolveCertificateConfigFilePath(
-  certConfigPathOverride?: string
+  certConfigPathOverride?: string,
 ): Promise<string> {
   // Step 1: Check if an override path was passed directly (highest precedence)
   if (certConfigPathOverride) {
@@ -150,14 +165,14 @@ export async function resolveCertificateConfigFilePath(
 /**
  * Reads and parses the certificate configuration JSON file to extract the
  * certificate and private key file paths from the workload configuration block.
- * 
+ *
  * @param configPath Absolute path to the certificate config file.
  * @returns The file paths to the certificate and key.
  * @throws {CertificateSourceUnavailableError} If the configuration file is unreadable.
  * @throws {InvalidConfigurationError} If the JSON contents are invalid or missing required paths.
  */
 export async function getCertAndKeyFilePathsFromConfig(
-  configPath: string
+  configPath: string,
 ): Promise<{certPath: string; keyPath: string}> {
   let fileContents: string;
   try {
@@ -169,7 +184,7 @@ export async function getCertAndKeyFilePathsFromConfig(
   }
 
   try {
-    const config = JSON.parse(fileContents);
+    const config = JSON.parse(fileContents) as CertificateConfigFileJson;
     const certPath = config?.cert_configs?.workload?.cert_path;
     const keyPath = config?.cert_configs?.workload?.key_path;
 
@@ -180,7 +195,10 @@ export async function getCertAndKeyFilePathsFromConfig(
     }
     return {certPath, keyPath};
   } catch (e) {
-    if (e instanceof InvalidConfigurationError || e instanceof CertificateSourceUnavailableError) {
+    if (
+      e instanceof InvalidConfigurationError ||
+      e instanceof CertificateSourceUnavailableError
+    ) {
       throw e;
     }
     throw new InvalidConfigurationError(
@@ -194,17 +212,20 @@ export async function getCertAndKeyFilePathsFromConfig(
 /**
  * Loads the actual certificate and private key bytes from disk.
  * Prioritizes the configuration file. Validates the loaded files are in the correct format.
- * 
+ *
  * @param certConfigPathOverride Optional override path.
  * @returns The loaded cert and private key buffers.
  * @throws {Error} If no credentials could be resolved or if validation fails.
  */
 export async function getClientCertAndKey(
-  certConfigPathOverride?: string
+  certConfigPathOverride?: string,
 ): Promise<{cert: Buffer; key: Buffer}> {
-  const configPath = await resolveCertificateConfigFilePath(certConfigPathOverride);
-  const {certPath, keyPath} = await getCertAndKeyFilePathsFromConfig(configPath);
-  
+  const configPath = await resolveCertificateConfigFilePath(
+    certConfigPathOverride,
+  );
+  const {certPath, keyPath} =
+    await getCertAndKeyFilePathsFromConfig(configPath);
+
   let cert, key;
   try {
     cert = await fs.promises.readFile(certPath);

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -106,24 +106,27 @@ export async function canMtlsBeEnabled(
   }
 
   // Check for certificate configuration file
-  let configPath: string | null = null;
-  try {
-    configPath = await resolveCertificateConfigFilePath(certConfigPathOverride);
-  } catch (e) {
-    // Config file is simply not present.
-    return false;
+  if (
+    certConfigPathOverride ||
+    process.env[CERTIFICATE_CONFIGURATION_ENV_VARIABLE]
+  ) {
+    const configPath =
+      certConfigPathOverride ||
+      process.env[CERTIFICATE_CONFIGURATION_ENV_VARIABLE]!;
+    if (!(await isValidFile(configPath))) {
+      throw new CertificateSourceUnavailableError(
+        `Certificate configuration file does not exist or is not a file: ${configPath}`,
+      );
+    }
+    return true;
   }
 
-  // Config file exists / was specified. We must validate it.
-  // Any failure here must propagate as a hard error.
-  const {certPath, keyPath} =
-    await getCertAndKeyFilePathsFromConfig(configPath);
-  if (!(await isValidFile(certPath)) || !(await isValidFile(keyPath))) {
-    throw new Error(
-      `Certificate configuration exists but referenced files are missing: cert_path=${certPath}, key_path=${keyPath}`,
-    );
+  const wellKnownPath = getWellKnownCertificateConfigFileLocation();
+  if (await isValidFile(wellKnownPath)) {
+    return true;
   }
-  return true;
+
+  return false;
 }
 
 /**

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -1,0 +1,229 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as fs from 'fs';
+import {createPrivateKey, X509Certificate} from 'crypto';
+import {getWellKnownCertificateConfigFileLocation, isValidFile} from '../util';
+
+export const CERTIFICATE_CONFIGURATION_ENV_VARIABLE =
+  'GOOGLE_API_CERTIFICATE_CONFIG';
+
+/**
+ * Thrown when the certificate source cannot be located or accessed.
+ */
+export class CertificateSourceUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CertificateSourceUnavailableError';
+  }
+}
+
+/**
+ * Thrown for invalid configuration that is not related to file availability.
+ * Re-exported for use in CertificateSubjectTokenSupplier validation.
+ */
+export class InvalidConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidConfigurationError';
+  }
+}
+
+/**
+ * Endpoint usage policy for mutual TLS (mTLS).
+ */
+export enum MtlsEndpointUsagePolicy {
+  ALWAYS = 'always',
+  NEVER = 'never',
+  AUTO = 'auto',
+}
+
+/**
+ * Resolves the mTLS endpoint usage policy based on the `GOOGLE_API_USE_MTLS_ENDPOINT`
+ * environment variable.
+ * 
+ * @returns The resolved MtlsEndpointUsagePolicy.
+ */
+export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
+  const policy = process.env.GOOGLE_API_USE_MTLS_ENDPOINT;
+  if (policy === 'never') {
+    return MtlsEndpointUsagePolicy.NEVER;
+  } else if (policy === 'always') {
+    return MtlsEndpointUsagePolicy.ALWAYS;
+  }
+  return MtlsEndpointUsagePolicy.AUTO;
+}
+
+/**
+ * Centralized helper method to determine if mutual TLS (mTLS) can be enabled.
+ * 
+ * Checks for the environment policy constraints and parses the certificate configuration file.
+ * 
+ * @param certConfigPathOverride Optional path to override the certificate configuration file.
+ * @returns A promise that resolves to `true` if mTLS can be enabled, `false` otherwise.
+ * @throws {Error} If a configuration file is resolved but contains malformed contents or missing files.
+ */
+export async function canMtlsBeEnabled(certConfigPathOverride?: string): Promise<boolean> {
+  if (process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE === 'false') {
+    return false;
+  }
+  if (getMtlsEndpointUsagePolicy() === MtlsEndpointUsagePolicy.NEVER) {
+    return false;
+  }
+
+  // Check for certificate configuration file
+  let configPath: string | null = null;
+  try {
+    configPath = await resolveCertificateConfigFilePath(certConfigPathOverride);
+  } catch (e) {
+    // Config file is simply not present.
+    return false;
+  }
+
+  // Config file exists / was specified. We must validate it.
+  // Any failure here must propagate as a hard error.
+  const {certPath, keyPath} = await getCertAndKeyFilePathsFromConfig(configPath);
+  if (!(await isValidFile(certPath)) || !(await isValidFile(keyPath))) {
+    throw new Error(
+      `Certificate configuration exists but referenced files are missing: cert_path=${certPath}, key_path=${keyPath}`
+    );
+  }
+  return true;
+}
+
+/**
+ * Resolves the path to the certificate configuration JSON file.
+ * Checks the override path, standard environment variable, and well-known location.
+ * 
+ * @param certConfigPathOverride Optional override path.
+ * @returns The resolved absolute path to the configuration file.
+ * @throws {CertificateSourceUnavailableError} If the configuration file cannot be found.
+ */
+export async function resolveCertificateConfigFilePath(
+  certConfigPathOverride?: string
+): Promise<string> {
+  // Step 1: Check if an override path was passed directly (highest precedence)
+  if (certConfigPathOverride) {
+    if (await isValidFile(certConfigPathOverride)) {
+      return certConfigPathOverride;
+    }
+    throw new CertificateSourceUnavailableError(
+      `Provided certificate config path is invalid: ${certConfigPathOverride}`,
+    );
+  }
+
+  // Step 2: Check if the configuration path environment variable is defined
+  const envPath = process.env[CERTIFICATE_CONFIGURATION_ENV_VARIABLE];
+  if (envPath) {
+    if (await isValidFile(envPath)) {
+      return envPath;
+    }
+    throw new CertificateSourceUnavailableError(
+      `Path from environment variable "${CERTIFICATE_CONFIGURATION_ENV_VARIABLE}" is invalid: ${envPath}`,
+    );
+  }
+
+  // Step 3: Check in the default well-known gcloud location (lowest precedence)
+  const wellKnownPath = getWellKnownCertificateConfigFileLocation();
+  if (await isValidFile(wellKnownPath)) {
+    return wellKnownPath;
+  }
+
+  // Step 4: Throw error if no configuration file could be resolved
+  throw new CertificateSourceUnavailableError(
+    'Could not find certificate configuration file. Searched override path, ' +
+      `the "${CERTIFICATE_CONFIGURATION_ENV_VARIABLE}" env var, and the gcloud path (${wellKnownPath}).`,
+  );
+}
+
+/**
+ * Reads and parses the certificate configuration JSON file to extract the
+ * certificate and private key file paths from the workload configuration block.
+ * 
+ * @param configPath Absolute path to the certificate config file.
+ * @returns The file paths to the certificate and key.
+ * @throws {CertificateSourceUnavailableError} If the configuration file is unreadable.
+ * @throws {InvalidConfigurationError} If the JSON contents are invalid or missing required paths.
+ */
+export async function getCertAndKeyFilePathsFromConfig(
+  configPath: string
+): Promise<{certPath: string; keyPath: string}> {
+  let fileContents: string;
+  try {
+    fileContents = await fs.promises.readFile(configPath, 'utf8');
+  } catch (err) {
+    throw new CertificateSourceUnavailableError(
+      `Failed to read certificate config file at: ${configPath}`,
+    );
+  }
+
+  try {
+    const config = JSON.parse(fileContents);
+    const certPath = config?.cert_configs?.workload?.cert_path;
+    const keyPath = config?.cert_configs?.workload?.key_path;
+
+    if (!certPath || !keyPath) {
+      throw new InvalidConfigurationError(
+        `Certificate config file (${configPath}) is missing required "cert_path" or "key_path" in the workload config.`,
+      );
+    }
+    return {certPath, keyPath};
+  } catch (e) {
+    if (e instanceof InvalidConfigurationError || e instanceof CertificateSourceUnavailableError) {
+      throw e;
+    }
+    throw new InvalidConfigurationError(
+      `Failed to parse certificate config from ${configPath}: ${
+        (e as Error).message
+      }`,
+    );
+  }
+}
+
+/**
+ * Loads the actual certificate and private key bytes from disk.
+ * Prioritizes the configuration file. Validates the loaded files are in the correct format.
+ * 
+ * @param certConfigPathOverride Optional override path.
+ * @returns The loaded cert and private key buffers.
+ * @throws {Error} If no credentials could be resolved or if validation fails.
+ */
+export async function getClientCertAndKey(
+  certConfigPathOverride?: string
+): Promise<{cert: Buffer; key: Buffer}> {
+  const configPath = await resolveCertificateConfigFilePath(certConfigPathOverride);
+  const {certPath, keyPath} = await getCertAndKeyFilePathsFromConfig(configPath);
+  
+  let cert, key;
+  try {
+    cert = await fs.promises.readFile(certPath);
+    new X509Certificate(cert);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new CertificateSourceUnavailableError(
+      `Failed to read certificate file at ${certPath}: ${message}`,
+    );
+  }
+  try {
+    key = await fs.promises.readFile(keyPath);
+    createPrivateKey(key);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new CertificateSourceUnavailableError(
+      `Failed to read private key file at ${keyPath}: ${message}`,
+    );
+  }
+
+  return {cert, key};
+}

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -89,11 +89,20 @@ export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
 export async function canMtlsBeEnabled(
   certConfigPathOverride?: string,
 ): Promise<boolean> {
+  const policy = getMtlsEndpointUsagePolicy();
   if (process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE === 'false') {
+    if (policy === MtlsEndpointUsagePolicy.ALWAYS) {
+      throw new CertificateSourceUnavailableError(
+        'mTLS is configured to ALWAYS, but client certificate usage was explicitly disabled via GOOGLE_API_USE_CLIENT_CERTIFICATE=false.',
+      );
+    }
     return false;
   }
-  if (getMtlsEndpointUsagePolicy() === MtlsEndpointUsagePolicy.NEVER) {
+  if (policy === MtlsEndpointUsagePolicy.NEVER) {
     return false;
+  }
+  if (policy === MtlsEndpointUsagePolicy.ALWAYS) {
+    return true;
   }
 
   // Check for certificate configuration file

--- a/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/mtlsutils.ts
@@ -89,15 +89,10 @@ export function getMtlsEndpointUsagePolicy(): MtlsEndpointUsagePolicy {
 export async function canMtlsBeEnabled(
   certConfigPathOverride?: string,
 ): Promise<boolean> {
-  const policy = getMtlsEndpointUsagePolicy();
   if (process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE === 'false') {
-    if (policy === MtlsEndpointUsagePolicy.ALWAYS) {
-      throw new CertificateSourceUnavailableError(
-        'mTLS is configured to ALWAYS, but client certificate usage was explicitly disabled via GOOGLE_API_USE_CLIENT_CERTIFICATE=false.',
-      );
-    }
     return false;
   }
+  const policy = getMtlsEndpointUsagePolicy();
   if (policy === MtlsEndpointUsagePolicy.NEVER) {
     return false;
   }
@@ -259,4 +254,28 @@ export async function getClientCertAndKey(
   }
 
   return {cert, key};
+}
+
+/**
+ * Returns whether the mutual TLS (mTLS) endpoint should be used.
+ *
+ * @param certConfigPathOverride Optional path to override the certificate configuration file.
+ * @returns true if the mTLS endpoint should be used, false otherwise.
+ */
+export async function shouldMtlsEndpointBeUsed(
+  certConfigPathOverride?: string,
+): Promise<boolean> {
+  const policy = getMtlsEndpointUsagePolicy();
+  if (policy === MtlsEndpointUsagePolicy.ALWAYS) {
+    return true;
+  }
+  if (policy === MtlsEndpointUsagePolicy.NEVER) {
+    return false;
+  }
+  // policy is AUTO: use mTLS endpoint if client certificate can be enabled
+  try {
+    return await canMtlsBeEnabled(certConfigPathOverride);
+  } catch (e) {
+    return false;
+  }
 }

--- a/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Gaxios, GaxiosOptions } from 'gaxios';
-import { log as makeLog } from 'google-logging-utils';
+import {Gaxios, GaxiosOptions} from 'gaxios';
+import {log as makeLog} from 'google-logging-utils';
 import * as https from 'https';
 import {
   canMtlsBeEnabled,
   getClientCertAndKey,
   getMtlsEndpointUsagePolicy,
   MtlsEndpointUsagePolicy,
+  shouldMtlsEndpointBeUsed,
 } from './mtlsutils';
 
 const log = makeLog('auth');
@@ -263,15 +264,19 @@ export class RegionalAccessBoundaryManager {
       url: this.lookupUrl,
     };
 
-    // If mTLS can be enabled, use mTLS agent and switch to the mTLS endpoint
+    // Switch to the mTLS endpoint if configured or available
+    let mtlsApplied = false;
     try {
-      if (await canMtlsBeEnabled()) {
-        const { cert, key } = await getClientCertAndKey();
-        opts.agent = new https.Agent({ cert, key });
-        opts.url = this.lookupUrl.replace(
-          'iamcredentials.googleapis.com',
-          'iamcredentials.mtls.googleapis.com',
-        );
+      if (await shouldMtlsEndpointBeUsed()) {
+        if (await canMtlsBeEnabled()) {
+          const {cert, key} = await getClientCertAndKey();
+          opts.agent = new https.Agent({cert, key});
+          mtlsApplied = true;
+        } else if (
+          getMtlsEndpointUsagePolicy() === MtlsEndpointUsagePolicy.ALWAYS
+        ) {
+          mtlsApplied = true;
+        }
       }
     } catch (e) {
       log.error('RegionalAccessBoundary: Failed to initialize mTLS: ', e);
@@ -281,7 +286,14 @@ export class RegionalAccessBoundaryManager {
       }
     }
 
-    const { data: regionalAccessBoundaryData } =
+    if (mtlsApplied) {
+      opts.url = this.lookupUrl.replace(
+        'iamcredentials.googleapis.com',
+        'iamcredentials.mtls.googleapis.com',
+      );
+    }
+
+    const {data: regionalAccessBoundaryData} =
       await this.options.transporter.request<RegionalAccessBoundaryData>(opts);
 
     if (!regionalAccessBoundaryData?.encodedLocations) {

--- a/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
@@ -14,6 +14,8 @@
 
 import { Gaxios, GaxiosOptions } from 'gaxios';
 import { log as makeLog } from 'google-logging-utils';
+import * as https from 'https';
+import { canMtlsBeEnabled, getClientCertAndKey } from './mtlsutils';
 
 const log = makeLog('auth');
 
@@ -253,6 +255,20 @@ export class RegionalAccessBoundaryManager {
       headers,
       url: this.lookupUrl,
     };
+
+    // If mTLS can be enabled, use mTLS agent and switch to the mTLS endpoint
+    try {
+      if (await canMtlsBeEnabled()) {
+        const { cert, key } = await getClientCertAndKey();
+        opts.agent = new https.Agent({ cert, key });
+        opts.url = this.lookupUrl.replace(
+          'iamcredentials.googleapis.com',
+          'iamcredentials.mtls.googleapis.com',
+        );
+      }
+    } catch (e) {
+      log.error('RegionalAccessBoundary: Failed to initialize mTLS: ', e);
+    }
 
     const { data: regionalAccessBoundaryData } =
       await this.options.transporter.request<RegionalAccessBoundaryData>(opts);

--- a/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
@@ -33,6 +33,8 @@ export const WORKLOAD_LOOKUP_ENDPOINT =
 export const WORKFORCE_LOOKUP_ENDPOINT =
   'https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/{pool_id}/allowedLocations';
 
+export const REGIONAL_ACCESS_BOUNDARY_HEADER = 'x-allowed-locations';
+
 /**
  * RAB is considered valid for 6 hours.
  */

--- a/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
@@ -270,7 +270,8 @@ export class RegionalAccessBoundaryManager {
       if (await shouldMtlsEndpointBeUsed()) {
         if (await canMtlsBeEnabled()) {
           const {cert, key} = await getClientCertAndKey();
-          opts.agent = new https.Agent({cert, key});
+          opts.cert = cert.toString('utf8');
+          opts.key = key.toString('utf8');
           mtlsApplied = true;
         } else if (
           getMtlsEndpointUsagePolicy() === MtlsEndpointUsagePolicy.ALWAYS

--- a/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/regionalaccessboundary.ts
@@ -15,7 +15,12 @@
 import { Gaxios, GaxiosOptions } from 'gaxios';
 import { log as makeLog } from 'google-logging-utils';
 import * as https from 'https';
-import { canMtlsBeEnabled, getClientCertAndKey } from './mtlsutils';
+import {
+  canMtlsBeEnabled,
+  getClientCertAndKey,
+  getMtlsEndpointUsagePolicy,
+  MtlsEndpointUsagePolicy,
+} from './mtlsutils';
 
 const log = makeLog('auth');
 
@@ -268,6 +273,10 @@ export class RegionalAccessBoundaryManager {
       }
     } catch (e) {
       log.error('RegionalAccessBoundary: Failed to initialize mTLS: ', e);
+      // If mTLS is configured to ALWAYS, propagate the error instead of falling back to the standard endpoint.
+      if (getMtlsEndpointUsagePolicy() === MtlsEndpointUsagePolicy.ALWAYS) {
+        throw e;
+      }
     }
 
     const { data: regionalAccessBoundaryData } =

--- a/core/packages/google-auth-library-nodejs/test/test.authclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.authclient.ts
@@ -73,6 +73,11 @@ describe('AuthClient', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    sandbox.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
   });
 
   afterEach(() => {

--- a/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
@@ -165,6 +165,11 @@ describe('BaseExternalAccountClient', () => {
   let sandbox: sinon.SinonSandbox;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    sandbox.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
     sandbox
       .stub(BaseExternalAccountClient.prototype, 'getRegionalAccessBoundaryUrl')
       .resolves(undefined);

--- a/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.baseexternalclient.ts
@@ -2944,5 +2944,26 @@ describe('BaseExternalAccountClient', () => {
       rabScope.done();
       impersonatedScope.done();
     });
+
+    it('should encode special characters in workload pool ID and project number when constructing the URL', async () => {
+      const projectNumber = '123?45';
+      const workloadPoolId = 'my-pool#name';
+      const workloadAudience = `//iam.googleapis.com/projects/${projectNumber}/locations/global/workloadIdentityPools/${workloadPoolId}/providers/my-provider`;
+      const workloadOptions = {
+        ...externalAccountOptions,
+        audience: workloadAudience,
+      };
+      const client = new TestExternalAccountClient(workloadOptions);
+
+      const url = await client.getRegionalAccessBoundaryUrl();
+      const expectedUrl = WORKLOAD_LOOKUP_ENDPOINT.replace(
+        '{project_id}',
+        encodeURIComponent(projectNumber),
+      ).replace('{pool_id}', encodeURIComponent(workloadPoolId));
+
+      assert.strictEqual(url, expectedUrl);
+      assert.ok(url.includes('123%3F45'));
+      assert.ok(url.includes('my-pool%23name'));
+    });
   });
 });

--- a/core/packages/google-auth-library-nodejs/test/test.compute.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.compute.ts
@@ -47,6 +47,11 @@ describe('compute', () => {
   const sandbox = sinon.createSandbox();
   let compute: Compute;
   beforeEach(() => {
+    sandbox.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
     compute = new Compute();
     sandbox
       .stub(Compute.prototype, 'getRegionalAccessBoundaryUrl')
@@ -348,6 +353,65 @@ describe('compute', () => {
 
       tokenScope.done();
       rabScope.done();
+    });
+
+    it('should trigger asynchronous RAB refresh using mTLS when enabled', async () => {
+      const compute = new Compute();
+      const fakeEmail = 'fake-default-sa@developer.gserviceaccount.com';
+      const metadataStub = sandbox.stub(gcpMetadata, 'instance');
+      metadataStub.callThrough();
+      metadataStub
+        .withArgs('service-accounts/default/email')
+        .resolves(fakeEmail);
+
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'true';
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config.json';
+
+      const tokenScope = setupTokenNock('default');
+      
+      // The lookup url should be replaced with iamcredentials.mtls.googleapis.com
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(fakeEmail),
+      ).replace(
+        'iamcredentials.googleapis.com',
+        'iamcredentials.mtls.googleapis.com'
+      );
+      
+      const rabScope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', MOCK_AUTH_HEADER)
+        .reply(200, EXPECTED_RAB_DATA);
+
+      let rabLookupCalled = false;
+      rabScope.on('request', () => {
+        rabLookupCalled = true;
+      });
+
+      const url = 'https://pubsub.googleapis.com';
+      const headers = await compute.getRequestHeaders(url);
+
+      assert.strictEqual(headers.get('x-allowed-locations'), null);
+
+      let attempts = 0;
+      while (!rabLookupCalled && attempts < 10) {
+        await new Promise(r => setTimeout(r, 100));
+        attempts++;
+      }
+      assert.strictEqual(rabLookupCalled, true);
+
+      await new Promise(r => setTimeout(r, 50));
+      assert.deepStrictEqual(
+        compute.getRegionalAccessBoundary(),
+        EXPECTED_RAB_DATA,
+      );
+
+      tokenScope.done();
+      rabScope.done();
+
+      delete process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE;
+      delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
     });
 
     it('should fail getRegionalAccessBoundaryUrl in background if metadata call fails', async () => {

--- a/core/packages/google-auth-library-nodejs/test/test.compute.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.compute.ts
@@ -369,16 +369,16 @@ describe('compute', () => {
         './test/fixtures/external-account-cert/cert_config.json';
 
       const tokenScope = setupTokenNock('default');
-      
+
       // The lookup url should be replaced with iamcredentials.mtls.googleapis.com
       const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
         '{service_account_email}',
         encodeURIComponent(fakeEmail),
       ).replace(
         'iamcredentials.googleapis.com',
-        'iamcredentials.mtls.googleapis.com'
+        'iamcredentials.mtls.googleapis.com',
       );
-      
+
       const rabScope = nock(new URL(lookupUrl).origin)
         .get(new URL(lookupUrl).pathname)
         .matchHeader('authorization', MOCK_AUTH_HEADER)

--- a/core/packages/google-auth-library-nodejs/test/test.externalaccountauthorizeduserclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.externalaccountauthorizeduserclient.ts
@@ -116,6 +116,11 @@ describe('ExternalAccountAuthorizedUserClient', () => {
     expires_in: 3600,
   };
   beforeEach(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
     clock = TestUtils.useFakeTimers(sinon, referenceDate);
   });
 
@@ -124,6 +129,7 @@ describe('ExternalAccountAuthorizedUserClient', () => {
     if (clock) {
       clock.restore();
     }
+    sinon.restore();
   });
 
   describe('Constructor', () => {

--- a/core/packages/google-auth-library-nodejs/test/test.identitypoolclient.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.identitypoolclient.ts
@@ -39,7 +39,7 @@ import {
   CERTIFICATE_CONFIGURATION_ENV_VARIABLE,
   CertificateSourceUnavailableError,
   InvalidConfigurationError,
-} from '../src/auth/certificatesubjecttokensupplier';
+} from '../src/auth/mtlsutils';
 import * as sinon from 'sinon';
 import * as util from '../src/util';
 

--- a/core/packages/google-auth-library-nodejs/test/test.impersonated.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.impersonated.ts
@@ -75,6 +75,11 @@ interface ImpersonatedCredentialRequest {
 
 describe('impersonated', () => {
   beforeEach(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
     sinon
       .stub(Impersonated.prototype, 'getRegionalAccessBoundaryUrl')
       .resolves(undefined);

--- a/core/packages/google-auth-library-nodejs/test/test.jwt.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.jwt.ts
@@ -1391,6 +1391,8 @@ describe('jwt', () => {
 
       const tokenScope = createGTokenMock({access_token: MOCK_ACCESS_TOKEN});
 
+      const requestSpy = localSandbox.spy(jwt.transporter, 'request');
+
       // Construct and mock the mTLS lookup URL
       const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
         '{service_account_email}',
@@ -1424,6 +1426,18 @@ describe('jwt', () => {
         jwt.getRegionalAccessBoundary(),
         EXPECTED_RAB_DATA,
       );
+
+      // Verify transporter request options
+      const lookupCall = requestSpy.getCalls().find(c => {
+        const url = c.args[0]?.url;
+        return url && url.toString().includes('allowedLocations');
+      });
+      assert.ok(lookupCall);
+      const callOpts = lookupCall!.args[0];
+      assert.ok(callOpts);
+      assert.strictEqual(callOpts.agent, undefined);
+      assert.ok(callOpts.cert);
+      assert.ok(callOpts.key);
 
       tokenScope.done();
       rabScope.done();

--- a/core/packages/google-auth-library-nodejs/test/test.jwt.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.jwt.ts
@@ -1282,12 +1282,17 @@ describe('jwt', () => {
         .reply(200, regionalAccessBoundaryData);
     }
 
+    let localSandbox: sinon.SinonSandbox;
+
     beforeEach(() => {
+      localSandbox = sinon.createSandbox();
+      localSandbox.stub(process, 'env').value({...process.env});
       (JWT.prototype.getRegionalAccessBoundaryUrl as sinon.SinonStub).restore();
     });
 
     afterEach(() => {
       nock.cleanAll();
+      localSandbox.restore();
     });
 
     it('should trigger asynchronous regional access boundaries refresh', async () => {
@@ -1341,6 +1346,19 @@ describe('jwt', () => {
 
       const tokenScope = createGTokenMock({access_token: MOCK_ACCESS_TOKEN});
 
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(SERVICE_ACCOUNT_EMAIL),
+      ).replace(
+        'iamcredentials.googleapis.com',
+        'iamcredentials.mtls.googleapis.com',
+      );
+
+      const rabScope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', MOCK_AUTH_HEADER)
+        .reply(403, 'Forbidden');
+
       // We trigger the background lookup by getting request headers.
       await jwt.getRequestHeaders('https://pubsub.googleapis.com');
 
@@ -1355,6 +1373,7 @@ describe('jwt', () => {
       assert.ok(jwt.getRegionalAccessBoundaryCooldownTime() > Date.now());
 
       tokenScope.done();
+      rabScope.done();
     });
 
     it('should use mTLS endpoint for RAB lookup if GOOGLE_API_USE_MTLS_ENDPOINT is always and valid cert config is present', async () => {

--- a/core/packages/google-auth-library-nodejs/test/test.jwt.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.jwt.ts
@@ -1327,6 +1327,89 @@ describe('jwt', () => {
       rabScope.done();
     });
 
+    it('should fail RAB lookup if GOOGLE_API_USE_MTLS_ENDPOINT is always but client certificate is disabled', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'false';
+
+      const jwt = new JWT({
+        email: SERVICE_ACCOUNT_EMAIL,
+        keyFile: PEM_PATH,
+        scopes: ['http://bar', 'http://foo'],
+        subject: 'bar@subjectaccount.com',
+      });
+      jwt.credentials = {refresh_token: 'jwt-placeholder'};
+
+      const tokenScope = createGTokenMock({access_token: MOCK_ACCESS_TOKEN});
+
+      // We trigger the background lookup by getting request headers.
+      await jwt.getRequestHeaders('https://pubsub.googleapis.com');
+
+      // Wait a bit for the async task to execute and fail
+      let attempts = 0;
+      while (!jwt.getRegionalAccessBoundaryCooldownTime() && attempts < 10) {
+        await new Promise(r => setTimeout(r, 50));
+        attempts++;
+      }
+
+      // It should enter cooldown because it failed to initialize mTLS
+      assert.ok(jwt.getRegionalAccessBoundaryCooldownTime() > Date.now());
+
+      tokenScope.done();
+    });
+
+    it('should use mTLS endpoint for RAB lookup if GOOGLE_API_USE_MTLS_ENDPOINT is always and valid cert config is present', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config.json';
+
+      const jwt = new JWT({
+        email: SERVICE_ACCOUNT_EMAIL,
+        keyFile: PEM_PATH,
+        scopes: ['http://bar', 'http://foo'],
+        subject: 'bar@subjectaccount.com',
+      });
+      jwt.credentials = {refresh_token: 'jwt-placeholder'};
+
+      const tokenScope = createGTokenMock({access_token: MOCK_ACCESS_TOKEN});
+
+      // Construct and mock the mTLS lookup URL
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(SERVICE_ACCOUNT_EMAIL),
+      ).replace(
+        'iamcredentials.googleapis.com',
+        'iamcredentials.mtls.googleapis.com',
+      );
+
+      let rabLookupCalled = false;
+      const rabScope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', MOCK_AUTH_HEADER)
+        .reply(() => {
+          rabLookupCalled = true;
+          return [200, EXPECTED_RAB_DATA];
+        });
+
+      // We trigger the background lookup by getting request headers.
+      await jwt.getRequestHeaders('https://pubsub.googleapis.com');
+
+      // Wait a bit for the async task to execute
+      let attempts = 0;
+      while (!rabLookupCalled && attempts < 10) {
+        await new Promise(r => setTimeout(r, 50));
+        attempts++;
+      }
+
+      assert.strictEqual(rabLookupCalled, true);
+      assert.deepStrictEqual(
+        jwt.getRegionalAccessBoundary(),
+        EXPECTED_RAB_DATA,
+      );
+
+      tokenScope.done();
+      rabScope.done();
+    });
+
     it('should trigger RAB refresh for self-signed JWT', async () => {
       // Self-signed JWT (no scopes)
       const keys = keypair(512);

--- a/core/packages/google-auth-library-nodejs/test/test.jwt.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.jwt.ts
@@ -72,6 +72,11 @@ describe('jwt', () => {
     json = createJSON();
     jwt = new JWT();
     sandbox = sinon.createSandbox();
+    sandbox.stub(process, 'env').value({
+      ...process.env,
+      GOOGLE_API_USE_CLIENT_CERTIFICATE: undefined,
+      GOOGLE_API_CERTIFICATE_CONFIG: undefined,
+    });
     sandbox
       .stub(JWT.prototype, 'getRegionalAccessBoundaryUrl')
       .resolves(undefined);

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -76,6 +76,25 @@ describe('mtlsutils', () => {
       const result = await canMtlsBeEnabled();
       assert.strictEqual(result, false);
     });
+
+    it('returns true if GOOGLE_API_USE_MTLS_ENDPOINT is always, even if no config file is present', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
+      sandbox
+        .stub(util, 'getWellKnownCertificateConfigFileLocation')
+        .returns(path.join(tempDir, 'non_existent.json'));
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, true);
+    });
+
+    it('throws error if GOOGLE_API_USE_MTLS_ENDPOINT is always and GOOGLE_API_USE_CLIENT_CERTIFICATE is false', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'false';
+      await assert.rejects(
+        canMtlsBeEnabled(),
+        /mTLS is configured to ALWAYS, but client certificate usage was explicitly disabled via GOOGLE_API_USE_CLIENT_CERTIFICATE=false\./,
+      );
+    });
   });
 
   describe('getClientCertAndKey', () => {

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -35,6 +35,9 @@ describe('mtlsutils', () => {
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
     sandbox.stub(process, 'env').value({...process.env});
+    delete process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE;
+    delete process.env.GOOGLE_API_USE_MTLS_ENDPOINT;
+    delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
     tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mtls-tests-'));
   });
 

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -18,10 +18,7 @@ import * as sinon from 'sinon';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import {
-  canMtlsBeEnabled,
-  getClientCertAndKey,
-} from '../src/auth/mtlsutils';
+import {canMtlsBeEnabled, getClientCertAndKey} from '../src/auth/mtlsutils';
 import * as util from '../src/util';
 
 describe('mtlsutils', () => {
@@ -30,7 +27,7 @@ describe('mtlsutils', () => {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(process, 'env').value({ ...process.env });
+    sandbox.stub(process, 'env').value({...process.env});
     tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mtls-tests-'));
   });
 
@@ -73,9 +70,9 @@ describe('mtlsutils', () => {
 
     it('returns false if no config is present', async () => {
       delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
-      sandbox.stub(util, 'getWellKnownCertificateConfigFileLocation').returns(
-        path.join(tempDir, 'non_existent.json')
-      );
+      sandbox
+        .stub(util, 'getWellKnownCertificateConfigFileLocation')
+        .returns(path.join(tempDir, 'non_existent.json'));
       const result = await canMtlsBeEnabled();
       assert.strictEqual(result, false);
     });
@@ -84,7 +81,7 @@ describe('mtlsutils', () => {
   describe('getClientCertAndKey', () => {
     it('loads cert and key from config successfully', async () => {
       const result = await getClientCertAndKey(
-        './test/fixtures/external-account-cert/cert_config.json'
+        './test/fixtures/external-account-cert/cert_config.json',
       );
       assert.ok(result.cert);
       assert.ok(result.key);
@@ -93,8 +90,8 @@ describe('mtlsutils', () => {
     it('throws error if files resolved by config are malformed', async () => {
       await assert.rejects(
         getClientCertAndKey(
-          './test/fixtures/external-account-cert/cert_config_with_malformed_key.json'
-        )
+          './test/fixtures/external-account-cert/cert_config_with_malformed_key.json',
+        ),
       );
     });
   });

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -18,7 +18,12 @@ import * as sinon from 'sinon';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import {canMtlsBeEnabled, getClientCertAndKey} from '../src/auth/mtlsutils';
+import {
+  canMtlsBeEnabled,
+  getClientCertAndKey,
+  CertificateSourceUnavailableError,
+  InvalidConfigurationError,
+} from '../src/auth/mtlsutils';
 import * as util from '../src/util';
 
 describe('mtlsutils', () => {
@@ -56,16 +61,37 @@ describe('mtlsutils', () => {
       assert.strictEqual(result, true);
     });
 
-    it('throws error if cert config file is malformed', async () => {
+    it('returns true even if cert config file is malformed', async () => {
       process.env.GOOGLE_API_CERTIFICATE_CONFIG =
         './test/fixtures/external-account-cert/cert_config_empty.json';
-      await assert.rejects(canMtlsBeEnabled());
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, true);
     });
 
-    it('throws error if cert config has missing files', async () => {
+    it('returns true even if cert config is missing required workload properties', async () => {
       process.env.GOOGLE_API_CERTIFICATE_CONFIG =
         './test/fixtures/external-account-cert/cert_config_missing_cert_path.json';
-      await assert.rejects(canMtlsBeEnabled());
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, true);
+    });
+
+    it('returns true even if cert config referenced files do not exist', async () => {
+      const invalidConfigPath = path.join(tempDir, 'invalid_config.json');
+      const invalidConfigJson = {
+        cert_configs: {
+          workload: {
+            cert_path: path.join(tempDir, 'non_existent.crt'),
+            key_path: path.join(tempDir, 'non_existent.key'),
+          },
+        },
+      };
+      await fs.promises.writeFile(
+        invalidConfigPath,
+        JSON.stringify(invalidConfigJson),
+      );
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG = invalidConfigPath;
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, true);
     });
 
     it('returns false if no config is present', async () => {
@@ -111,6 +137,44 @@ describe('mtlsutils', () => {
         getClientCertAndKey(
           './test/fixtures/external-account-cert/cert_config_with_malformed_key.json',
         ),
+      );
+    });
+
+    it('throws error if cert config file is malformed', async () => {
+      await assert.rejects(
+        getClientCertAndKey(
+          './test/fixtures/external-account-cert/cert_config_empty.json',
+        ),
+        InvalidConfigurationError,
+      );
+    });
+
+    it('throws error if cert config is missing required workload properties', async () => {
+      await assert.rejects(
+        getClientCertAndKey(
+          './test/fixtures/external-account-cert/cert_config_missing_cert_path.json',
+        ),
+        InvalidConfigurationError,
+      );
+    });
+
+    it('throws error if cert config referenced files do not exist', async () => {
+      const invalidConfigPath = path.join(tempDir, 'invalid_config.json');
+      const invalidConfigJson = {
+        cert_configs: {
+          workload: {
+            cert_path: path.join(tempDir, 'non_existent.crt'),
+            key_path: path.join(tempDir, 'non_existent.key'),
+          },
+        },
+      };
+      await fs.promises.writeFile(
+        invalidConfigPath,
+        JSON.stringify(invalidConfigJson),
+      );
+      await assert.rejects(
+        getClientCertAndKey(invalidConfigPath),
+        CertificateSourceUnavailableError,
       );
     });
   });

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import * as sinon from 'sinon';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  canMtlsBeEnabled,
+  getClientCertAndKey,
+} from '../src/auth/mtlsutils';
+import * as util from '../src/util';
+
+describe('mtlsutils', () => {
+  let sandbox: sinon.SinonSandbox;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(process, 'env').value({ ...process.env });
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mtls-tests-'));
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await fs.promises.rm(tempDir, {recursive: true, force: true});
+  });
+
+  describe('canMtlsBeEnabled', () => {
+    it('returns false if GOOGLE_API_USE_CLIENT_CERTIFICATE is false', async () => {
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'false';
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, false);
+    });
+
+    it('returns false if GOOGLE_API_USE_MTLS_ENDPOINT is never', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'never';
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, false);
+    });
+
+    it('returns true if valid cert config file is present', async () => {
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config.json';
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, true);
+    });
+
+    it('throws error if cert config file is malformed', async () => {
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config_empty.json';
+      await assert.rejects(canMtlsBeEnabled());
+    });
+
+    it('throws error if cert config has missing files', async () => {
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config_missing_cert_path.json';
+      await assert.rejects(canMtlsBeEnabled());
+    });
+
+    it('returns false if no config is present', async () => {
+      delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
+      sandbox.stub(util, 'getWellKnownCertificateConfigFileLocation').returns(
+        path.join(tempDir, 'non_existent.json')
+      );
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, false);
+    });
+  });
+
+  describe('getClientCertAndKey', () => {
+    it('loads cert and key from config successfully', async () => {
+      const result = await getClientCertAndKey(
+        './test/fixtures/external-account-cert/cert_config.json'
+      );
+      assert.ok(result.cert);
+      assert.ok(result.key);
+    });
+
+    it('throws error if files resolved by config are malformed', async () => {
+      await assert.rejects(
+        getClientCertAndKey(
+          './test/fixtures/external-account-cert/cert_config_with_malformed_key.json'
+        )
+      );
+    });
+  });
+});

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -25,6 +25,7 @@ import {
   InvalidConfigurationError,
   getMtlsEndpointUsagePolicy,
   MtlsEndpointUsagePolicy,
+  shouldMtlsEndpointBeUsed,
 } from '../src/auth/mtlsutils';
 import * as util from '../src/util';
 
@@ -118,13 +119,11 @@ describe('mtlsutils', () => {
       assert.strictEqual(result, true);
     });
 
-    it('throws error if GOOGLE_API_USE_MTLS_ENDPOINT is always and GOOGLE_API_USE_CLIENT_CERTIFICATE is false', async () => {
+    it('returns false if GOOGLE_API_USE_CLIENT_CERTIFICATE is false, even if GOOGLE_API_USE_MTLS_ENDPOINT is always', async () => {
       process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
       process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'false';
-      await assert.rejects(
-        canMtlsBeEnabled(),
-        /mTLS is configured to ALWAYS, but client certificate usage was explicitly disabled via GOOGLE_API_USE_CLIENT_CERTIFICATE=false\./,
-      );
+      const result = await canMtlsBeEnabled();
+      assert.strictEqual(result, false);
     });
   });
 
@@ -197,6 +196,45 @@ describe('mtlsutils', () => {
         getMtlsEndpointUsagePolicy(),
         MtlsEndpointUsagePolicy.ALWAYS,
       );
+    });
+  });
+
+  describe('shouldMtlsEndpointBeUsed', () => {
+    it('returns true if GOOGLE_API_USE_MTLS_ENDPOINT is always', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      const result = await shouldMtlsEndpointBeUsed();
+      assert.strictEqual(result, true);
+    });
+
+    it('returns false if GOOGLE_API_USE_MTLS_ENDPOINT is never', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'never';
+      const result = await shouldMtlsEndpointBeUsed();
+      assert.strictEqual(result, false);
+    });
+
+    it('returns true if GOOGLE_API_USE_MTLS_ENDPOINT is auto and cert config is present', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'auto';
+      process.env.GOOGLE_API_CERTIFICATE_CONFIG =
+        './test/fixtures/external-account-cert/cert_config.json';
+      const result = await shouldMtlsEndpointBeUsed();
+      assert.strictEqual(result, true);
+    });
+
+    it('returns false if GOOGLE_API_USE_MTLS_ENDPOINT is auto and no cert config is present', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'auto';
+      delete process.env.GOOGLE_API_CERTIFICATE_CONFIG;
+      sandbox
+        .stub(util, 'getWellKnownCertificateConfigFileLocation')
+        .returns(path.join(tempDir, 'non_existent.json'));
+      const result = await shouldMtlsEndpointBeUsed();
+      assert.strictEqual(result, false);
+    });
+
+    it('returns true if GOOGLE_API_USE_MTLS_ENDPOINT is always and GOOGLE_API_USE_CLIENT_CERTIFICATE is false', async () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'always';
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'false';
+      const result = await shouldMtlsEndpointBeUsed();
+      assert.strictEqual(result, true);
     });
   });
 });

--- a/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.mtlsutils.ts
@@ -23,6 +23,8 @@ import {
   getClientCertAndKey,
   CertificateSourceUnavailableError,
   InvalidConfigurationError,
+  getMtlsEndpointUsagePolicy,
+  MtlsEndpointUsagePolicy,
 } from '../src/auth/mtlsutils';
 import * as util from '../src/util';
 
@@ -175,6 +177,22 @@ describe('mtlsutils', () => {
       await assert.rejects(
         getClientCertAndKey(invalidConfigPath),
         CertificateSourceUnavailableError,
+      );
+    });
+  });
+
+  describe('getMtlsEndpointUsagePolicy', () => {
+    it('returns NEVER or ALWAYS case-insensitively', () => {
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'NeVeR';
+      assert.strictEqual(
+        getMtlsEndpointUsagePolicy(),
+        MtlsEndpointUsagePolicy.NEVER,
+      );
+
+      process.env.GOOGLE_API_USE_MTLS_ENDPOINT = 'AlWaYs';
+      assert.strictEqual(
+        getMtlsEndpointUsagePolicy(),
+        MtlsEndpointUsagePolicy.ALWAYS,
       );
     });
   });


### PR DESCRIPTION
Added logic to:

Centralize mTLS enablement logic within the auth library.
Based on 1. determine whether mtls or regular RAB lookup endpoint should be called.
Added tests for the same.