### PR TITLE
fix(generator): filter out empty services from api.services

### DIFF
--- a/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
+++ b/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
@@ -207,7 +207,14 @@ export class API {
       .filter(proto => proto.fileToGenerate)
       .reduce((retval, proto) => {
         retval.push(
-          ...Object.keys(proto.services).map(name => proto.services[name]),
+          ...Object.keys(proto.services)
+            .map(name => proto.services[name])
+            .filter(
+              service =>
+                (service.method && service.method.length > 0) ||
+                service.IAMPolicyMixin > 0 ||
+                service.LocationMixin > 0,
+            ),
         );
         return retval;
       }, [] as ServiceDescriptorProto[])

--- a/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
+++ b/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
@@ -212,8 +212,8 @@ export class API {
             .filter(
               service =>
                 (service.method && service.method.length > 0) ||
-                service.IAMPolicyMixin > 0 ||
-                service.LocationMixin > 0,
+                !!service.IAMPolicyMixin ||
+                !!service.LocationMixin,
             ),
         );
         return retval;

--- a/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
+++ b/core/generator/gapic-generator-typescript/typescript/src/schema/api.ts
@@ -213,7 +213,9 @@ export class API {
               service =>
                 (service.method && service.method.length > 0) ||
                 !!service.IAMPolicyMixin ||
-                !!service.LocationMixin,
+                !!service.LocationMixin ||
+                !!service.LongRunningOperationsMixin ||
+                (service.serviceYaml?.apis?.length ?? 0) > 0,
             ),
         );
         return retval;


### PR DESCRIPTION
The TypeScript generator does not generate the corresponding client class files if the proto files have services with zero RPC methods, resulting in compilation failures due to missing client file imports (e.g. `Cannot find module './sql_available_database_versions_service_client'`).

This recently caused build failures in the google-cloud-sql package regeneration ([PR 8626](https://github.com/googleapis/google-cloud-node/pull/8626)), which defines several empty placeholder/internal services like SqlRegionsService and SqlEventsService.

This PR filters out "empty" services from the services collection in the API schema generator class (core/generator/gapic-generator-typescript/typescript/src/schema/api.ts).

A service is considered empty and skipped if it has:
- Zero native RPC methods defined in the proto file.
- No mixins enabled (such as IAMPolicy or Locations) that would inject mixed-in methods.

This prevents the generator from producing client classes and index.ts exports for non-functional empty services.

**Testing**
- Local Regeneration: Regenerated google-cloud-sql client code locally. Confirmed that the empty services (like SqlRegionsService, SqlEventsService, etc.) are no longer generated or exported, resulting in a successful compile.
- Mixin Verification: Verified that google-cloud-dataplex (ContentService), which defines zero native methods but has IAMPolicy and Locations mixins configured, is still correctly generated and exported as expected.
Unit Tests: Ran all 155 unit tests of the generator; all passed successfully with no regressions.