### PR TITLE
chore: regenerate google-cloud-aiplatform

### DIFF
--- a/packages/google-cloud-aiplatform/protos/google/cloud/aiplatform/v1beta1/endpoint.proto
+++ b/packages/google-cloud-aiplatform/protos/google/cloud/aiplatform/v1beta1/endpoint.proto
@@ -400,8 +400,24 @@ message PredictRequestResponseLoggingConfig {
 
 // This message contains configs of a publisher model.
 message PublisherModelConfig {
+  // A model provider (publisher) that prediction data may be shared with.
+  enum ModelProvider {
+    // Unspecified model provider.
+    MODEL_PROVIDER_UNSPECIFIED = 0;
+
+    // Anthropic.
+    ANTHROPIC = 1;
+  }
+
   // The prediction request/response logging config.
   PredictRequestResponseLoggingConfig logging_config = 3;
+
+  // Optional. The model provider (publisher) for which the customer has enabled
+  // data sharing. For publisher models that are configured to require data
+  // sharing, a prediction request is only allowed when the model's publisher
+  // matches this provider. Otherwise, the request is rejected.
+  ModelProvider data_sharing_enabled_provider = 4
+      [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Configurations (e.g. inference timeout) that are applied on your endpoints.

--- a/packages/google-cloud-aiplatform/protos/protos.d.ts
+++ b/packages/google-cloud-aiplatform/protos/protos.d.ts
@@ -190604,6 +190604,9 @@ export namespace google {
 
                     /** PublisherModelConfig loggingConfig */
                     loggingConfig?: (google.cloud.aiplatform.v1beta1.IPredictRequestResponseLoggingConfig|null);
+
+                    /** PublisherModelConfig dataSharingEnabledProvider */
+                    dataSharingEnabledProvider?: (google.cloud.aiplatform.v1beta1.PublisherModelConfig.ModelProvider|keyof typeof google.cloud.aiplatform.v1beta1.PublisherModelConfig.ModelProvider|null);
                 }
 
                 /** Represents a PublisherModelConfig. */
@@ -190617,6 +190620,9 @@ export namespace google {
 
                     /** PublisherModelConfig loggingConfig. */
                     public loggingConfig?: (google.cloud.aiplatform.v1beta1.IPredictRequestResponseLoggingConfig|null);
+
+                    /** PublisherModelConfig dataSharingEnabledProvider. */
+                    public dataSharingEnabledProvider: (google.cloud.aiplatform.v1beta1.PublisherModelConfig.ModelProvider|keyof typeof google.cloud.aiplatform.v1beta1.PublisherModelConfig.ModelProvider);
 
                     /**
                      * Creates a new PublisherModelConfig instance using the specified properties.
@@ -190694,6 +190700,15 @@ export namespace google {
                      * @returns The default type url
                      */
                     public static getTypeUrl(typeUrlPrefix?: string): string;
+                }
+
+                namespace PublisherModelConfig {
+
+                    /** ModelProvider enum. */
+                    enum ModelProvider {
+                        MODEL_PROVIDER_UNSPECIFIED = 0,
+                        ANTHROPIC = 1
+                    }
                 }
 
                 /** Properties of a ClientConnectionConfig. */

--- a/packages/google-cloud-aiplatform/protos/protos.json
+++ b/packages/google-cloud-aiplatform/protos/protos.json
@@ -51841,6 +51841,21 @@
                         "loggingConfig": {
                           "type": "PredictRequestResponseLoggingConfig",
                           "id": 3
+                        },
+                        "dataSharingEnabledProvider": {
+                          "type": "ModelProvider",
+                          "id": 4,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
+                        }
+                      },
+                      "nested": {
+                        "ModelProvider": {
+                          "values": {
+                            "MODEL_PROVIDER_UNSPECIFIED": 0,
+                            "ANTHROPIC": 1
+                          }
                         }
                       }
                     },

--- a/packages/google-cloud-aiplatform/test/gapic_dataset_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_dataset_service_v1.ts
@@ -2733,9 +2733,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2784,9 +2784,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2827,9 +2827,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2867,9 +2867,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3056,9 +3056,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3106,9 +3106,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3155,9 +3155,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3196,9 +3196,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3365,9 +3365,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3414,9 +3414,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3457,9 +3457,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3497,9 +3497,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3684,9 +3684,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3733,9 +3733,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3782,9 +3782,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3822,9 +3822,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4009,9 +4009,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4058,9 +4058,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4107,9 +4107,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4147,9 +4147,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4334,9 +4334,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4383,9 +4383,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4432,9 +4432,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4472,9 +4472,9 @@ describe('v1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_dataset_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_dataset_service_v1beta1.ts
@@ -3132,9 +3132,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3183,9 +3183,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3232,9 +3232,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3272,9 +3272,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasets.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3354,8 +3354,7 @@ describe('v1beta1.DatasetServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IDatasetVersion[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IDatasetVersion[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3463,9 +3462,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3513,9 +3512,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3563,9 +3562,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3604,9 +3603,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDatasetVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3791,9 +3790,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3840,9 +3839,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3889,9 +3888,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3930,9 +3929,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4011,8 +4010,7 @@ describe('v1beta1.DatasetServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IDataItemView[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IDataItemView[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4120,9 +4118,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4170,9 +4168,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4220,9 +4218,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4261,9 +4259,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.searchDataItems.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4342,8 +4340,7 @@ describe('v1beta1.DatasetServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ISavedQuery[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ISavedQuery[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4451,9 +4448,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4501,9 +4498,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4551,9 +4548,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4592,9 +4589,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listSavedQueries.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4673,8 +4670,7 @@ describe('v1beta1.DatasetServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IAnnotation[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IAnnotation[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4782,9 +4778,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4832,9 +4828,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4882,9 +4878,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4923,9 +4919,9 @@ describe('v1beta1.DatasetServiceClient', () => {
       assert(
         (client.descriptors.page.listAnnotations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_deployment_resource_pool_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_deployment_resource_pool_service_v1.ts
@@ -1765,9 +1765,9 @@ describe('v1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1817,9 +1817,9 @@ describe('v1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1869,9 +1869,9 @@ describe('v1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1913,9 +1913,9 @@ describe('v1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_deployment_resource_pool_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_deployment_resource_pool_service_v1beta1.ts
@@ -1653,8 +1653,7 @@ describe('v1beta1.DeploymentResourcePoolServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IDeployedModel[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IDeployedModel[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1768,9 +1767,9 @@ describe('v1beta1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1821,9 +1820,9 @@ describe('v1beta1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1874,9 +1873,9 @@ describe('v1beta1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1918,9 +1917,9 @@ describe('v1beta1.DeploymentResourcePoolServiceClient', () => {
       assert(
         (client.descriptors.page.queryDeployedModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_endpoint_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_endpoint_service_v1.ts
@@ -1953,9 +1953,9 @@ describe('v1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2002,9 +2002,9 @@ describe('v1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2045,9 +2045,9 @@ describe('v1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2085,9 +2085,9 @@ describe('v1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_endpoint_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_endpoint_service_v1beta1.ts
@@ -2310,9 +2310,9 @@ describe('v1beta1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2359,9 +2359,9 @@ describe('v1beta1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2408,9 +2408,9 @@ describe('v1beta1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2449,9 +2449,9 @@ describe('v1beta1.EndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_example_store_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_example_store_service_v1beta1.ts
@@ -1595,8 +1595,7 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IExampleStore[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IExampleStore[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1706,9 +1705,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.listExampleStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1757,9 +1756,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.listExampleStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1808,9 +1807,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.listExampleStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1850,9 +1849,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.listExampleStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -2041,9 +2040,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.fetchExamples.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2091,9 +2090,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.fetchExamples.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2141,9 +2140,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.fetchExamples.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2182,9 +2181,9 @@ describe('v1beta1.ExampleStoreServiceClient', () => {
       assert(
         (client.descriptors.page.fetchExamples.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_extension_registry_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_extension_registry_service_v1beta1.ts
@@ -1292,9 +1292,9 @@ describe('v1beta1.ExtensionRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listExtensions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1345,9 +1345,9 @@ describe('v1beta1.ExtensionRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listExtensions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1397,9 +1397,9 @@ describe('v1beta1.ExtensionRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listExtensions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1441,9 +1441,9 @@ describe('v1beta1.ExtensionRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listExtensions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_feature_online_store_admin_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_feature_online_store_admin_service_v1.ts
@@ -2340,8 +2340,7 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IFeatureOnlineStore[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IFeatureOnlineStore[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -2827,9 +2826,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2879,9 +2878,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2931,9 +2930,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2974,9 +2973,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3062,8 +3061,7 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IFeatureViewSync[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IFeatureViewSync[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3177,9 +3175,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3230,9 +3228,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3283,9 +3281,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3327,9 +3325,9 @@ describe('v1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_feature_online_store_admin_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_feature_online_store_admin_service_v1beta1.ts
@@ -2719,8 +2719,7 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IFeatureView[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IFeatureView[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -2834,9 +2833,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2887,9 +2886,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2940,9 +2939,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2984,9 +2983,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViews.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3072,8 +3071,7 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IFeatureViewSync[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IFeatureViewSync[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3189,9 +3187,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3244,9 +3242,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3297,9 +3295,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3341,9 +3339,9 @@ describe('v1beta1.FeatureOnlineStoreAdminServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureViewSyncs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_feature_registry_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_feature_registry_service_v1.ts
@@ -2235,9 +2235,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2285,9 +2285,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2335,9 +2335,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2376,9 +2376,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -2549,9 +2549,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2601,9 +2601,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2645,9 +2645,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2686,9 +2686,9 @@ describe('v1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_feature_registry_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_feature_registry_service_v1beta1.ts
@@ -3147,8 +3147,7 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IFeatureGroup[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IFeatureGroup[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3258,9 +3257,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3309,9 +3308,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3360,9 +3359,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3402,9 +3401,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureGroups.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3593,9 +3592,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3645,9 +3644,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3695,9 +3694,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3736,9 +3735,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3820,8 +3819,7 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IFeatureMonitor[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IFeatureMonitor[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3931,9 +3929,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureMonitors.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3982,9 +3980,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureMonitors.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4033,9 +4031,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureMonitors.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4075,9 +4073,9 @@ describe('v1beta1.FeatureRegistryServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatureMonitors.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_featurestore_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_featurestore_service_v1.ts
@@ -3747,9 +3747,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3798,9 +3798,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3849,9 +3849,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3891,9 +3891,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4086,9 +4086,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4137,9 +4137,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4188,9 +4188,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4230,9 +4230,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4407,9 +4407,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4460,9 +4460,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4505,9 +4505,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4547,9 +4547,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4724,9 +4724,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4775,9 +4775,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4820,9 +4820,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4862,9 +4862,9 @@ describe('v1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_featurestore_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_featurestore_service_v1beta1.ts
@@ -3542,8 +3542,7 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IFeaturestore[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IFeaturestore[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3653,9 +3652,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3704,9 +3703,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3755,9 +3754,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3797,9 +3796,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeaturestores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3880,8 +3879,7 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IEntityType[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IEntityType[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3991,9 +3989,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4042,9 +4040,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4093,9 +4091,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4135,9 +4133,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listEntityTypes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4326,9 +4324,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4378,9 +4376,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4428,9 +4426,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4469,9 +4467,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.listFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4660,9 +4658,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4710,9 +4708,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4760,9 +4758,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4801,9 +4799,9 @@ describe('v1beta1.FeaturestoreServiceClient', () => {
       assert(
         (client.descriptors.page.searchFeatures.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_gen_ai_cache_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_gen_ai_cache_service_v1.ts
@@ -1034,9 +1034,9 @@ describe('v1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1083,9 +1083,9 @@ describe('v1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1132,9 +1132,9 @@ describe('v1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1173,9 +1173,9 @@ describe('v1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_gen_ai_cache_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_gen_ai_cache_service_v1beta1.ts
@@ -958,8 +958,7 @@ describe('v1beta1.GenAiCacheServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ICachedContent[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ICachedContent[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1069,9 +1068,9 @@ describe('v1beta1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1120,9 +1119,9 @@ describe('v1beta1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1171,9 +1170,9 @@ describe('v1beta1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1213,9 +1212,9 @@ describe('v1beta1.GenAiCacheServiceClient', () => {
       assert(
         (client.descriptors.page.listCachedContents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_gen_ai_tuning_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_gen_ai_tuning_service_v1.ts
@@ -1127,9 +1127,9 @@ describe('v1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1176,9 +1176,9 @@ describe('v1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1225,9 +1225,9 @@ describe('v1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1265,9 +1265,9 @@ describe('v1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_gen_ai_tuning_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_gen_ai_tuning_service_v1beta1.ts
@@ -1162,9 +1162,9 @@ describe('v1beta1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1213,9 +1213,9 @@ describe('v1beta1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1263,9 +1263,9 @@ describe('v1beta1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1305,9 +1305,9 @@ describe('v1beta1.GenAiTuningServiceClient', () => {
       assert(
         (client.descriptors.page.listTuningJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_index_endpoint_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_index_endpoint_service_v1.ts
@@ -1827,9 +1827,9 @@ describe('v1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1877,9 +1877,9 @@ describe('v1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1927,9 +1927,9 @@ describe('v1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1969,9 +1969,9 @@ describe('v1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_index_endpoint_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_index_endpoint_service_v1beta1.ts
@@ -1721,8 +1721,7 @@ describe('v1beta1.IndexEndpointServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IIndexEndpoint[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IIndexEndpoint[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1832,9 +1831,9 @@ describe('v1beta1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1883,9 +1882,9 @@ describe('v1beta1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1934,9 +1933,9 @@ describe('v1beta1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1976,9 +1975,9 @@ describe('v1beta1.IndexEndpointServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexEndpoints.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_index_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_index_service_v1.ts
@@ -1484,9 +1484,9 @@ describe('v1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1535,9 +1535,9 @@ describe('v1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1578,9 +1578,9 @@ describe('v1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1620,9 +1620,9 @@ describe('v1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_index_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_index_service_v1beta1.ts
@@ -1692,9 +1692,9 @@ describe('v1beta1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1743,9 +1743,9 @@ describe('v1beta1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1792,9 +1792,9 @@ describe('v1beta1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1834,9 +1834,9 @@ describe('v1beta1.IndexServiceClient', () => {
       assert(
         (client.descriptors.page.listIndexes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_job_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_job_service_v1.ts
@@ -4629,9 +4629,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4678,9 +4678,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4727,9 +4727,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4767,9 +4767,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4849,8 +4849,7 @@ describe('v1.JobServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IDataLabelingJob[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IDataLabelingJob[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4958,9 +4957,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5008,9 +5007,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5058,9 +5057,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5099,9 +5098,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5633,9 +5632,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5684,9 +5683,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5727,9 +5726,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5769,9 +5768,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5958,9 +5957,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6008,9 +6007,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6057,9 +6056,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6098,9 +6097,9 @@ describe('v1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -6180,8 +6179,7 @@ describe('v1.JobServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IBatchPredictionJob[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IBatchPredictionJob[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_job_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_job_service_v1beta1.ts
@@ -4632,9 +4632,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4682,9 +4682,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4731,9 +4731,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4772,9 +4772,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listCustomJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4854,8 +4854,7 @@ describe('v1beta1.JobServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IDataLabelingJob[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IDataLabelingJob[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4965,9 +4964,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5017,9 +5016,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5067,9 +5066,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5108,9 +5107,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listDataLabelingJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5660,9 +5659,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5711,9 +5710,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5760,9 +5759,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5802,9 +5801,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5884,8 +5883,7 @@ describe('v1beta1.JobServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.INasTrialDetail[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.INasTrialDetail[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5993,9 +5991,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6043,9 +6041,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6093,9 +6091,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6134,9 +6132,9 @@ describe('v1beta1.JobServiceClient', () => {
       assert(
         (client.descriptors.page.listNasTrialDetails.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_memory_bank_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_memory_bank_service_v1beta1.ts
@@ -1613,9 +1613,9 @@ describe('v1beta1.MemoryBankServiceClient', () => {
       assert(
         (client.descriptors.page.listMemories.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1665,9 +1665,9 @@ describe('v1beta1.MemoryBankServiceClient', () => {
       assert(
         (client.descriptors.page.listMemories.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1715,9 +1715,9 @@ describe('v1beta1.MemoryBankServiceClient', () => {
       assert(
         (client.descriptors.page.listMemories.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1756,9 +1756,9 @@ describe('v1beta1.MemoryBankServiceClient', () => {
       assert(
         (client.descriptors.page.listMemories.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_metadata_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_metadata_service_v1.ts
@@ -4646,9 +4646,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4695,9 +4695,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4744,9 +4744,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4785,9 +4785,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4954,9 +4954,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5003,9 +5003,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5046,9 +5046,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5086,9 +5086,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5255,9 +5255,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5306,9 +5306,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5349,9 +5349,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5389,9 +5389,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5576,9 +5576,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5625,9 +5625,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5674,9 +5674,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5714,9 +5714,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5903,9 +5903,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5953,9 +5953,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6002,9 +6002,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6043,9 +6043,9 @@ describe('v1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_metadata_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_metadata_service_v1beta1.ts
@@ -4542,8 +4542,7 @@ describe('v1beta1.MetadataServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IMetadataStore[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IMetadataStore[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4651,9 +4650,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4701,9 +4700,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4751,9 +4750,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4792,9 +4791,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataStores.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4979,9 +4978,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5028,9 +5027,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5077,9 +5076,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5118,9 +5117,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listArtifacts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5305,9 +5304,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5356,9 +5355,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5405,9 +5404,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5445,9 +5444,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listContexts.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5633,9 +5632,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5683,9 +5682,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5732,9 +5731,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5773,9 +5772,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listExecutions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5855,8 +5854,7 @@ describe('v1beta1.MetadataServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IMetadataSchema[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IMetadataSchema[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5964,9 +5962,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6014,9 +6012,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6064,9 +6062,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -6105,9 +6103,9 @@ describe('v1beta1.MetadataServiceClient', () => {
       assert(
         (client.descriptors.page.listMetadataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_migration_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_migration_service_v1.ts
@@ -627,8 +627,7 @@ describe('v1.MigrationServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IMigratableResource[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IMigratableResource[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_model_garden_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_model_garden_service_v1beta1.ts
@@ -1497,8 +1497,7 @@ describe('v1beta1.ModelGardenServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IPublisherModel[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IPublisherModel[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1608,9 +1607,9 @@ describe('v1beta1.ModelGardenServiceClient', () => {
       assert(
         (client.descriptors.page.listPublisherModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1659,9 +1658,9 @@ describe('v1beta1.ModelGardenServiceClient', () => {
       assert(
         (client.descriptors.page.listPublisherModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1710,9 +1709,9 @@ describe('v1beta1.ModelGardenServiceClient', () => {
       assert(
         (client.descriptors.page.listPublisherModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1752,9 +1751,9 @@ describe('v1beta1.ModelGardenServiceClient', () => {
       assert(
         (client.descriptors.page.listPublisherModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_model_monitoring_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_model_monitoring_service_v1beta1.ts
@@ -1677,8 +1677,7 @@ describe('v1beta1.ModelMonitoringServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IModelMonitor[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IModelMonitor[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1788,9 +1787,9 @@ describe('v1beta1.ModelMonitoringServiceClient', () => {
       assert(
         (client.descriptors.page.listModelMonitors.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1839,9 +1838,9 @@ describe('v1beta1.ModelMonitoringServiceClient', () => {
       assert(
         (client.descriptors.page.listModelMonitors.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1890,9 +1889,9 @@ describe('v1beta1.ModelMonitoringServiceClient', () => {
       assert(
         (client.descriptors.page.listModelMonitors.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1932,9 +1931,9 @@ describe('v1beta1.ModelMonitoringServiceClient', () => {
       assert(
         (client.descriptors.page.listModelMonitors.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_model_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_model_service_v1.ts
@@ -2756,9 +2756,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2807,9 +2807,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2850,9 +2850,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2892,9 +2892,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3061,9 +3061,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3110,9 +3110,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3153,9 +3153,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3193,9 +3193,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3640,8 +3640,7 @@ describe('v1.ModelServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IModelEvaluation[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IModelEvaluation[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3749,9 +3748,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3799,9 +3798,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3849,9 +3848,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3890,9 +3889,9 @@ describe('v1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3972,8 +3971,7 @@ describe('v1.ModelServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IModelEvaluationSlice[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IModelEvaluationSlice[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_model_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_model_service_v1beta1.ts
@@ -2906,9 +2906,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2957,9 +2957,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3006,9 +3006,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3048,9 +3048,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModels.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3235,9 +3235,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3284,9 +3284,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3333,9 +3333,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3373,9 +3373,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelVersions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3820,8 +3820,7 @@ describe('v1beta1.ModelServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IModelEvaluation[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IModelEvaluation[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3931,9 +3930,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3983,9 +3982,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4033,9 +4032,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4074,9 +4073,9 @@ describe('v1beta1.ModelServiceClient', () => {
       assert(
         (client.descriptors.page.listModelEvaluations.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_notebook_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_notebook_service_v1.ts
@@ -3120,8 +3120,7 @@ describe('v1.NotebookServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.INotebookRuntime[]
-              | null,
+              protos.google.cloud.aiplatform.v1.INotebookRuntime[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3229,9 +3228,9 @@ describe('v1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3279,9 +3278,9 @@ describe('v1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3329,9 +3328,9 @@ describe('v1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3370,9 +3369,9 @@ describe('v1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -3452,8 +3451,7 @@ describe('v1.NotebookServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.INotebookExecutionJob[]
-              | null,
+              protos.google.cloud.aiplatform.v1.INotebookExecutionJob[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_notebook_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_notebook_service_v1beta1.ts
@@ -3122,8 +3122,7 @@ describe('v1beta1.NotebookServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.INotebookRuntime[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.INotebookRuntime[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -3233,9 +3232,9 @@ describe('v1beta1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3285,9 +3284,9 @@ describe('v1beta1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3335,9 +3334,9 @@ describe('v1beta1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -3376,9 +3375,9 @@ describe('v1beta1.NotebookServiceClient', () => {
       assert(
         (client.descriptors.page.listNotebookRuntimes.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_online_evaluator_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_online_evaluator_service_v1beta1.ts
@@ -1605,8 +1605,7 @@ describe('v1beta1.OnlineEvaluatorServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IOnlineEvaluator[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IOnlineEvaluator[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1718,9 +1717,9 @@ describe('v1beta1.OnlineEvaluatorServiceClient', () => {
       assert(
         (client.descriptors.page.listOnlineEvaluators.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1771,9 +1770,9 @@ describe('v1beta1.OnlineEvaluatorServiceClient', () => {
       assert(
         (client.descriptors.page.listOnlineEvaluators.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1822,9 +1821,9 @@ describe('v1beta1.OnlineEvaluatorServiceClient', () => {
       assert(
         (client.descriptors.page.listOnlineEvaluators.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1864,9 +1863,9 @@ describe('v1beta1.OnlineEvaluatorServiceClient', () => {
       assert(
         (client.descriptors.page.listOnlineEvaluators.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_persistent_resource_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_persistent_resource_service_v1.ts
@@ -1411,8 +1411,7 @@ describe('v1.PersistentResourceServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IPersistentResource[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IPersistentResource[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_pipeline_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_pipeline_service_v1.ts
@@ -2024,8 +2024,7 @@ describe('v1.PipelineServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.ITrainingPipeline[]
-              | null,
+              protos.google.cloud.aiplatform.v1.ITrainingPipeline[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -2484,9 +2483,9 @@ describe('v1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2533,9 +2532,9 @@ describe('v1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2582,9 +2581,9 @@ describe('v1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2622,9 +2621,9 @@ describe('v1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_pipeline_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_pipeline_service_v1beta1.ts
@@ -2026,8 +2026,7 @@ describe('v1beta1.PipelineServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ITrainingPipeline[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ITrainingPipeline[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -2384,8 +2383,7 @@ describe('v1beta1.PipelineServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IPipelineJob[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IPipelineJob[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -2493,9 +2491,9 @@ describe('v1beta1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2543,9 +2541,9 @@ describe('v1beta1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2593,9 +2591,9 @@ describe('v1beta1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2634,9 +2632,9 @@ describe('v1beta1.PipelineServiceClient', () => {
       assert(
         (client.descriptors.page.listPipelineJobs.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_reasoning_engine_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_reasoning_engine_service_v1.ts
@@ -1198,8 +1198,7 @@ describe('v1.ReasoningEngineServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.IReasoningEngine[]
-              | null,
+              protos.google.cloud.aiplatform.v1.IReasoningEngine[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1309,9 +1308,9 @@ describe('v1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1360,9 +1359,9 @@ describe('v1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1411,9 +1410,9 @@ describe('v1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1453,9 +1452,9 @@ describe('v1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_reasoning_engine_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_reasoning_engine_service_v1beta1.ts
@@ -1198,8 +1198,7 @@ describe('v1beta1.ReasoningEngineServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IReasoningEngine[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IReasoningEngine[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1311,9 +1310,9 @@ describe('v1beta1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1364,9 +1363,9 @@ describe('v1beta1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1415,9 +1414,9 @@ describe('v1beta1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1457,9 +1456,9 @@ describe('v1beta1.ReasoningEngineServiceClient', () => {
       assert(
         (client.descriptors.page.listReasoningEngines.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_schedule_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_schedule_service_v1.ts
@@ -1375,9 +1375,9 @@ describe('v1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1424,9 +1424,9 @@ describe('v1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1467,9 +1467,9 @@ describe('v1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1507,9 +1507,9 @@ describe('v1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_schedule_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_schedule_service_v1beta1.ts
@@ -1395,9 +1395,9 @@ describe('v1beta1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1444,9 +1444,9 @@ describe('v1beta1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1493,9 +1493,9 @@ describe('v1beta1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1534,9 +1534,9 @@ describe('v1beta1.ScheduleServiceClient', () => {
       assert(
         (client.descriptors.page.listSchedules.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_session_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_session_service_v1.ts
@@ -1305,9 +1305,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1356,9 +1356,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1399,9 +1399,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1439,9 +1439,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -1626,9 +1626,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1677,9 +1677,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1726,9 +1726,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1768,9 +1768,9 @@ describe('v1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_session_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_session_service_v1beta1.ts
@@ -1324,9 +1324,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1375,9 +1375,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1424,9 +1424,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1464,9 +1464,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listSessions.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -1545,8 +1545,7 @@ describe('v1beta1.SessionServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ISessionEvent[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ISessionEvent[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1654,9 +1653,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1706,9 +1705,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1756,9 +1755,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1799,9 +1798,9 @@ describe('v1beta1.SessionServiceClient', () => {
       assert(
         (client.descriptors.page.listEvents.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_specialist_pool_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_specialist_pool_service_v1.ts
@@ -1297,9 +1297,9 @@ describe('v1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1348,9 +1348,9 @@ describe('v1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1398,9 +1398,9 @@ describe('v1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1440,9 +1440,9 @@ describe('v1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_specialist_pool_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_specialist_pool_service_v1beta1.ts
@@ -1188,8 +1188,7 @@ describe('v1beta1.SpecialistPoolServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ISpecialistPool[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ISpecialistPool[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -1299,9 +1298,9 @@ describe('v1beta1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1350,9 +1349,9 @@ describe('v1beta1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1401,9 +1400,9 @@ describe('v1beta1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -1443,9 +1442,9 @@ describe('v1beta1.SpecialistPoolServiceClient', () => {
       assert(
         (client.descriptors.page.listSpecialistPools.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_tensorboard_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_tensorboard_service_v1.ts
@@ -4394,9 +4394,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4443,9 +4443,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4492,9 +4492,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4532,9 +4532,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4614,8 +4614,7 @@ describe('v1.TensorboardServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.ITensorboardExperiment[]
-              | null,
+              protos.google.cloud.aiplatform.v1.ITensorboardExperiment[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5080,9 +5079,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5130,9 +5129,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5179,9 +5178,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5220,9 +5219,9 @@ describe('v1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5302,8 +5301,7 @@ describe('v1.TensorboardServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.ITensorboardTimeSeries[]
-              | null,
+              protos.google.cloud.aiplatform.v1.ITensorboardTimeSeries[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5661,8 +5659,7 @@ describe('v1.TensorboardServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1.ITimeSeriesDataPoint[]
-              | null,
+              protos.google.cloud.aiplatform.v1.ITimeSeriesDataPoint[] | null,
           ) => {
             if (err) {
               reject(err);

--- a/packages/google-cloud-aiplatform/test/gapic_tensorboard_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_tensorboard_service_v1beta1.ts
@@ -4415,8 +4415,7 @@ describe('v1beta1.TensorboardServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ITensorboard[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ITensorboard[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4526,9 +4525,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4577,9 +4576,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4628,9 +4627,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4670,9 +4669,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboards.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -5120,8 +5119,7 @@ describe('v1beta1.TensorboardServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.ITensorboardRun[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.ITensorboardRun[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5231,9 +5229,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5282,9 +5280,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5333,9 +5331,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5375,9 +5373,9 @@ describe('v1beta1.TensorboardServiceClient', () => {
       assert(
         (client.descriptors.page.listTensorboardRuns.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_vertex_rag_data_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_vertex_rag_data_service_v1.ts
@@ -2309,9 +2309,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2359,9 +2359,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2409,9 +2409,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2450,9 +2450,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -2623,9 +2623,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2675,9 +2675,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2719,9 +2719,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2760,9 +2760,9 @@ describe('v1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_vertex_rag_data_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_vertex_rag_data_service_v1beta1.ts
@@ -4084,9 +4084,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4135,9 +4135,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4185,9 +4185,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4227,9 +4227,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagCorpora.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4418,9 +4418,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4470,9 +4470,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4520,9 +4520,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4561,9 +4561,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagFiles.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4645,8 +4645,7 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IRagDataSchema[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IRagDataSchema[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -4756,9 +4755,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagDataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4807,9 +4806,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagDataSchemas.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4858,9 +4857,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagDataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -4900,9 +4899,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagDataSchemas.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -4983,8 +4982,7 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
           (
             err?: Error | null,
             result?:
-              | protos.google.cloud.aiplatform.v1beta1.IRagMetadata[]
-              | null,
+              protos.google.cloud.aiplatform.v1beta1.IRagMetadata[] | null,
           ) => {
             if (err) {
               reject(err);
@@ -5094,9 +5092,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagMetadata.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5145,9 +5143,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagMetadata.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5196,9 +5194,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagMetadata.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -5238,9 +5236,9 @@ describe('v1beta1.VertexRagDataServiceClient', () => {
       assert(
         (client.descriptors.page.listRagMetadata.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_vizier_service_v1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_vizier_service_v1.ts
@@ -2353,9 +2353,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2404,9 +2404,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2447,9 +2447,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2489,9 +2489,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -2658,9 +2658,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2709,9 +2709,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2752,9 +2752,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2794,9 +2794,9 @@ describe('v1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });

--- a/packages/google-cloud-aiplatform/test/gapic_vizier_service_v1beta1.ts
+++ b/packages/google-cloud-aiplatform/test/gapic_vizier_service_v1beta1.ts
@@ -2371,9 +2371,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2422,9 +2422,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2471,9 +2471,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2513,9 +2513,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listStudies.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });
@@ -2700,9 +2700,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2751,9 +2751,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.createStream as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2800,9 +2800,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
 
@@ -2842,9 +2842,9 @@ describe('v1beta1.VizierServiceClient', () => {
       assert(
         (client.descriptors.page.listTrials.asyncIterate as SinonStub)
           .getCall(0)
-          .args[2].otherArgs.headers[
-            'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          .args[2].otherArgs.headers['x-goog-request-params'].includes(
+            expectedHeaderRequestParams,
+          ),
       );
     });
   });


### PR DESCRIPTION
This PR migrates `google-cloud-aiplatform` to use Librarian for generation.

### Highlights
- Generated updated client and proto surface for `google-cloud-aiplatform`. I didn't use "-all" because it generates a pull request that cannot be reviewed (https://github.com/googleapis/librarian/issues/6638).
- Single package standalone migration PR to isolate large proto/GAPIC surface changes.


For https://github.com/googleapis/librarian/issues/6638.
