### PR TITLE
chore: add packages/google-cloud-agentregistry in Release Please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -263,5 +263,5 @@
   "packages/google-devicesandservices-health": "0.3.0",
   "packages/google-cloud-databasecenter": "0.3.0",
   "packages/google-maps-mapmanagement": "0.1.0",
-  "packages/google-cloud-agentregistry" : "0.0.0"
+  "packages/google-cloud-agentregistry": "0.0.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -262,5 +262,6 @@
   "packages/google-cloud-appoptimize": "0.2.0",
   "packages/google-devicesandservices-health": "0.3.0",
   "packages/google-cloud-databasecenter": "0.3.0",
-  "packages/google-maps-mapmanagement": "0.1.0"
+  "packages/google-maps-mapmanagement": "0.1.0",
+  "packages/google-cloud-agentregistry" : "0.0.0"
 }

--- a/packages/google-cloud-agentregistry/package.json
+++ b/packages/google-cloud-agentregistry/package.json
@@ -2,7 +2,12 @@
   "name": "@google-cloud/agentregistry",
   "version": "0.1.0",
   "description": "Agentregistry client for Node.js",
-  "repository": "googleapis/nodejs-agentregistry",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-cloud-agentregistry"
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-cloud-agentregistry",
   "license": "Apache-2.0",
   "author": "Google LLC",
   "main": "build/src/index.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -229,6 +229,7 @@
     "packages/google-maps-geocode": {},
     "packages/google-cloud-datacatalog-lineage-configmanagement": {},
     "packages/google-maps-mapmanagement": {},
+    "packages/google-cloud-agentregistry": {},
     "packages/google-cloud-appoptimize": {},
     "packages/google-devicesandservices-health": {},
     "packages/google-cloud-databasecenter": {}


### PR DESCRIPTION
Without this addition, Release Please does not add the agentregistry
package to the upcoming release pull request.

This manual work is temporary. We will ensure the Release Please
config files are updated when we onboard a new library.

After this pull request is merged, we will confirm https://github.com/googleapis/google-cloud-node/pull/8662
is updated with the agentregistry package.