### PR TITLE
docs: fix reCAPTCHA Enterprise reference link

### DIFF
--- a/packages/google-cloud-recaptchaenterprise/README.md
+++ b/packages/google-cloud-recaptchaenterprise/README.md
@@ -18,7 +18,7 @@ reCAPTCHA Enterprise API client for Node.js
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [reCAPTCHA Enterprise API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/recaptchaenterprise/latest)
+* [reCAPTCHA Enterprise API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/recaptcha-enterprise/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older


### PR DESCRIPTION
## Summary
- update the reCAPTCHA Enterprise README API reference link to the current `recaptcha-enterprise` URL

Fixes #7667

## Verification
- `git diff --check`
- `rg -n "recaptchaenterprise/latest|recaptcha-enterprise/latest" packages/google-cloud-recaptchaenterprise/README.md libraries.json`
- old URL returns 404: `https://cloud.google.com/nodejs/docs/reference/recaptchaenterprise/latest`
- new URL returns 200: `https://cloud.google.com/nodejs/docs/reference/recaptcha-enterprise/latest`