### PR TITLE
fix: correct repository URLs in core package.json files

### DIFF
--- a/core/dev-packages/jsdoc-fresh/package.json
+++ b/core/dev-packages/jsdoc-fresh/package.json
@@ -14,15 +14,15 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/jsdoc-fresh",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/dev-packages/jsdoc-fresh",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/jsdoc-fresh",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/jsdoc-fresh",
   "devDependencies": {
     "gts": "^5.0.0",
     "typescript": "^5.1.6"

--- a/core/dev-packages/jsdoc-region-tag/package.json
+++ b/core/dev-packages/jsdoc-region-tag/package.json
@@ -18,8 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "directory": "dev-packages/jsdoc-region-tag",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/dev-packages/jsdoc-region-tag",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "keywords": [
     "region",
@@ -30,9 +30,9 @@
   "author": "Google LLC",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/jsdoc-region-tag",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/jsdoc-region-tag",
   "dependencies": {
     "glob": "^7.1.6"
   },

--- a/core/dev-packages/pack-n-play/package.json
+++ b/core/dev-packages/pack-n-play/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "directory": "dev-packages/pack-n-play",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/dev-packages/pack-n-play",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
@@ -60,5 +60,5 @@
       "build/test"
     ]
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/pack-n-play"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/dev-packages/pack-n-play"
 }

--- a/core/generator/gapic-generator-typescript/package.json
+++ b/core/generator/gapic-generator-typescript/package.json
@@ -3,15 +3,15 @@
   "version": "4.12.0",
   "type": "module",
   "description": "Google API Client Library Generator for TypeScript, written in TypeScript.",
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gapic-generator-typescript",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/generator/gapic-generator-typescript",
   "private": true,
   "bugs": {
-    "url": "https://github.com/googleapis/gapic-generator-typescript/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gapic-generator-typescript",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/generator/gapic-generator-typescript",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "license": "Apache-2.0",
   "author": "Google LLC",

--- a/core/packages/gax/package.json
+++ b/core/packages/gax/package.json
@@ -96,15 +96,15 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gax",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/gax",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "author": "Google API Authors",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gax",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gax",
   "engines": {
     "node": ">=18"
   },

--- a/core/packages/gax/samples/package.json
+++ b/core/packages/gax/samples/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/gax-nodejs",
+  "repository": "googleapis/google-cloud-node",
   "private": true,
   "scripts": {
     "test": "c8 mocha system-test"

--- a/core/packages/gaxios/package.json
+++ b/core/packages/gaxios/package.json
@@ -38,8 +38,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/gaxios",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/gaxios",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "keywords": [
     "google"
@@ -101,5 +101,5 @@
     "https-proxy-agent": "^7.0.1",
     "node-fetch": "^3.3.2"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gaxios"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gaxios"
 }

--- a/core/packages/gcp-metadata/package.json
+++ b/core/packages/gcp-metadata/package.json
@@ -4,8 +4,8 @@
   "description": "Get the metadata from a Google Cloud Platform environment",
   "repository": {
     "type": "git",
-    "directory": "packages/gcp-metadata",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/gcp-metadata",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
@@ -70,5 +70,5 @@
   "engines": {
     "node": ">=18"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gcp-metadata"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/gcp-metadata"
 }

--- a/core/packages/gcp-metadata/samples/package.json
+++ b/core/packages/gcp-metadata/samples/package.json
@@ -8,7 +8,7 @@
   "files": [
     "*.js"
   ],
-  "repository": "googleapis/gcp-metadata",
+  "repository": "googleapis/google-cloud-node",
   "private": true,
   "scripts": {
     "test": "mocha"

--- a/core/packages/google-auth-library-nodejs/package.json
+++ b/core/packages/google-auth-library-nodejs/package.json
@@ -10,8 +10,8 @@
   "types": "./build/src/index.d.ts",
   "repository": {
     "type": "git",
-    "directory": "packages/google-auth-library-nodejs",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/google-auth-library-nodejs",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "keywords": [
     "google",
@@ -86,5 +86,5 @@
     "prelint": "cd samples; npm link ../; npm install"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/google-auth-library-nodejs"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/google-auth-library-nodejs"
 }

--- a/core/packages/logging-utils/package.json
+++ b/core/packages/logging-utils/package.json
@@ -24,8 +24,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "directory": "dev-packages/logging-utils",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/logging-utils",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
@@ -38,9 +38,9 @@
     "typescript": "5.8.3"
   },
   "bugs": {
-    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/logging-utils",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/logging-utils",
   "engines": {
     "node": ">=14"
   }

--- a/core/packages/logging-utils/samples/package.json
+++ b/core/packages/logging-utils/samples/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "logging-utils/samples"
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "core/packages/logging-utils/samples"
   },
   "engines": {
     "node": ">=14"

--- a/core/packages/nodejs-googleapis-common/package.json
+++ b/core/packages/nodejs-googleapis-common/package.json
@@ -4,8 +4,8 @@
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "repository": {
     "type": "git",
-    "directory": "packages/nodejs-googleapis-common",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/nodejs-googleapis-common",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -89,5 +89,5 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/nodejs-googleapis-common"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/nodejs-googleapis-common"
 }

--- a/core/packages/nodejs-googleapis-common/samples/package.json
+++ b/core/packages/nodejs-googleapis-common/samples/package.json
@@ -9,7 +9,7 @@
     "*.js",
     "!test/"
   ],
-  "repository": "googleapis/nodejs-googleapis-common",
+  "repository": "googleapis/google-cloud-node",
   "private": true,
   "scripts": {
     "test": "echo \"There are no sample tests 👻\""

--- a/core/packages/nodejs-proto-files/package.json
+++ b/core/packages/nodejs-proto-files/package.json
@@ -9,8 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/nodejs-proto-files",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/nodejs-proto-files",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
@@ -63,5 +63,5 @@
     "sinon": "21.0.3",
     "typescript": "5.8.3"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/nodejs-proto-files"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/nodejs-proto-files"
 }

--- a/core/packages/nodejs-proto-files/samples/package.json
+++ b/core/packages/nodejs-proto-files/samples/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/nodejs-proto-files",
+  "repository": "googleapis/google-cloud-node",
   "private": true,
   "scripts": {
     "test": "mocha"

--- a/core/packages/proto3-json-serializer-nodejs/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/package.json
@@ -3,8 +3,8 @@
   "version": "3.0.5",
   "repository": {
     "type": "git",
-    "directory": "packages/proto3-json-serializer-nodejs",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/proto3-json-serializer-nodejs",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "description": "Support for proto3 JSON serialiazation/deserialization for protobuf.js",
   "main": "build/src/index.js",

--- a/core/packages/proto3-json-serializer-nodejs/samples/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/samples/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18"
   },
-  "repository": "googleapis/proto3-json-serializer-nodejs",
+  "repository": "googleapis/google-cloud-node",
   "private": true,
   "scripts": {
     "test": "c8 mocha system-test"

--- a/core/packages/retry-request/package.json
+++ b/core/packages/retry-request/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "directory": "packages/retry-request",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/retry-request",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "scripts": {
     "docs": "jsdoc -c .jsdoc.js",
@@ -47,5 +47,5 @@
     "mocha": "^11.1.0",
     "typescript": "5.8.3"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/retry-request"
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/retry-request"
 }

--- a/core/packages/teeny-request/package.json
+++ b/core/packages/teeny-request/package.json
@@ -25,8 +25,8 @@
   ],
   "repository": {
     "type": "git",
-    "directory": "packages/teeny-request",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/teeny-request",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "keywords": [
     "request",
@@ -36,9 +36,9 @@
   "author": "fhinkel",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googleapis/teeny-request/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/teeny-request",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/teeny-request",
   "dependencies": {
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.1",

--- a/core/packages/tools/package.json
+++ b/core/packages/tools/package.json
@@ -40,8 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "directory": "packages/tools",
-    "url": "https://github.com/googleapis/google-cloud-node-core.git"
+    "directory": "core/packages/tools",
+    "url": "https://github.com/googleapis/google-cloud-node.git"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",
@@ -59,9 +59,9 @@
     "typescript": "5.8.3"
   },
   "bugs": {
-    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+    "url": "https://github.com/googleapis/google-cloud-node/issues"
   },
-  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/tools",
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/tools",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
Many repository URLs in the core directory are outdated. This can break release please when it tries to grab the latest tag for each package.

This PR updates the repository URLs, directories, and any links to older repos.