### PR TITLE
fix(auth): honor CLOUDSDK_CONFIG when locating the ADC well-known file

### DIFF
--- a/core/packages/google-auth-library-nodejs/src/auth/googleauth.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/googleauth.ts
@@ -592,31 +592,35 @@ export class GoogleAuth<T extends AuthClient = AuthClient> {
   async _tryGetApplicationCredentialsFromWellKnownFile(
     options?: AuthClientOptions,
   ): Promise<JSONClient | null> {
-    // First, figure out the location of the file, depending upon the OS type.
-    let location = null;
-    if (this._isWindows()) {
-      // Windows
-      location = process.env['APPDATA'];
-    } else {
-      // Linux or Mac
-      const home = process.env['HOME'];
-      if (home) {
-        location = path.join(home, '.config');
+    // First, figure out the location of the Cloud SDK config directory. The
+    // `CLOUDSDK_CONFIG` environment variable overrides the platform-specific
+    // default location; when it is set, `gcloud` stores the application default
+    // credentials file there, so it takes precedence.
+    let configDir: string | undefined = process.env['CLOUDSDK_CONFIG'];
+    if (!configDir) {
+      if (this._isWindows()) {
+        // Windows
+        if (process.env['APPDATA']) {
+          configDir = path.join(process.env['APPDATA'], 'gcloud');
+        }
+      } else {
+        // Linux or Mac
+        const home = process.env['HOME'];
+        if (home) {
+          configDir = path.join(home, '.config', 'gcloud');
+        }
       }
     }
-    // If we found the root path, expand it.
-    if (location) {
-      location = path.join(
-        location,
-        'gcloud',
-        'application_default_credentials.json',
-      );
-      if (!fs.existsSync(location)) {
-        location = null;
-      }
+    // The config directory could not be determined.
+    if (!configDir) {
+      return null;
     }
+    const location = path.join(
+      configDir,
+      'application_default_credentials.json',
+    );
     // The file does not exist.
-    if (!location) {
+    if (!fs.existsSync(location)) {
       return null;
     }
     // The file seems to exist. Try to use it.

--- a/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
@@ -894,6 +894,34 @@ describe('googleauth', () => {
       );
     });
 
+    it('_tryGetApplicationCredentialsFromWellKnownFile should honor CLOUDSDK_CONFIG over the default location', async () => {
+      // `gcloud` writes the ADC file under $CLOUDSDK_CONFIG when it is set, so
+      // it must take precedence over the platform default ($HOME/.config/gcloud
+      // here). The default Linux well-known file is left absent on purpose.
+      const cloudSdkConfigDir = path.join('/', 'fake', 'cloudsdk', 'config');
+      const cloudSdkAdcPath = path.join(
+        cloudSdkConfigDir,
+        'application_default_credentials.json',
+      );
+      mockEnvVar('CLOUDSDK_CONFIG', cloudSdkConfigDir);
+      (fs.existsSync as sinon.SinonStub)
+        .withArgs(cloudSdkAdcPath)
+        .returns(true);
+      (fs.createReadStream as sinon.SinonStub)
+        .withArgs(cloudSdkAdcPath)
+        .callsFake(() => fs.createReadStream('./test/fixtures/private2.json'));
+      (fs.realpathSync as unknown as sinon.SinonStub)
+        .withArgs(cloudSdkAdcPath)
+        .returnsArg(0);
+      (fs.lstatSync as sinon.SinonStub)
+        .withArgs(cloudSdkAdcPath)
+        .returns({isFile: () => true} as fs.Stats);
+
+      const client =
+        (await auth._tryGetApplicationCredentialsFromWellKnownFile()) as JWT;
+      assert.strictEqual(client.email, private2JSON.client_email);
+    });
+
     it('getProjectId should return a new projectId the first time and a cached projectId the second time', async () => {
       mockEnvVar('GCLOUD_PROJECT', STUB_PROJECT);
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-node/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #8797 🦕

## What

`GoogleAuth._tryGetApplicationCredentialsFromWellKnownFile()` (in
`core/packages/google-auth-library-nodejs`) now honors the `CLOUDSDK_CONFIG`
environment variable when locating the Application Default Credentials
well-known file, falling back to the existing platform-specific default
(`$HOME/.config/gcloud` / `%APPDATA%\gcloud`) when it is not set.

## Why

`gcloud` stores all of its configuration — including
`application_default_credentials.json` written by
`gcloud auth application-default login` — under `$CLOUDSDK_CONFIG` when that
variable is set. The ADC lookup previously hard-coded the platform default and
ignored `CLOUDSDK_CONFIG`, so ADC could not find user credentials in common
setups (containers, CI, custom or side-by-side gcloud configurations) and fell
through to GCE detection or threw `Could not load the default credentials`.

This aligns the Node.js library with:
- the Cloud SDK / ADC behavior and the other language auth libraries (Python,
  Go, Java), which all honor `CLOUDSDK_CONFIG` for the ADC well-known file; and
- this library's own `getWellKnownCertificateConfigFileLocation()` in
  `src/util.ts`, which already resolves the config directory as
  `process.env.CLOUDSDK_CONFIG || <platform default>`.

## How

The method now resolves the gcloud config directory first (`CLOUDSDK_CONFIG`
taking precedence over the platform default), then joins
`application_default_credentials.json`. The output for the default,
non-`CLOUDSDK_CONFIG` case is unchanged, so existing behavior and tests are
preserved.

## Affected versions

Environment: any OS, any supported Node.js version.

Present in `google-auth-library` 10.9.0 and all prior releases.
`_tryGetApplicationCredentialsFromWellKnownFile()` has resolved the well-known
file from the hard-coded platform default (`%APPDATA%` / `$HOME/.config`) since
the method was first introduced (initial commit, Feb 2015), so `CLOUDSDK_CONFIG`
has never been honored in this path. The omission became an internal
inconsistency once `getWellKnownCertificateConfigFileLocation()` in `util.ts`
started resolving `CLOUDSDK_CONFIG` first, which this PR brings into line.

## Testing

- Added a unit test asserting the well-known file is read from
  `$CLOUDSDK_CONFIG` (taking precedence over the platform default) in
  `test/test.googleauth.ts`.
- `npm run compile` passes.
- `npx mocha build/test/test.googleauth.js` — all 188 tests pass, including the
  new one.
