### PR TITLE
deps(pubsub): bump @opentelemetry/core to ^2.0.0

### DIFF
--- a/handwritten/pubsub/package.json
+++ b/handwritten/pubsub/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.8.0",
-    "@opentelemetry/sdk-trace-base": "^1.17.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@types/duplexify": "^3.6.4",
     "@types/extend": "^3.0.4",
     "@types/lodash.snakecase": "^4.1.9",

--- a/handwritten/pubsub/package.json
+++ b/handwritten/pubsub/package.json
@@ -55,7 +55,7 @@
     "@google-cloud/projectify": "^5.0.0",
     "@google-cloud/promisify": "^5.0.0",
     "@opentelemetry/api": "~1.9.0",
-    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/semantic-conventions": "~1.39.0",
     "arrify": "^2.0.0",
     "extend": "^3.0.2",

--- a/handwritten/pubsub/test/subscriber.ts
+++ b/handwritten/pubsub/test/subscriber.ts
@@ -1200,7 +1200,10 @@ describe('Subscriber', () => {
       assert.strictEqual(spans[0].events.length, 2);
       const firstSpan = spans.pop();
       assert.ok(firstSpan);
-      assert.strictEqual(firstSpan.parentSpanId, parentSpanContext.spanId);
+      assert.strictEqual(
+        firstSpan.parentSpanContext?.spanId,
+        parentSpanContext.spanId,
+      );
       assert.strictEqual(
         firstSpan.name,
         `${subId} subscribe`,

--- a/handwritten/pubsub/test/telemetry-tracing.ts
+++ b/handwritten/pubsub/test/telemetry-tracing.ts
@@ -361,7 +361,7 @@ describe('OpenTelemetryTracer', () => {
         'receive',
       );
       assert.strictEqual(childReadSpan.kind, SpanKind.CONSUMER);
-      assert.ok(childReadSpan.parentSpanId);
+      assert.ok(childReadSpan.parentSpanContext?.spanId);
     });
 
     it('creates publish RPC spans', () => {
@@ -373,14 +373,19 @@ describe('OpenTelemetryTracer', () => {
         'test',
       ) as trace.Span;
       message.parentSpan = span;
-      span.end();
 
+      // The publish RPC span adds a back-link onto the parent span, so it must
+      // be created while the parent is still open. This mirrors the real
+      // publish flow (Queue._publish), where parent spans are ended only after
+      // the RPC span is created. In @opentelemetry/sdk-trace-base v2,
+      // `addLink()` on an already-ended span is a no-op.
       const publishSpan = otel.PubsubSpans.createPublishRpcSpan(
         [message],
         topicName,
         'test',
       );
 
+      span.end();
       publishSpan?.end();
       const spans = exporter.getFinishedSpans();
       const publishReadSpan = spans.pop();

--- a/handwritten/pubsub/test/tracing.ts
+++ b/handwritten/pubsub/test/tracing.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {trace} from '@opentelemetry/api';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -36,6 +37,9 @@ import {
  * its defined beforehand.
  */
 export const exporter: InMemorySpanExporter = new InMemorySpanExporter();
-export const provider: BasicTracerProvider = new BasicTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-provider.register();
+export const provider: BasicTracerProvider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+// `BasicTracerProvider.register()` was removed in @opentelemetry/sdk-trace-base
+// v2; register the provider as the global one via the API instead.
+trace.setGlobalTracerProvider(provider);


### PR DESCRIPTION
## Motivation

`@google-cloud/pubsub` depends on `@opentelemetry/core@^1.30.1`, which is affected by [GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf) (moderate) — *Unbounded memory allocation in W3C Baggage propagation*. The 2.x line is not affected.

This surfaces as a Dependabot / `npm audit` advisory for downstream consumers.

## Change

- Bump `@opentelemetry/core` from `^1.30.1` to `^2.0.0` (dependency) — the actual security fix.
- Bump `@opentelemetry/sdk-trace-base` from `^1.17.0` to `^2.0.0` (**devDependency**) so the test tree no longer pulls `@opentelemetry/core@1.x` in alongside the `core@2.x` bump (addresses the duplicate-`core` concern raised in review). This does not affect consumers.
- Adapt the tests for the `sdk-trace-base` v2 breaking changes (see below).

## Compatibility

**Production source is unchanged.** The only symbol pubsub imports from `@opentelemetry/core` is `W3CTraceContextPropagator` (`src/telemetry-tracing.ts`); its public API is unchanged between v1 and v2.

`@opentelemetry/core@2.x` declares the peer dependency `@opentelemetry/api: ">=1.0.0 <1.10.0"`, satisfied by pubsub's existing `@opentelemetry/api@~1.9.0`. `@opentelemetry/api` and `@opentelemetry/semantic-conventions` are versioned independently of the SDK and are intentionally kept on 1.x — the context registry / propagation machinery lives in `@opentelemetry/api`, of which there is a single instance, so there is no duplicate-instance or `instanceof` hazard for consumers.

### Test adaptations for `@opentelemetry/sdk-trace-base@2`

- `BasicTracerProvider` now takes span processors via its constructor and no longer exposes `register()` — use `trace.setGlobalTracerProvider()` (`test/tracing.ts`).
- `ReadableSpan.parentSpanId` was replaced by `parentSpanContext` (`test/subscriber.ts`, `test/telemetry-tracing.ts`).
- `addLink()` on an already-ended span is now a no-op. One test ended the parent span before the publish RPC span (which adds a back-link onto it) was created; reordered to create the RPC span while the parent is still open, matching the real publish flow in `Queue._publish` (`test/telemetry-tracing.ts`).
