### PR TITLE
test(auth): verify ADC fallback gracefully rejects when GCE check is false

### DIFF
--- a/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
@@ -1188,6 +1188,15 @@ describe('googleauth', () => {
       await assert.rejects(auth.getApplicationDefault(), e);
     });
 
+    it('getApplicationDefault should reject with NO_ADC_FOUND if _checkIsGCE returns false', async () => {
+      mockWindows();
+      sandbox.stub(auth, '_checkIsGCE').resolves(false);
+      await assert.rejects(
+        auth.getApplicationDefault(),
+        new Error(GoogleAuthExceptionMessages.NO_ADC_FOUND)
+      );
+    });
+
     it('getApplicationDefault should also get project ID', async () => {
       // Set up the creds.
       // * Environment variable is set up to point to private.json


### PR DESCRIPTION
Other client libraries (like Python, Go, and Ruby) have robust tests verifying that if the GCE residency check returns false, the application default credentials (ADC) loader cleanly rejects with a standard NO_ADC_FOUND error. Node.js lacked a test for this clean rejection, only covering scenarios where the residency check threw an active connection error.
