### PR TITLE
chore: refine reviewer auto-assignment triggers and routing

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -2,7 +2,7 @@ name: Auto Assign Reviewers
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, reopened]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -197,10 +197,25 @@ jobs:
                     pull_number: context.payload.pull_request.number,
                     reviewers: [leastLoadedReviewer],
                   });
+                  assigned = true;
                 } catch (err) {
                   console.error("Failed to assign reviewers using load balancing:", err);
                 }
               } else {
                 console.warn("No default reviewers found in CODEOWNERS (or they only contained teams/author).");
+              }
+            }
+
+            if (assigned) {
+              console.log("Removing default cloud-sdk-nodejs-team reviewer...");
+              try {
+                await github.rest.pulls.removeRequestedReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  team_reviewers: ['cloud-sdk-nodejs-team'],
+                });
+              } catch (err) {
+                console.warn("Failed to remove default cloud-sdk-nodejs-team reviewer:", err.message || err);
               }
             }

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -79,8 +79,6 @@ jobs:
               { prefix: 'handwritten/firestore/', team: 'firestore-team' },
               { prefix: 'handwritten/spanner/', team: 'spanner-team' },
               { prefix: 'handwritten/bigquery-storage/', team: 'bigquery-team' },
-              { prefix: 'handwritten/pubsub/', team: 'pubsub-team' },
-              { prefix: 'handwritten/bigtable/', team: 'bigtable-team' },
               { prefix: 'core/packages/google-auth-library-nodejs/', team: 'aion-team' }
             ];
 


### PR DESCRIPTION
This PR improves the auto-assign reviewers workflow by updating its event triggers, path-routing configurations, and reviewer cleanups.

- Added the reopened event trigger to the workflow so reviewer assignments are recalculated when a closed PR is reopened.
- Added logic to automatically remove the catch-all @googleapis/cloud-sdk-nodejs-team (which is requested by default via native GitHub CODEOWNERS rules) once a specific load-balanced reviewer or team reviewer is successfully assigned.
- Removed handwritten/pubsub/ and handwritten/bigtable/ path routings. Since these teams do not have collaborator access in this repository, changes to these paths will now fall back to the default codeowners load balancing.