### PR TITLE
fix(spanner): kokoro pipeline for system test

### DIFF
--- a/handwritten/spanner/.kokoro/trampoline_v2.sh
+++ b/handwritten/spanner/.kokoro/trampoline_v2.sh
@@ -261,15 +261,22 @@ cd "${PROJECT_ROOT}"
 # Check if the package directory has changes. If not, skip tests.
 if [[ "${RUNNING_IN_CI:-}" == "true" ]]; then
     # The package path is hardcoded during migration
-    RELATIVE_PKG_PATH="handwritten/spanner"
+    RELATIVE_PKG_PATH="."
     
     echo "Checking for changes in ${RELATIVE_PKG_PATH}..."
     
     # Determine the diff range based on the CI system/event
-    # Safe default: HEAD~1..HEAD
     DIFF_RANGE="HEAD~1..HEAD"
-
-    git fetch --deepen=10 2>/dev/null || true
+    
+    # If we are in a Kokoro Pull Request, diff against the main branch
+    if [[ -n "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+        git fetch origin main --deepen=300 2>/dev/null || true
+        if git merge-base origin/main HEAD >/dev/null 2>&1; then
+            DIFF_RANGE="origin/main..."
+        fi
+    else
+        git fetch --deepen=10 2>/dev/null || true
+    fi
     if git diff --quiet "${DIFF_RANGE}" -- "${RELATIVE_PKG_PATH}"; then
         echo "No changes detected in ${RELATIVE_PKG_PATH}. Skipping tests."
         exit 0


### PR DESCRIPTION
Previously, the `.kokoro/trampoline_v2.sh` script used a hardcoded diff range of `HEAD~1..HEAD` to determine if a commit modified the handwritten/spanner directory. This flawed logic only looked at the very last commit in a branch. If a PR had multiple commits, and the final commit did not touch Spanner (e.g., fixing a typo or modifying a global config), Kokoro would falsely conclude there were "no changes" to Spanner and skip the system tests entirely.

What this PR does: This PR updates the Kokoro auto-injected conditional check to intelligently handle Pull Requests:

Dynamic Diff Range: It checks if it's running in a PR context via `KOKORO_GITHUB_PULL_REQUEST_NUMBER`. If so, it uses origin/main... to compare against the common ancestor, effectively evaluating all commits in the PR at once.
Graceful Fallback: Because Kokoro uses shallow clones, there is an edge case where an old branch might not have a common ancestor within the fetch depth, which causes origin/main... to throw a fatal Git error. To prevent this, we added a git merge-base check. If it can't find an ancestor, it silently swallows the error and falls back to the default `HEAD~1..HEAD` behavior, keeping the pipeline stable.
Continuous Builds Unaffected: For post-merge continuous/nightly builds, it correctly retains the `HEAD~1..HEAD` default behavior.