### PR TITLE
fix(auth): add GOOGLE_APPLICATION_CREDENTIALS context to credential load errors

### DIFF
--- a/core/packages/google-auth-library-nodejs/src/auth/googleauth.ts
+++ b/core/packages/google-auth-library-nodejs/src/auth/googleauth.ts
@@ -571,7 +571,7 @@ export class GoogleAuth<T extends AuthClient = AuthClient> {
       return null;
     }
     try {
-      return this._getApplicationCredentialsFromFilePath(
+      return await this._getApplicationCredentialsFromFilePath(
         credentialsPath,
         options,
       );

--- a/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
+++ b/core/packages/google-auth-library-nodejs/test/test.googleauth.ts
@@ -782,12 +782,10 @@ describe('googleauth', () => {
     it('tryGetApplicationCredentialsFromEnvironmentVariable should handle invalid environment variable', async () => {
       // Set up a mock to return a path to an invalid file.
       mockEnvVar('GOOGLE_APPLICATION_CREDENTIALS', './nonexistantfile.json');
-      try {
-        await auth._tryGetApplicationCredentialsFromEnvironmentVariable();
-      } catch (e) {
-        return;
-      }
-      assert.fail('failed to throw');
+      await assert.rejects(
+        auth._tryGetApplicationCredentialsFromEnvironmentVariable(),
+        /Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable/,
+      );
     });
 
     it('tryGetApplicationCredentialsFromEnvironmentVariable should handle valid environment variable', async () => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-node/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #8799 🦕

`GoogleAuth._tryGetApplicationCredentialsFromEnvironmentVariable()` returns the
promise from the `async` `_getApplicationCredentialsFromFilePath()` without
`await`, so the surrounding `try`/`catch` — whose only purpose is to prefix
load errors with
`Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable: ...`
— is unreachable, and users get the bare underlying error (raw `ENOENT`,
`SyntaxError`, etc.) with no hint that the file was selected via
`GOOGLE_APPLICATION_CREDENTIALS`.

This PR adds the missing `await` so rejections are caught and prefixed as
intended, and tightens the existing unit test
(`tryGetApplicationCredentialsFromEnvironmentVariable should handle invalid environment variable`)
to assert the documented prefix instead of only asserting that something
throws.

Reproduction: https://github.com/heychs/repro-google-cloud-node-8799

All 935 unit tests pass (`npm test` in
`core/packages/google-auth-library-nodejs`). Remaining lint findings on the
package are pre-existing on `main` and untouched by this change.
