### PR TITLE
chore: agentregistry module to have 0.0.0 before its first release

### DIFF
--- a/packages/google-cloud-agentregistry/package.json
+++ b/packages/google-cloud-agentregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/agentregistry",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Agentregistry client for Node.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Release Please pull request will bump the version to 0.1.0.
The release script runs the diff for the released module for a
release Git commit. The package.json needs to be touched.

The corresponding template update is at
https://github.com/googleapis/google-cloud-node/pull/8694.
