### PR TITLE
chore: define and parse default reviewers from team_members comment in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/cloud-sdk-nodejs-team
+# The cloud sdk nodejs team is the default owner for nodejs repositories.
+*     @pearigee @feywind @djbruce @shivanee-p
 /handwritten/bigquery @googleapis/bigquery-team
 /handwritten/cloud-profiler @googleapis/cloud-profiler-team
 /handwritten/storage @googleapis/gcs-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The cloud sdk nodejs team is the default owner for nodejs repositories.
-# team_members: @pearigee @feywind @djbruce @shivanee-p
+# team_members: @pearigee @feywind @danieljbruce @shivanee-p
 *     @googleapis/cloud-sdk-nodejs-team
 /handwritten/bigquery @googleapis/bigquery-team
 /handwritten/cloud-profiler @googleapis/cloud-profiler-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,4 @@
 /handwritten/firestore @googleapis/firestore-team
 /handwritten/spanner @googleapis/spanner-team
 /handwritten/bigquery-storage @googleapis/bigquery-team
-/handwritten/pubsub @googleapis/pubsub-team
-/handwritten/bigtable @googleapis/bigtable-team
 /core/packages/google-auth-library-nodejs @googleapis/aion-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,8 @@
 
 
 # The cloud sdk nodejs team is the default owner for nodejs repositories.
-*     @pearigee @feywind @djbruce @shivanee-p
+# team_members: @pearigee @feywind @djbruce @shivanee-p
+*     @googleapis/cloud-sdk-nodejs-team
 /handwritten/bigquery @googleapis/bigquery-team
 /handwritten/cloud-profiler @googleapis/cloud-profiler-team
 /handwritten/storage @googleapis/gcs-team

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -117,6 +117,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   path: '.github/CODEOWNERS',
+                  ref: context.payload.pull_request.head.sha,
                 });
                 const content = Buffer.from(codeownersData.content, 'base64').toString('utf-8');
                 const lines = content.split('\n');

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -91,16 +91,25 @@ jobs:
               }
             }
 
+            let assigned = false;
             if (assignedTeams.size > 0) {
               const teamReviewers = Array.from(assignedTeams);
               console.log(`PR contains changes matching specific routes. Requesting review from: ${teamReviewers.join(', ')}`);
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                team_reviewers: teamReviewers,
-              });
-            } else {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  team_reviewers: teamReviewers,
+                });
+                assigned = true;
+              } catch (err) {
+                console.error(`Failed to assign route-specific team reviewers (${teamReviewers.join(', ')}):`, err.message || err);
+                console.log("Falling back to default team members.");
+              }
+            }
+
+            if (!assigned) {
               console.log("Fetching .github/CODEOWNERS to identify default reviewers...");
               let defaultReviewers = [];
               try {

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -112,19 +112,18 @@ jobs:
                 const content = Buffer.from(codeownersData.content, 'base64').toString('utf-8');
                 const lines = content.split('\n');
                 for (const line of lines) {
-                  const commentIdx = line.indexOf('#');
-                  const cleanLine = (commentIdx !== -1 ? line.substring(0, commentIdx) : line).trim();
-                  if (!cleanLine) continue;
-
-                  const parts = cleanLine.split(/\s+/);
-                  const pattern = parts[0];
-                  if (pattern === '*') {
-                    const owners = parts.slice(1);
-                    defaultReviewers = owners
-                      .filter(p => p.startsWith('@') && !p.includes('/'))
-                      .map(p => p.substring(1))
-                      .filter(login => login !== author);
-                    break;
+                  const trimmed = line.trim();
+                  if (trimmed.startsWith('#')) {
+                    const commentContent = trimmed.substring(1).trim();
+                    if (commentContent.startsWith('team_members:')) {
+                      const listPart = commentContent.substring('team_members:'.length).trim();
+                      const parts = listPart.split(/\s+/);
+                      defaultReviewers = parts
+                        .filter(p => p.startsWith('@'))
+                        .map(p => p.substring(1))
+                        .filter(login => login !== author);
+                      break;
+                    }
                   }
                 }
               } catch (err) {

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -101,19 +101,39 @@ jobs:
                 team_reviewers: teamReviewers,
               });
             } else {
-              // Route to cloud-sdk-nodejs-team members with load balancing
-              console.log("Requesting review from a member of cloud-sdk-nodejs-team using load balancing.");
+              console.log("Fetching .github/CODEOWNERS to identify default reviewers...");
+              let defaultReviewers = [];
               try {
-                const { data: members } = await github.rest.teams.listMembersInOrg({
-                  org: 'googleapis',
-                  team_slug: 'cloud-sdk-nodejs-team',
+                const { data: codeownersData } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: '.github/CODEOWNERS',
                 });
-                
-                const memberLogins = members
-                  .map(m => m.login)
-                  .filter(login => login !== author);
+                const content = Buffer.from(codeownersData.content, 'base64').toString('utf-8');
+                const lines = content.split('\n');
+                for (const line of lines) {
+                  const commentIdx = line.indexOf('#');
+                  const cleanLine = (commentIdx !== -1 ? line.substring(0, commentIdx) : line).trim();
+                  if (!cleanLine) continue;
 
-                if (memberLogins.length > 0) {
+                  const parts = cleanLine.split(/\s+/);
+                  const pattern = parts[0];
+                  if (pattern === '*') {
+                    const owners = parts.slice(1);
+                    defaultReviewers = owners
+                      .filter(p => p.startsWith('@') && !p.includes('/'))
+                      .map(p => p.substring(1))
+                      .filter(login => login !== author);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.error("Failed to read or parse CODEOWNERS:", err);
+              }
+
+              if (defaultReviewers.length > 0) {
+                console.log(`Found default reviewers: ${defaultReviewers.join(', ')}. Load balancing among them.`);
+                try {
                   // Retrieve active open PRs to calculate load
                   const { data: openPRs } = await github.rest.pulls.list({
                     owner: context.repo.owner,
@@ -123,7 +143,7 @@ jobs:
                   });
 
                   const loadMap = {};
-                  for (const member of memberLogins) {
+                  for (const member of defaultReviewers) {
                     loadMap[member] = 0;
                   }
 
@@ -151,7 +171,7 @@ jobs:
                   // Find members with the minimum load
                   let minLoad = Infinity;
                   let selectedReviewers = [];
-                  for (const member of memberLogins) {
+                  for (const member of defaultReviewers) {
                     const load = loadMap[member];
                     if (load < minLoad) {
                       minLoad = load;
@@ -169,25 +189,11 @@ jobs:
                     repo: context.repo.repo,
                     pull_number: context.payload.pull_request.number,
                     reviewers: [leastLoadedReviewer],
-                    team_reviewers: ['cloud-sdk-nodejs-team'],
                   });
-                } else {
-                  console.log("No other members found in cloud-sdk-nodejs-team. Requesting team review only.");
-                  await github.rest.pulls.requestReviewers({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: context.payload.pull_request.number,
-                    team_reviewers: ['cloud-sdk-nodejs-team'],
-                  });
+                } catch (err) {
+                  console.error("Failed to assign reviewers using load balancing:", err);
                 }
-              } catch (err) {
-                console.error("Failed to fetch team members or assign reviewers:", err);
-                // Fallback to just requesting the team review
-                await github.rest.pulls.requestReviewers({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.payload.pull_request.number,
-                  team_reviewers: ['cloud-sdk-nodejs-team'],
-                });
+              } else {
+                console.warn("No default reviewers found in CODEOWNERS (or they only contained teams/author).");
               }
             }


### PR DESCRIPTION
Updates the PR auto-assignment workflow to identify default reviewers using a custom comment-based variable defined in the `CODEOWNERS` file, rather than querying members of the `cloud-sdk-nodejs-team` via the GitHub REST API.

- Custom team_members Variable in CODEOWNERS: Defined a group of default reviewers as a comment inside .github/CODEOWNERS
- Workflow Update: Updated the parsing script in .github/workflows/assign-reviewers.yml to fetch and parse CODEOWNERS. It scans comments for a line starting with team_members:, extracts the individual handles, and load-balances incoming PRs among them (excluding the PR author).
- Removed Team CC Fallback: Removed automatic routing to cloud-sdk-nodejs-team when load-balancing, ensuring that reviews are requested only from individual team members.