### PR TITLE
fix(teeny-request): avoid piping into destroyed streams

### DIFF
--- a/core/packages/teeny-request/src/index.ts
+++ b/core/packages/teeny-request/src/index.ts
@@ -276,13 +276,19 @@ function teenyRequest(
     const requestStream = streamEvents(new PassThrough());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let responseStream: any;
+    const pipeResponseStream = () => {
+      if (requestStream.destroyed) {
+        responseStream.destroy();
+        return;
+      }
+
+      pipeline(responseStream, requestStream, () => {});
+    };
     requestStream.once('reading', () => {
       if (responseStream) {
-        pipeline(responseStream, requestStream, () => {});
+        pipeResponseStream();
       } else {
-        requestStream.once('response', () => {
-          pipeline(responseStream, requestStream, () => {});
-        });
+        requestStream.once('response', pipeResponseStream);
       }
     });
     options.compress = false;

--- a/core/packages/teeny-request/test/index.ts
+++ b/core/packages/teeny-request/test/index.ts
@@ -275,6 +275,23 @@ describe('teeny', () => {
       });
   });
 
+  it('should discard the response if the request stream is destroyed before piping', async () => {
+    const scope = mockJson();
+    const stream = teenyRequest({uri});
+    const responseClosed = new Promise<void>((resolve, reject) => {
+      stream.once('error', reject);
+      stream.once('response', response => {
+        response.body.once('error', reject);
+        response.body.once('close', resolve);
+        stream.destroy();
+      });
+    });
+
+    stream.resume();
+    await responseClosed;
+    scope.done();
+  });
+
   it('should not pipe response stream to user unless they ask for it', async () => {
     const scope = mockJson();
     const stream = teenyRequest({uri}).on('error', err => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] An issue with a runnable reproduction was opened before the source change.
- [x] The package tests and linter pass.
- [x] Code coverage does not decrease.
- [x] No documentation update is necessary for this internal stream lifecycle fix.

Fixes #8670

## Summary

Stream-mode requests defer pipeline setup until both the consumer starts reading and the fetch response arrives. A `response` listener can destroy the returned request stream before the later teeny-request listener constructs the pipeline. `retry-request` follows this sequence when it discards a retryable response before starting another attempt.

Passing the destroyed destination to `pipeline()` produces an unhandled `ERR_STREAM_UNABLE_TO_PIPE`. The unused fetch response body also remains open.

This change centralizes response pipeline setup and checks the destination immediately before constructing the pipeline. If the request stream is already destroyed, teeny-request destroys the unused response body instead.

A regression test reproduces the real listener ordering and verifies that the discarded body closes.

## Testing

- Baseline reproduction on Node 24.16.0: unhandled `ERR_STREAM_UNABLE_TO_PIPE`; response body remained open.
- `npm test`: 116 passing, 2 existing pending.
- Full compiled suite passed on Node 18, 22, 24, and 26.
- `npm run lint` passed.
- `retry-request` integration passed: a 500 response was discarded, the request retried, and the 200 response body was returned without an unhandled rejection.