### PR TITLE
fix(gaxios): prevent comma corruption when draining stream error responses

### DIFF
--- a/core/packages/gaxios/src/gaxios.ts
+++ b/core/packages/gaxios/src/gaxios.ts
@@ -202,7 +202,13 @@ export class Gaxios implements FetchCompliance {
             response.push(chunk);
           }
 
-          translatedResponse.data = response.toString() as T;
+          if (response.every(chunk => typeof chunk === 'string')) {
+            translatedResponse.data = response.join('') as T;
+          } else {
+            translatedResponse.data = Buffer.concat(
+              response.map(c => (typeof c === 'string' ? Buffer.from(c) : c)),
+            ).toString('utf8') as T;
+          }
         }
 
         const errorInfo = GaxiosError.extractAPIErrorFromResponse(

--- a/core/packages/gaxios/test/test.getch.ts
+++ b/core/packages/gaxios/test/test.getch.ts
@@ -143,6 +143,29 @@ describe('🚙 error handling', () => {
     );
   });
 
+  it('should handle stream error responses split across multiple chunks without corrupting them with commas', async () => {
+    const chunks = [
+      '{"error": {"code": 400, ',
+      '"message": "Invalid ',
+      'argument", "status": "INVALID_ARGUMENT"}}',
+    ];
+    const readableStream = Readable.from(chunks);
+    const scope = nock(url).get('/').reply(400, readableStream);
+
+    await assert.rejects(
+      request({url, responseType: 'stream'}),
+      (err: GaxiosError) => {
+        scope.done();
+        const apiError = JSON.parse(err.message);
+        return (
+          apiError.error.code === 400 &&
+          apiError.error.message === 'Invalid argument' &&
+          apiError.error.status === 'INVALID_ARGUMENT'
+        );
+      },
+    );
+  });
+
   it('should not throw an error during a translation error', () => {
     const notJSON = '.';
     const response = {
@@ -1302,6 +1325,14 @@ describe('🍂 defaults & instances', () => {
   });
 
   describe('mtls', () => {
+    beforeEach(() => {
+      setEnv({
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      });
+    });
     class GaxiosAssertAgentCache extends Gaxios {
       getAgentCache() {
         return this.agentCache;


### PR DESCRIPTION
With this fix, we are hoping to address https://github.com/google-gemini/gemini-cli/pull/21884 and https://github.com/googleapis/google-cloud-node/issues/8768.

Credit to @jerrylin3321 for originally creating this branch. We are creating a PR to add a few additional changes on top of it.