### PR TITLE
chore: bump librarian version to v0.22.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: nodejs
-version: v0.21.0
+version: v0.22.0
 repo: googleapis/google-cloud-node
 sources:
   googleapis:


### PR DESCRIPTION
Closes (librarian/6537)[https://github.com/googleapis/librarian/issues/6537]