### PR TITLE
feat: update formatting on typescript in preparation for linter

### DIFF
--- a/handwritten/bigquery-storage/src/v1/big_query_read_client.ts
+++ b/handwritten/bigquery-storage/src/v1/big_query_read_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -51,7 +51,7 @@ export class BigQueryReadClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('bigquery-storage');
@@ -64,9 +64,9 @@ export class BigQueryReadClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  bigQueryReadStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  bigQueryReadStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of BigQueryReadClient.
@@ -142,7 +142,7 @@ export class BigQueryReadClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== this._servicePath && !('scopes' in opts)) {
@@ -231,7 +231,7 @@ export class BigQueryReadClient {
       'google.cloud.bigquery.storage.v1.BigQueryRead',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -271,7 +271,7 @@ export class BigQueryReadClient {
           (this._protos as any).google.cloud.bigquery.storage.v1.BigQueryRead,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -282,11 +282,11 @@ export class BigQueryReadClient {
     ];
     for (const methodName of bigQueryReadStubMethods) {
       const callPromise = this.bigQueryReadStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -542,7 +542,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         'read_session.table': request.readSession!.table ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('createReadSession request %j', request);
@@ -704,7 +704,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('splitReadStream request %j', request);
@@ -793,7 +793,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         read_stream: request.readStream ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('readRows stream %j', options);
@@ -1078,7 +1078,7 @@ export class BigQueryReadClient {
    */
   close(): Promise<void> {
     if (this.bigQueryReadStub && !this._terminated) {
-      return this.bigQueryReadStub.then((stub) => {
+      return this.bigQueryReadStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1/big_query_write_client.ts
+++ b/handwritten/bigquery-storage/src/v1/big_query_write_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -54,7 +54,7 @@ export class BigQueryWriteClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('bigquery-storage');
@@ -67,9 +67,9 @@ export class BigQueryWriteClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  bigQueryWriteStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  bigQueryWriteStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of BigQueryWriteClient.
@@ -145,7 +145,7 @@ export class BigQueryWriteClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== this._servicePath && !('scopes' in opts)) {
@@ -234,7 +234,7 @@ export class BigQueryWriteClient {
       'google.cloud.bigquery.storage.v1.BigQueryWrite',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -274,7 +274,7 @@ export class BigQueryWriteClient {
           (this._protos as any).google.cloud.bigquery.storage.v1.BigQueryWrite,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -288,11 +288,11 @@ export class BigQueryWriteClient {
     ];
     for (const methodName of bigQueryWriteStubMethods) {
       const callPromise = this.bigQueryWriteStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -516,7 +516,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('createWriteStream request %j', request);
@@ -663,7 +663,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('getWriteStream request %j', request);
@@ -808,7 +808,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('finalizeWriteStream request %j', request);
@@ -959,7 +959,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchCommitWriteStreams request %j', request);
@@ -1106,7 +1106,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         write_stream: request.writeStream ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('flushRows request %j', request);
@@ -1199,7 +1199,7 @@ export class BigQueryWriteClient {
    * region_tag:bigquerystorage_v1_generated_BigQueryWrite_AppendRows_async
    */
   appendRows(options?: CallOptions): gax.CancellableStream {
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('appendRows stream %j', options);
@@ -1484,7 +1484,7 @@ export class BigQueryWriteClient {
    */
   close(): Promise<void> {
     if (this.bigQueryWriteStub && !this._terminated) {
-      return this.bigQueryWriteStub.then((stub) => {
+      return this.bigQueryWriteStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1/index.ts
+++ b/handwritten/bigquery-storage/src/v1/index.ts
@@ -16,5 +16,5 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-export { BigQueryReadClient } from './big_query_read_client';
-export { BigQueryWriteClient } from './big_query_write_client';
+export {BigQueryReadClient} from './big_query_read_client';
+export {BigQueryWriteClient} from './big_query_write_client';

--- a/handwritten/bigquery-storage/src/v1alpha/index.ts
+++ b/handwritten/bigquery-storage/src/v1alpha/index.ts
@@ -16,4 +16,4 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-export { MetastorePartitionServiceClient } from './metastore_partition_service_client';
+export {MetastorePartitionServiceClient} from './metastore_partition_service_client';

--- a/handwritten/bigquery-storage/src/v1alpha/metastore_partition_service_client.ts
+++ b/handwritten/bigquery-storage/src/v1alpha/metastore_partition_service_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -51,7 +51,7 @@ export class MetastorePartitionServiceClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('storage');
@@ -64,9 +64,9 @@ export class MetastorePartitionServiceClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  metastorePartitionServiceStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  metastorePartitionServiceStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of MetastorePartitionServiceClient.
@@ -143,7 +143,7 @@ export class MetastorePartitionServiceClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // Request numeric enum values if REST transport is used.
     opts.numericEnums = true;
@@ -226,7 +226,7 @@ export class MetastorePartitionServiceClient {
       'google.cloud.bigquery.storage.v1alpha.MetastorePartitionService',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -267,7 +267,7 @@ export class MetastorePartitionServiceClient {
             .MetastorePartitionService,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -280,11 +280,11 @@ export class MetastorePartitionServiceClient {
     ];
     for (const methodName of metastorePartitionServiceStubMethods) {
       const callPromise = this.metastorePartitionServiceStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -515,7 +515,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchCreateMetastorePartitions request %j', request);
@@ -675,7 +675,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchDeleteMetastorePartitions request %j', request);
@@ -834,7 +834,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchUpdateMetastorePartitions request %j', request);
@@ -1002,7 +1002,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('listMetastorePartitions request %j', request);
@@ -1073,7 +1073,7 @@ export class MetastorePartitionServiceClient {
    * region_tag:bigquerystorage_v1alpha_generated_MetastorePartitionService_StreamMetastorePartitions_async
    */
   streamMetastorePartitions(options?: CallOptions): gax.CancellableStream {
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('streamMetastorePartitions stream %j', options);
@@ -1212,7 +1212,7 @@ export class MetastorePartitionServiceClient {
    */
   close(): Promise<void> {
     if (this.metastorePartitionServiceStub && !this._terminated) {
-      return this.metastorePartitionServiceStub.then((stub) => {
+      return this.metastorePartitionServiceStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1beta/index.ts
+++ b/handwritten/bigquery-storage/src/v1beta/index.ts
@@ -16,4 +16,4 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-export { MetastorePartitionServiceClient } from './metastore_partition_service_client';
+export {MetastorePartitionServiceClient} from './metastore_partition_service_client';

--- a/handwritten/bigquery-storage/src/v1beta/metastore_partition_service_client.ts
+++ b/handwritten/bigquery-storage/src/v1beta/metastore_partition_service_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -51,7 +51,7 @@ export class MetastorePartitionServiceClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('storage');
@@ -64,9 +64,9 @@ export class MetastorePartitionServiceClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  metastorePartitionServiceStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  metastorePartitionServiceStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of MetastorePartitionServiceClient.
@@ -143,7 +143,7 @@ export class MetastorePartitionServiceClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // Request numeric enum values if REST transport is used.
     opts.numericEnums = true;
@@ -226,7 +226,7 @@ export class MetastorePartitionServiceClient {
       'google.cloud.bigquery.storage.v1beta.MetastorePartitionService',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -267,7 +267,7 @@ export class MetastorePartitionServiceClient {
             .MetastorePartitionService,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -280,11 +280,11 @@ export class MetastorePartitionServiceClient {
     ];
     for (const methodName of metastorePartitionServiceStubMethods) {
       const callPromise = this.metastorePartitionServiceStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -515,7 +515,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchCreateMetastorePartitions request %j', request);
@@ -675,7 +675,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchDeleteMetastorePartitions request %j', request);
@@ -834,7 +834,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchUpdateMetastorePartitions request %j', request);
@@ -1004,7 +1004,7 @@ export class MetastorePartitionServiceClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('listMetastorePartitions request %j', request);
@@ -1075,7 +1075,7 @@ export class MetastorePartitionServiceClient {
    * region_tag:bigquerystorage_v1beta_generated_MetastorePartitionService_StreamMetastorePartitions_async
    */
   streamMetastorePartitions(options?: CallOptions): gax.CancellableStream {
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('streamMetastorePartitions stream %j', options);
@@ -1214,7 +1214,7 @@ export class MetastorePartitionServiceClient {
    */
   close(): Promise<void> {
     if (this.metastorePartitionServiceStub && !this._terminated) {
-      return this.metastorePartitionServiceStub.then((stub) => {
+      return this.metastorePartitionServiceStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1beta1/big_query_storage_client.ts
+++ b/handwritten/bigquery-storage/src/v1beta1/big_query_storage_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -56,7 +56,7 @@ export class BigQueryStorageClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('bigquery-storage');
@@ -69,9 +69,9 @@ export class BigQueryStorageClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  bigQueryStorageStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  bigQueryStorageStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of BigQueryStorageClient.
@@ -147,7 +147,7 @@ export class BigQueryStorageClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== this._servicePath && !('scopes' in opts)) {
@@ -230,7 +230,7 @@ export class BigQueryStorageClient {
       'google.cloud.bigquery.storage.v1beta1.BigQueryStorage',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -271,7 +271,7 @@ export class BigQueryStorageClient {
             .BigQueryStorage,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -284,11 +284,11 @@ export class BigQueryStorageClient {
     ];
     for (const methodName of bigQueryStorageStubMethods) {
       const callPromise = this.bigQueryStorageStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -539,7 +539,7 @@ export class BigQueryStorageClient {
         'table_reference.dataset_id':
           request.tableReference!.datasetId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('createReadSession request %j', request);
@@ -689,7 +689,7 @@ export class BigQueryStorageClient {
       this._gaxModule.routingHeader.fromParams({
         'session.name': request.session!.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('batchCreateReadSessionStreams request %j', request);
@@ -845,7 +845,7 @@ export class BigQueryStorageClient {
       this._gaxModule.routingHeader.fromParams({
         'stream.name': request.stream!.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('finalizeStream request %j', request);
@@ -1008,7 +1008,7 @@ export class BigQueryStorageClient {
       this._gaxModule.routingHeader.fromParams({
         'original_stream.name': request.originalStream!.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('splitReadStream request %j', request);
@@ -1097,7 +1097,7 @@ export class BigQueryStorageClient {
       this._gaxModule.routingHeader.fromParams({
         'read_position.stream.name': request.readPosition!.stream!.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('readRows stream %j', options);
@@ -1240,7 +1240,7 @@ export class BigQueryStorageClient {
    */
   close(): Promise<void> {
     if (this.bigQueryStorageStub && !this._terminated) {
-      return this.bigQueryStorageStub.then((stub) => {
+      return this.bigQueryStorageStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1beta1/index.ts
+++ b/handwritten/bigquery-storage/src/v1beta1/index.ts
@@ -16,4 +16,4 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-export { BigQueryStorageClient } from './big_query_storage_client';
+export {BigQueryStorageClient} from './big_query_storage_client';

--- a/handwritten/bigquery-storage/src/v1beta2/big_query_read_client.ts
+++ b/handwritten/bigquery-storage/src/v1beta2/big_query_read_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -54,7 +54,7 @@ export class BigQueryReadClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('storage');
@@ -67,9 +67,9 @@ export class BigQueryReadClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  bigQueryReadStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  bigQueryReadStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of BigQueryReadClient.
@@ -145,7 +145,7 @@ export class BigQueryReadClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== this._servicePath && !('scopes' in opts)) {
@@ -234,7 +234,7 @@ export class BigQueryReadClient {
       'google.cloud.bigquery.storage.v1beta2.BigQueryRead',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -275,7 +275,7 @@ export class BigQueryReadClient {
             .BigQueryRead,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -286,11 +286,11 @@ export class BigQueryReadClient {
     ];
     for (const methodName of bigQueryReadStubMethods) {
       const callPromise = this.bigQueryReadStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -535,7 +535,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         'read_session.table': request.readSession!.table ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('createReadSession request %j', request);
@@ -697,7 +697,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('splitReadStream request %j', request);
@@ -786,7 +786,7 @@ export class BigQueryReadClient {
       this._gaxModule.routingHeader.fromParams({
         read_stream: request.readStream ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('readRows stream %j', options);
@@ -1071,7 +1071,7 @@ export class BigQueryReadClient {
    */
   close(): Promise<void> {
     if (this.bigQueryReadStub && !this._terminated) {
-      return this.bigQueryReadStub.then((stub) => {
+      return this.bigQueryReadStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1beta2/big_query_write_client.ts
+++ b/handwritten/bigquery-storage/src/v1beta2/big_query_write_client.ts
@@ -24,10 +24,10 @@ import type {
   Descriptors,
   ClientOptions,
 } from 'google-gax';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -57,7 +57,7 @@ export class BigQueryWriteClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('storage');
@@ -70,9 +70,9 @@ export class BigQueryWriteClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
-  pathTemplates: { [name: string]: gax.PathTemplate };
-  bigQueryWriteStub?: Promise<{ [name: string]: Function }>;
+  innerApiCalls: {[name: string]: Function};
+  pathTemplates: {[name: string]: gax.PathTemplate};
+  bigQueryWriteStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of BigQueryWriteClient.
@@ -148,7 +148,7 @@ export class BigQueryWriteClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== this._servicePath && !('scopes' in opts)) {
@@ -237,7 +237,7 @@ export class BigQueryWriteClient {
       'google.cloud.bigquery.storage.v1beta2.BigQueryWrite',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -283,7 +283,7 @@ export class BigQueryWriteClient {
             .BigQueryWrite,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -297,11 +297,11 @@ export class BigQueryWriteClient {
     ];
     for (const methodName of bigQueryWriteStubMethods) {
       const callPromise = this.bigQueryWriteStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               if (methodName in this.descriptors.stream) {
-                const stream = new PassThrough({ objectMode: true });
+                const stream = new PassThrough({objectMode: true});
                 setImmediate(() => {
                   stream.emit(
                     'error',
@@ -531,7 +531,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -681,7 +681,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -832,7 +832,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         name: request.name ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -988,7 +988,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         parent: request.parent ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -1145,7 +1145,7 @@ export class BigQueryWriteClient {
       this._gaxModule.routingHeader.fromParams({
         write_stream: request.writeStream ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -1235,7 +1235,7 @@ export class BigQueryWriteClient {
    * @deprecated AppendRows is deprecated and may be removed in a future version.
    */
   appendRows(options?: CallOptions): gax.CancellableStream {
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this.warn(
@@ -1525,7 +1525,7 @@ export class BigQueryWriteClient {
    */
   close(): Promise<void> {
     if (this.bigQueryWriteStub && !this._terminated) {
-      return this.bigQueryWriteStub.then((stub) => {
+      return this.bigQueryWriteStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/bigquery-storage/src/v1beta2/index.ts
+++ b/handwritten/bigquery-storage/src/v1beta2/index.ts
@@ -16,5 +16,5 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-export { BigQueryReadClient } from './big_query_read_client';
-export { BigQueryWriteClient } from './big_query_write_client';
+export {BigQueryReadClient} from './big_query_read_client';
+export {BigQueryWriteClient} from './big_query_write_client';

--- a/handwritten/bigquery-storage/system-test/install.ts
+++ b/handwritten/bigquery-storage/system-test/install.ts
@@ -16,9 +16,9 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import { packNTest } from 'pack-n-play';
-import { readFileSync } from 'fs';
-import { describe, it } from 'mocha';
+import {packNTest} from 'pack-n-play';
+import {readFileSync} from 'fs';
+import {describe, it} from 'mocha';
 
 describe('📦 pack-n-play test', () => {
   it('TypeScript code', async function () {

--- a/handwritten/bigquery-storage/test/gapic_big_query_read_v1.ts
+++ b/handwritten/bigquery-storage/test/gapic_big_query_read_v1.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as bigqueryreadModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -202,7 +202,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryReadStub, undefined);
@@ -210,12 +210,12 @@ describe('v1.BigQueryReadClient', () => {
       assert(client.bigQueryReadStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.bigQueryReadStub);
@@ -224,14 +224,14 @@ describe('v1.BigQueryReadClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryReadStub, undefined);
@@ -240,7 +240,7 @@ describe('v1.BigQueryReadClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -248,7 +248,7 @@ describe('v1.BigQueryReadClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -260,7 +260,7 @@ describe('v1.BigQueryReadClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -283,7 +283,7 @@ describe('v1.BigQueryReadClient', () => {
   describe('createReadSession', () => {
     it('invokes createReadSession without error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -315,7 +315,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes createReadSession without error using callback', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -363,7 +363,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes createReadSession with error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -395,7 +395,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes createReadSession with closed client', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -409,7 +409,7 @@ describe('v1.BigQueryReadClient', () => {
       );
       request.readSession.table = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.createReadSession(request), expectedError);
@@ -419,7 +419,7 @@ describe('v1.BigQueryReadClient', () => {
   describe('splitReadStream', () => {
     it('invokes splitReadStream without error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -450,7 +450,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes splitReadStream without error using callback', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -497,7 +497,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes splitReadStream with error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -528,7 +528,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes splitReadStream with closed client', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -541,7 +541,7 @@ describe('v1.BigQueryReadClient', () => {
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.splitReadStream(request), expectedError);
@@ -551,7 +551,7 @@ describe('v1.BigQueryReadClient', () => {
   describe('readRows', () => {
     it('invokes readRows without error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -596,7 +596,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes readRows without error and gaxServerStreamingRetries enabled', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
         gaxServerStreamingRetries: true,
       });
@@ -642,7 +642,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes readRows with error', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -687,7 +687,7 @@ describe('v1.BigQueryReadClient', () => {
 
     it('invokes readRows with closed client', async () => {
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -700,11 +700,11 @@ describe('v1.BigQueryReadClient', () => {
       );
       request.readStream = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       const stream = client.readRows(request, {
-        retryRequestOptions: { noResponseRetries: 0 },
+        retryRequestOptions: {noResponseRetries: 0},
       });
       const promise = new Promise((resolve, reject) => {
         stream.on(
@@ -736,7 +736,7 @@ describe('v1.BigQueryReadClient', () => {
         project: 'projectValue',
       };
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -776,7 +776,7 @@ describe('v1.BigQueryReadClient', () => {
         session: 'sessionValue',
       };
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -841,7 +841,7 @@ describe('v1.BigQueryReadClient', () => {
         stream: 'streamValue',
       };
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -916,7 +916,7 @@ describe('v1.BigQueryReadClient', () => {
         table: 'tableValue',
       };
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -981,7 +981,7 @@ describe('v1.BigQueryReadClient', () => {
         stream: 'streamValue',
       };
       const client = new bigqueryreadModule.v1.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/bigquery-storage/test/gapic_big_query_read_v1beta2.ts
+++ b/handwritten/bigquery-storage/test/gapic_big_query_read_v1beta2.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as bigqueryreadModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -202,7 +202,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryReadStub, undefined);
@@ -210,12 +210,12 @@ describe('v1beta2.BigQueryReadClient', () => {
       assert(client.bigQueryReadStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.bigQueryReadStub);
@@ -224,14 +224,14 @@ describe('v1beta2.BigQueryReadClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryReadStub, undefined);
@@ -240,7 +240,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -248,7 +248,7 @@ describe('v1beta2.BigQueryReadClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -260,7 +260,7 @@ describe('v1beta2.BigQueryReadClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -283,7 +283,7 @@ describe('v1beta2.BigQueryReadClient', () => {
   describe('createReadSession', () => {
     it('invokes createReadSession without error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -315,7 +315,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes createReadSession without error using callback', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -363,7 +363,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes createReadSession with error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -395,7 +395,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes createReadSession with closed client', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -409,7 +409,7 @@ describe('v1beta2.BigQueryReadClient', () => {
       );
       request.readSession.table = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.createReadSession(request), expectedError);
@@ -419,7 +419,7 @@ describe('v1beta2.BigQueryReadClient', () => {
   describe('splitReadStream', () => {
     it('invokes splitReadStream without error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -450,7 +450,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes splitReadStream without error using callback', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -497,7 +497,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes splitReadStream with error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -528,7 +528,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes splitReadStream with closed client', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -541,7 +541,7 @@ describe('v1beta2.BigQueryReadClient', () => {
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.splitReadStream(request), expectedError);
@@ -551,7 +551,7 @@ describe('v1beta2.BigQueryReadClient', () => {
   describe('readRows', () => {
     it('invokes readRows without error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -596,7 +596,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes readRows without error and gaxServerStreamingRetries enabled', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
         gaxServerStreamingRetries: true,
       });
@@ -642,7 +642,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes readRows with error', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -687,7 +687,7 @@ describe('v1beta2.BigQueryReadClient', () => {
 
     it('invokes readRows with closed client', async () => {
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -700,11 +700,11 @@ describe('v1beta2.BigQueryReadClient', () => {
       );
       request.readStream = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       const stream = client.readRows(request, {
-        retryRequestOptions: { noResponseRetries: 0 },
+        retryRequestOptions: {noResponseRetries: 0},
       });
       const promise = new Promise((resolve, reject) => {
         stream.on(
@@ -736,7 +736,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         project: 'projectValue',
       };
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -776,7 +776,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         session: 'sessionValue',
       };
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -841,7 +841,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         stream: 'streamValue',
       };
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -916,7 +916,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         table: 'tableValue',
       };
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -981,7 +981,7 @@ describe('v1beta2.BigQueryReadClient', () => {
         stream: 'streamValue',
       };
       const client = new bigqueryreadModule.v1beta2.BigQueryReadClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts
+++ b/handwritten/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as bigquerystorageModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -204,7 +204,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryStorageStub, undefined);
@@ -212,12 +212,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
       assert(client.bigQueryStorageStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.bigQueryStorageStub);
@@ -226,14 +226,14 @@ describe('v1beta1.BigQueryStorageClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryStorageStub, undefined);
@@ -242,7 +242,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -250,7 +250,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -262,7 +262,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -285,7 +285,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
   describe('createReadSession', () => {
     it('invokes createReadSession without error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -323,7 +323,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes createReadSession without error using callback', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -377,7 +377,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes createReadSession with error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -415,7 +415,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes createReadSession with closed client', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -435,7 +435,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
       );
       request.tableReference.datasetId = defaultValue2;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.createReadSession(request), expectedError);
@@ -445,7 +445,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
   describe('batchCreateReadSessionStreams', () => {
     it('invokes batchCreateReadSessionStreams without error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -478,7 +478,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes batchCreateReadSessionStreams without error using callback', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -526,7 +526,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes batchCreateReadSessionStreams with error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -561,7 +561,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes batchCreateReadSessionStreams with closed client', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -575,7 +575,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
       );
       request.session.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -588,7 +588,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
   describe('finalizeStream', () => {
     it('invokes finalizeStream without error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -620,7 +620,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes finalizeStream without error using callback', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -668,7 +668,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes finalizeStream with error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -700,7 +700,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes finalizeStream with closed client', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -714,7 +714,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
       );
       request.stream.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.finalizeStream(request), expectedError);
@@ -724,7 +724,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
   describe('splitReadStream', () => {
     it('invokes splitReadStream without error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -756,7 +756,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes splitReadStream without error using callback', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -804,7 +804,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes splitReadStream with error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -836,7 +836,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes splitReadStream with closed client', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -850,7 +850,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
       );
       request.originalStream.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.splitReadStream(request), expectedError);
@@ -860,7 +860,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
   describe('readRows', () => {
     it('invokes readRows without error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -907,7 +907,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes readRows without error and gaxServerStreamingRetries enabled', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
         gaxServerStreamingRetries: true,
       });
@@ -955,7 +955,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes readRows with error', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1002,7 +1002,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
 
     it('invokes readRows with closed client', async () => {
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1017,11 +1017,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
       );
       request.readPosition.stream.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       const stream = client.readRows(request, {
-        retryRequestOptions: { noResponseRetries: 0 },
+        retryRequestOptions: {noResponseRetries: 0},
       });
       const promise = new Promise((resolve, reject) => {
         stream.on(
@@ -1053,7 +1053,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
         project: 'projectValue',
       };
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1093,7 +1093,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
         session: 'sessionValue',
       };
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1157,7 +1157,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
         stream: 'streamValue',
       };
       const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/bigquery-storage/test/gapic_big_query_write_v1.ts
+++ b/handwritten/bigquery-storage/test/gapic_big_query_write_v1.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as bigquerywriteModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -195,7 +195,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryWriteStub, undefined);
@@ -203,12 +203,12 @@ describe('v1.BigQueryWriteClient', () => {
       assert(client.bigQueryWriteStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.bigQueryWriteStub);
@@ -217,14 +217,14 @@ describe('v1.BigQueryWriteClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.bigQueryWriteStub, undefined);
@@ -233,7 +233,7 @@ describe('v1.BigQueryWriteClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -241,7 +241,7 @@ describe('v1.BigQueryWriteClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -253,7 +253,7 @@ describe('v1.BigQueryWriteClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -276,7 +276,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('createWriteStream', () => {
     it('invokes createWriteStream without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -307,7 +307,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes createWriteStream without error using callback', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -354,7 +354,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes createWriteStream with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -385,7 +385,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes createWriteStream with closed client', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -398,7 +398,7 @@ describe('v1.BigQueryWriteClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.createWriteStream(request), expectedError);
@@ -408,7 +408,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('getWriteStream', () => {
     it('invokes getWriteStream without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -439,7 +439,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes getWriteStream without error using callback', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -486,7 +486,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes getWriteStream with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -517,7 +517,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes getWriteStream with closed client', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -530,7 +530,7 @@ describe('v1.BigQueryWriteClient', () => {
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.getWriteStream(request), expectedError);
@@ -540,7 +540,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('finalizeWriteStream', () => {
     it('invokes finalizeWriteStream without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -572,7 +572,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes finalizeWriteStream without error using callback', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -619,7 +619,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes finalizeWriteStream with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -650,7 +650,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes finalizeWriteStream with closed client', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -663,7 +663,7 @@ describe('v1.BigQueryWriteClient', () => {
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.finalizeWriteStream(request), expectedError);
@@ -673,7 +673,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('batchCommitWriteStreams', () => {
     it('invokes batchCommitWriteStreams without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -705,7 +705,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes batchCommitWriteStreams without error using callback', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -752,7 +752,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes batchCommitWriteStreams with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -786,7 +786,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes batchCommitWriteStreams with closed client', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -799,7 +799,7 @@ describe('v1.BigQueryWriteClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -812,7 +812,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('flushRows', () => {
     it('invokes flushRows without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -843,7 +843,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes flushRows without error using callback', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -890,7 +890,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes flushRows with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -918,7 +918,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes flushRows with closed client', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -931,7 +931,7 @@ describe('v1.BigQueryWriteClient', () => {
       );
       request.writeStream = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.flushRows(request), expectedError);
@@ -941,7 +941,7 @@ describe('v1.BigQueryWriteClient', () => {
   describe('appendRows', () => {
     it('invokes appendRows without error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -985,7 +985,7 @@ describe('v1.BigQueryWriteClient', () => {
 
     it('invokes appendRows with error', async () => {
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1034,7 +1034,7 @@ describe('v1.BigQueryWriteClient', () => {
         project: 'projectValue',
       };
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1074,7 +1074,7 @@ describe('v1.BigQueryWriteClient', () => {
         session: 'sessionValue',
       };
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1139,7 +1139,7 @@ describe('v1.BigQueryWriteClient', () => {
         stream: 'streamValue',
       };
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1214,7 +1214,7 @@ describe('v1.BigQueryWriteClient', () => {
         table: 'tableValue',
       };
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1279,7 +1279,7 @@ describe('v1.BigQueryWriteClient', () => {
         stream: 'streamValue',
       };
       const client = new bigquerywriteModule.v1.BigQueryWriteClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/bigquery-storage/test/gapic_metastore_partition_service_v1alpha.ts
+++ b/handwritten/bigquery-storage/test/gapic_metastore_partition_service_v1alpha.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as metastorepartitionserviceModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -123,7 +123,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
     it('sets apiEndpoint according to universe domain camelCase', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
-          { universeDomain: 'example.com' },
+          {universeDomain: 'example.com'},
         );
       const servicePath = client.apiEndpoint;
       assert.strictEqual(servicePath, 'bigquerystorage.example.com');
@@ -132,7 +132,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
     it('sets apiEndpoint according to universe domain snakeCase', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
-          { universe_domain: 'example.com' },
+          {universe_domain: 'example.com'},
         );
       const servicePath = client.apiEndpoint;
       assert.strictEqual(servicePath, 'bigquerystorage.example.com');
@@ -159,7 +159,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
           process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = 'example.com';
           const client =
             new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
-              { universeDomain: 'configured.example.com' },
+              {universeDomain: 'configured.example.com'},
             );
           const servicePath = client.apiEndpoint;
           assert.strictEqual(
@@ -177,7 +177,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
     it('does not allow setting both universeDomain and universe_domain', () => {
       assert.throws(() => {
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
-          { universe_domain: 'example.com', universeDomain: 'example.net' },
+          {universe_domain: 'example.com', universeDomain: 'example.net'},
         );
       });
     });
@@ -210,7 +210,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -219,15 +219,15 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       assert(client.metastorePartitionServiceStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.metastorePartitionServiceStub);
@@ -236,16 +236,16 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -255,7 +255,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -265,7 +265,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -280,7 +280,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -306,7 +306,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -341,7 +341,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -391,7 +391,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -428,7 +428,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -442,7 +442,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -457,7 +457,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -492,7 +492,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -542,7 +542,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -579,7 +579,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -593,7 +593,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -608,7 +608,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -643,7 +643,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -693,7 +693,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -730,7 +730,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -744,7 +744,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -759,7 +759,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -794,7 +794,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -844,7 +844,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -881,7 +881,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -895,7 +895,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -910,7 +910,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -958,7 +958,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -1013,7 +1013,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -1091,7 +1091,7 @@ describe('v1alpha.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1alpha.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );

--- a/handwritten/bigquery-storage/test/gapic_metastore_partition_service_v1beta.ts
+++ b/handwritten/bigquery-storage/test/gapic_metastore_partition_service_v1beta.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as metastorepartitionserviceModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf } from 'google-gax';
+import {protobuf} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -123,7 +123,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
     it('sets apiEndpoint according to universe domain camelCase', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
-          { universeDomain: 'example.com' },
+          {universeDomain: 'example.com'},
         );
       const servicePath = client.apiEndpoint;
       assert.strictEqual(servicePath, 'bigquerystorage.example.com');
@@ -132,7 +132,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
     it('sets apiEndpoint according to universe domain snakeCase', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
-          { universe_domain: 'example.com' },
+          {universe_domain: 'example.com'},
         );
       const servicePath = client.apiEndpoint;
       assert.strictEqual(servicePath, 'bigquerystorage.example.com');
@@ -159,7 +159,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
           process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = 'example.com';
           const client =
             new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
-              { universeDomain: 'configured.example.com' },
+              {universeDomain: 'configured.example.com'},
             );
           const servicePath = client.apiEndpoint;
           assert.strictEqual(
@@ -177,7 +177,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
     it('does not allow setting both universeDomain and universe_domain', () => {
       assert.throws(() => {
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
-          { universe_domain: 'example.com', universeDomain: 'example.net' },
+          {universe_domain: 'example.com', universeDomain: 'example.net'},
         );
       });
     });
@@ -210,7 +210,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -219,15 +219,15 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       assert(client.metastorePartitionServiceStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.metastorePartitionServiceStub);
@@ -236,16 +236,16 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -255,7 +255,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -265,7 +265,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -280,7 +280,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -306,7 +306,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -341,7 +341,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -391,7 +391,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -428,7 +428,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -442,7 +442,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -457,7 +457,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -492,7 +492,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -542,7 +542,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -579,7 +579,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -593,7 +593,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -608,7 +608,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -643,7 +643,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -693,7 +693,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -730,7 +730,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -744,7 +744,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -759,7 +759,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -794,7 +794,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -844,7 +844,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -881,7 +881,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -895,7 +895,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(
@@ -910,7 +910,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -958,7 +958,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -1013,7 +1013,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );
@@ -1091,7 +1091,7 @@ describe('v1beta.MetastorePartitionServiceClient', () => {
       const client =
         new metastorepartitionserviceModule.v1beta.MetastorePartitionServiceClient(
           {
-            credentials: { client_email: 'bogus', private_key: 'bogus' },
+            credentials: {client_email: 'bogus', private_key: 'bogus'},
             projectId: 'bogus',
           },
         );

--- a/handwritten/cloud-profiler/src/index.ts
+++ b/handwritten/cloud-profiler/src/index.ts
@@ -28,7 +28,7 @@ const pjson = require('../../package.json');
 const serviceRegex = /^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$/;
 
 function hasService(
-  config: Config
+  config: Config,
 ): config is {serviceContext: {service: string}} {
   return (
     config.serviceContext !== undefined &&
@@ -85,7 +85,7 @@ function initConfigLocal(config: Config): LocalConfig {
   ) {
     throw new Error(
       'serviceMapSearchPath is an empty array. Use disableSourceMaps to' +
-        ' disable source map support instead.'
+        ' disable source map support instead.',
     );
   }
 
@@ -99,7 +99,7 @@ function initConfigLocal(config: Config): LocalConfig {
     throw new Error(
       `Service ${
         mergedConfig.serviceContext.service
-      } does not match regular expression "${serviceRegex.toString()}"`
+      } does not match regular expression "${serviceRegex.toString()}"`,
     );
   }
 
@@ -111,12 +111,12 @@ function initConfigLocal(config: Config): LocalConfig {
  * metadata.
  */
 async function initConfigMetadata(
-  config: LocalConfig
+  config: LocalConfig,
 ): Promise<ProfilerConfig> {
   const logger = createLogger(config.logLevel);
   const getMetadataProperty = async (
     f: (s: string) => Promise<string>,
-    field: string
+    field: string,
   ) => {
     try {
       return await f(field);
@@ -175,7 +175,7 @@ export async function createProfiler(config: Config = {}): Promise<Profiler> {
       `Could not start profiler: node version ${process.version}` +
         ` does not satisfies "${pjson.engines.node}"` +
         '\nSee https://github.com/googleapis/cloud-profiler-nodejs#prerequisites' +
-        ' for details.'
+        ' for details.',
     );
   }
 
@@ -187,7 +187,7 @@ export async function createProfiler(config: Config = {}): Promise<Profiler> {
   if (!localConfig.disableHeap) {
     heapProfiler.start(
       localConfig.heapIntervalBytes,
-      localConfig.heapMaxStackDepth
+      localConfig.heapMaxStackDepth,
     );
   }
   let profilerConfig: ProfilerConfig;

--- a/handwritten/cloud-profiler/src/profiler.ts
+++ b/handwritten/cloud-profiler/src/profiler.ts
@@ -84,7 +84,7 @@ export interface RequestProfile {
 function getResponseErrorMessage(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: r.Response<any>,
-  err: Error | null
+  err: Error | null,
 ): string | undefined {
   if (err && err.message) {
     return err.message;
@@ -180,7 +180,7 @@ async function profileBytes(p: perftools.profiles.IProfile): Promise<string> {
 export class BackoffResponseError extends Error {
   constructor(
     message: string | undefined,
-    readonly backoffMillis: number
+    readonly backoffMillis: number,
   ) {
     super(message);
   }
@@ -207,7 +207,7 @@ export class Retryer {
     readonly initialBackoffMillis: number,
     readonly backoffCapMillis: number,
     readonly backoffMultiplier: number,
-    random = Math.random
+    random = Math.random,
   ) {
     this.nextBackoffMillis = this.initialBackoffMillis;
     this.random = random;
@@ -216,7 +216,7 @@ export class Retryer {
     const curBackoff = this.random() * this.nextBackoffMillis;
     this.nextBackoffMillis = Math.min(
       this.backoffMultiplier * this.nextBackoffMillis,
-      this.backoffCapMillis
+      this.backoffCapMillis,
     );
     return curBackoff;
   }
@@ -235,7 +235,7 @@ function responseToProfileOrError(
   err: Error | null,
   body?: object,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  response?: r.Response<any>
+  response?: r.Response<any>,
 ): RequestProfile {
   // response.statusCode is guaranteed to exist on client requests.
   if (response && isErrorResponseStatusCode(response.statusCode!)) {
@@ -324,7 +324,7 @@ export class Profiler extends ServiceObject {
     this.retryer = new Retryer(
       this.config.initialBackoffMillis,
       this.config.backoffCapMillis,
-      this.config.backoffMultiplier
+      this.config.backoffMultiplier,
     );
   }
 
@@ -342,11 +342,11 @@ export class Profiler extends ServiceObject {
     if (!this.config.disableSourceMaps) {
       try {
         this.sourceMapper = await SourceMapper.create(
-          this.config.sourceMapSearchPath
+          this.config.sourceMapSearchPath,
         );
       } catch (err) {
         this.logger.error(
-          `Failed to initialize SourceMapper. Source map support has been disabled: ${err}`
+          `Failed to initialize SourceMapper. Source map support has been disabled: ${err}`,
         );
         this.config.disableSourceMaps = true;
       }
@@ -379,19 +379,19 @@ export class Profiler extends ServiceObject {
       if (isBackoffResponseError(err as BackoffResponseError)) {
         this.logger.debug(
           `Must wait ${msToStr(
-            (err as BackoffResponseError).backoffMillis
-          )} to create profile: ${err}`
+            (err as BackoffResponseError).backoffMillis,
+          )} to create profile: ${err}`,
         );
         return Math.min(
           (err as BackoffResponseError).backoffMillis,
-          this.config.serverBackoffCapMillis
+          this.config.serverBackoffCapMillis,
         );
       }
       const backoff = this.retryer.getBackoff();
       this.logger.warn(
         `Failed to create profile, waiting ${msToStr(
-          backoff
-        )} to try again: ${err}`
+          backoff,
+        )} to try again: ${err}`,
       );
       return backoff;
     }
@@ -444,18 +444,18 @@ export class Profiler extends ServiceObject {
           err: Error | ApiError | null,
           body?: object,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          response?: r.Response<any>
+          response?: r.Response<any>,
         ) => {
           try {
             const prof = responseToProfileOrError(err, body, response);
             this.logger.debug(
-              `Successfully created profile ${prof.profileType}.`
+              `Successfully created profile ${prof.profileType}.`,
             );
             resolve(prof);
           } catch (err) {
             reject(err);
           }
-        }
+        },
       );
     });
   }
@@ -536,7 +536,7 @@ export class Profiler extends ServiceObject {
     if (!durationMillis) {
       throw Error(
         `Cannot collect time profile, duration "${prof.duration}" cannot` +
-          ' be parsed.'
+          ' be parsed.',
       );
     }
     const options = {
@@ -562,7 +562,7 @@ export class Profiler extends ServiceObject {
     }
     const p = heapProfiler.profile(
       this.config.ignoreHeapSamplesPath,
-      this.sourceMapper
+      this.sourceMapper,
     );
     prof.profileBytes = await profileBytes(p);
     return prof;

--- a/handwritten/cloud-profiler/system-test/test-start.ts
+++ b/handwritten/cloud-profiler/system-test/test-start.ts
@@ -106,32 +106,32 @@ describe('start', () => {
     nock.restore();
     assert.ok(
       uploadedProfiles.length >= 2,
-      'Expected 2 or more profiles to be uploaded'
+      'Expected 2 or more profiles to be uploaded',
     );
   });
   it('should have uploaded wall profile with samples first', async () => {
     const wall = uploadedProfiles[0];
     const decodedBytes = Buffer.from(wall.profileBytes as string, 'base64');
     const unzippedBytes = (await promisify(zlib.gunzip)(
-      decodedBytes
+      decodedBytes,
     )) as Uint8Array;
     const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
     assert.strictEqual(wall.profileType, 'WALL');
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[0].type as number],
-      'sample'
+      'sample',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[1].type as number],
-      'wall'
+      'wall',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[0].unit as number],
-      'count'
+      'count',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[1].unit as number],
-      'microseconds'
+      'microseconds',
     );
     assert.ok(outProfile.sample.length > 0, 'Expected 1 or more samples');
   });
@@ -139,25 +139,25 @@ describe('start', () => {
     const heap = uploadedProfiles[1];
     const decodedBytes = Buffer.from(heap.profileBytes as string, 'base64');
     const unzippedBytes = (await promisify(zlib.gunzip)(
-      decodedBytes
+      decodedBytes,
     )) as Uint8Array;
     const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
     assert.strictEqual(heap.profileType, 'HEAP');
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[0].type as number],
-      'objects'
+      'objects',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[1].type as number],
-      'space'
+      'space',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[0].unit as number],
-      'count'
+      'count',
     );
     assert.strictEqual(
       outProfile.stringTable[outProfile.sampleType[1].unit as number],
-      'bytes'
+      'bytes',
     );
   });
 });

--- a/handwritten/cloud-profiler/test/profiles-for-tests.ts
+++ b/handwritten/cloud-profiler/test/profiles-for-tests.ts
@@ -184,7 +184,7 @@ export const timeProfile: perftools.profiles.IProfile = Object.freeze({
 const encodedTimeProfile =
   perftools.profiles.Profile.encode(timeProfile).finish();
 export const decodedTimeProfile = Object.freeze(
-  perftools.profiles.Profile.decode(encodedTimeProfile)
+  perftools.profiles.Profile.decode(encodedTimeProfile),
 );
 
 const heapLeaf1 = {
@@ -340,7 +340,7 @@ export const heapProfile: perftools.profiles.IProfile = Object.freeze({
 const encodedHeapProfile =
   perftools.profiles.Profile.encode(heapProfile).finish();
 export const decodedHeapProfile = Object.freeze(
-  perftools.profiles.Profile.decode(encodedHeapProfile)
+  perftools.profiles.Profile.decode(encodedHeapProfile),
 );
 
 const heapLinesWithExternal = [
@@ -453,7 +453,7 @@ export const heapProfileWithExternal: perftools.profiles.IProfile =
 // heapProfile is encoded then decoded to convert numbers to longs, in
 // decodedHeapProfile
 export const decodedHeapProfileWithExternal = Object.freeze(
-  perftools.profiles.Profile.decode(encodedHeapProfile)
+  perftools.profiles.Profile.decode(encodedHeapProfile),
 );
 
 const anonymousHeapNode = {
@@ -759,10 +759,10 @@ export const heapProfileIncludePath: perftools.profiles.IProfile =
 // heapProfile is encoded then decoded to convert numbers to longs, in
 // decodedHeapProfile
 const encodedHeapProfileIncludePath = perftools.profiles.Profile.encode(
-  heapProfileIncludePath
+  heapProfileIncludePath,
 ).finish();
 export const decodedHeapProfileIncludePath = Object.freeze(
-  perftools.profiles.Profile.decode(encodedHeapProfileIncludePath)
+  perftools.profiles.Profile.decode(encodedHeapProfileIncludePath),
 );
 
 const heapExcludePathFunctions = [
@@ -824,10 +824,10 @@ export const heapProfileExcludePath: perftools.profiles.IProfile =
 // heapProfile is encoded then decoded to convert numbers to longs, in
 // decodedHeapProfile
 const encodedHeapProfileExcludePath = perftools.profiles.Profile.encode(
-  heapProfileExcludePath
+  heapProfileExcludePath,
 ).finish();
 export const decodedHeapProfileExcludePath = Object.freeze(
-  perftools.profiles.Profile.decode(encodedHeapProfileExcludePath)
+  perftools.profiles.Profile.decode(encodedHeapProfileExcludePath),
 );
 
 const mapDir = tmp.dirSync();

--- a/handwritten/cloud-profiler/test/test-init-config.ts
+++ b/handwritten/cloud-profiler/test/test-init-config.ts
@@ -33,7 +33,7 @@ describe('nodeVersionOkay', () => {
   it('should accept nightly versions', () => {
     assert.strictEqual(
       true,
-      nodeVersionOkay(`v${version}.0.0-nightly2018000000`)
+      nodeVersionOkay(`v${version}.0.0-nightly2018000000`),
     );
   });
   it('should accept pre-release versions', () => {
@@ -118,7 +118,7 @@ describe('createProfiler', () => {
         zone: 'zone',
         projectId: 'fake-projectId',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
 
     const profiler: Profiler = await createProfiler(config);
@@ -146,7 +146,7 @@ describe('createProfiler', () => {
         zone: 'zone',
         projectId: 'fake-projectId',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const profiler: Profiler = await createProfiler(config);
     const expConfig = Object.assign({}, defaultConfig, config);
@@ -169,7 +169,7 @@ describe('createProfiler', () => {
         disableHeap: true,
         disableTime: true,
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const expConfigParams = {
       projectId: 'gce-project',
@@ -185,7 +185,7 @@ describe('createProfiler', () => {
       {},
       defaultConfig,
       disableSourceMapParams,
-      expConfigParams
+      expConfigParams,
     );
     assert.deepStrictEqual(profiler.config, expConfig);
   });
@@ -200,7 +200,7 @@ describe('createProfiler', () => {
         projectId: 'fake-projectId',
         serviceContext: {service: 'fake-service'},
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const expConfigParams = {
       logLevel: 2,
@@ -214,7 +214,7 @@ describe('createProfiler', () => {
       {},
       defaultConfig,
       disableSourceMapParams,
-      expConfigParams
+      expConfigParams,
     );
     assert.deepStrictEqual(profiler.config, expConfig);
   });
@@ -231,7 +231,7 @@ describe('createProfiler', () => {
         disableHeap: true,
         disableTime: true,
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     await createProfiler(config)
       .then(() => {
@@ -240,7 +240,7 @@ describe('createProfiler', () => {
       .catch((e: Error) => {
         assert.strictEqual(
           e.message,
-          'Service must be specified in the configuration'
+          'Service must be specified in the configuration',
         );
       });
   });
@@ -262,7 +262,7 @@ describe('createProfiler', () => {
     } catch (e) {
       assert.strictEqual(
         (e as Error).message,
-        'Service serviceName does not match regular expression "/^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$/"'
+        'Service serviceName does not match regular expression "/^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$/"',
       );
     }
   });
@@ -281,7 +281,7 @@ describe('createProfiler', () => {
         instance: 'instance',
         zone: 'zone',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     try {
       await createProfiler(config);
@@ -289,7 +289,7 @@ describe('createProfiler', () => {
     } catch (e) {
       assert.strictEqual(
         (e as Error).message,
-        'Project ID must be specified in the configuration'
+        'Project ID must be specified in the configuration',
       );
     }
   });
@@ -310,14 +310,14 @@ describe('createProfiler', () => {
         zone: 'zone',
         sourceMapSearchPath: ['path'],
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const profiler: Profiler = await createProfiler(config);
     const expConfig = Object.assign(
       {},
       config,
       disableSourceMapParams,
-      defaultConfig
+      defaultConfig,
     );
     assert.deepStrictEqual(profiler.config, expConfig);
   });
@@ -342,7 +342,7 @@ describe('createProfiler', () => {
       assert.strictEqual(
         (e as Error).message,
         'serviceMapSearchPath is an empty array. Use disableSourceMaps ' +
-          'to disable source map support instead.'
+          'to disable source map support instead.',
       );
     }
   });
@@ -359,7 +359,7 @@ describe('createProfiler', () => {
         apiEndpoint: 'test-cloudprofiler.sandbox.googleapis.com',
         serviceContext: {version: '', service: 'fake-service'},
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const expConfigParams = {
       projectId: 'project',
@@ -373,7 +373,7 @@ describe('createProfiler', () => {
       {},
       defaultConfig,
       disableSourceMapParams,
-      expConfigParams
+      expConfigParams,
     );
     const profiler: Profiler = await createProfiler(config);
     assert.deepStrictEqual(profiler.config, expConfig);
@@ -421,7 +421,7 @@ describe('createProfiler', () => {
     projectMetadataStub.throwsException('cannot access metadata');
     const config = Object.assign(
       {projectId: 'project'},
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const expConfigParams = {
       serviceContext: {version: 'k-version', service: 'k-service'},
@@ -445,7 +445,7 @@ describe('createProfiler', () => {
     projectMetadataStub.throwsException('cannot access metadata');
     const config = Object.assign(
       {projectId: 'project'},
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const expConfigParams = {
       serviceContext: {
@@ -489,7 +489,7 @@ describe('createProfiler', () => {
         instance: 'instance',
         zone: 'zone',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     const profiler: Profiler = await createProfiler(config);
     const expConfig = Object.assign({}, config, defaultConfig);
@@ -530,12 +530,12 @@ describe('createProfiler', () => {
         instance: 'envConfig-instance',
         zone: 'envConfig-zone',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     await createProfiler(config);
     assert.ok(
       startStub.calledWith(1024 * 512, 64),
-      'expected heap profiler to be started'
+      'expected heap profiler to be started',
     );
   });
   it('should start not heap profiler when disableHeap is true', async () => {
@@ -547,7 +547,7 @@ describe('createProfiler', () => {
         instance: 'envConfig-instance',
         zone: 'envConfig-zone',
       },
-      disableSourceMapParams
+      disableSourceMapParams,
     );
     await createProfiler(config);
     assert.ok(!startStub.called, 'expected heap profiler to not be started');

--- a/handwritten/cloud-profiler/test/test-profiler.ts
+++ b/handwritten/cloud-profiler/test/test-profiler.ts
@@ -106,7 +106,7 @@ describe('Profiler', () => {
   beforeEach(() => {
     sinonStubs.push(sinon.stub(timeProfiler, 'start'));
     sinonStubs.push(
-      sinon.stub(timeProfiler, 'profile').returns(Promise.resolve(timeProfile))
+      sinon.stub(timeProfiler, 'profile').returns(Promise.resolve(timeProfile)),
     );
 
     sinonStubs.push(sinon.stub(heapProfiler, 'stop'));
@@ -131,7 +131,7 @@ describe('Profiler', () => {
       const prof = await profiler.profile(requestProf);
       const decodedBytes = Buffer.from(prof.profileBytes as 'string', 'base64');
       const unzippedBytes = (await promisify(zlib.gunzip)(
-        decodedBytes
+        decodedBytes,
       )) as Uint8Array;
       const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
       assert.deepStrictEqual(decodedTimeProfile, outProfile);
@@ -146,7 +146,7 @@ describe('Profiler', () => {
       const prof = await profiler.profile(requestProf);
       const decodedBytes = Buffer.from(prof.profileBytes as 'string', 'base64');
       const unzippedBytes = (await promisify(zlib.gunzip)(
-        decodedBytes
+        decodedBytes,
       )) as Uint8Array;
       const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
       assert.deepStrictEqual(decodedHeapProfile, outProfile);
@@ -165,7 +165,7 @@ describe('Profiler', () => {
       } catch (err) {
         assert.strictEqual(
           (err as Error).message,
-          'Unexpected profile type UNKNOWN.'
+          'Unexpected profile type UNKNOWN.',
         );
       }
     });
@@ -193,14 +193,14 @@ describe('Profiler', () => {
 
         const decodedBytes = Buffer.from(encodedBytes as string, 'base64');
         const unzippedBytes = (await promisify(zlib.gunzip)(
-          decodedBytes
+          decodedBytes,
         )) as Uint8Array;
         const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
 
         // compare to decodedTimeProfile, which is equivalent to timeProfile,
         // but numbers are replaced with longs.
         assert.deepStrictEqual(decodedTimeProfile, outProfile);
-      }
+      },
     );
     it('should throw error when time profiling is not enabled.', async () => {
       const config = extend(true, {}, testConfig);
@@ -218,7 +218,7 @@ describe('Profiler', () => {
       } catch (err) {
         assert.strictEqual(
           (err as Error).message,
-          'Cannot collect time profile, time profiler not enabled.'
+          'Cannot collect time profile, time profiler not enabled.',
         );
       }
     });
@@ -245,14 +245,14 @@ describe('Profiler', () => {
 
         const decodedBytes = Buffer.from(encodedBytes as string, 'base64');
         const unzippedBytes = (await promisify(zlib.gunzip)(
-          decodedBytes
+          decodedBytes,
         )) as Uint8Array;
         const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
 
         // compare to decodedTimeProfile, which is equivalent to timeProfile,
         // but numbers are replaced with longs.
         assert.deepStrictEqual(decodedHeapProfile, outProfile);
-      }
+      },
     );
     it('should throw error when heap profiling is not enabled.', async () => {
       const config = extend(true, {}, testConfig);
@@ -269,7 +269,7 @@ describe('Profiler', () => {
       } catch (err) {
         assert.strictEqual(
           (err as Error).message,
-          'Cannot collect heap profile, heap profiler not enabled.'
+          'Cannot collect heap profile, heap profiler not enabled.',
         );
       }
     });
@@ -304,10 +304,10 @@ describe('Profiler', () => {
       };
       const decodedBytes = Buffer.from(
         uploaded.profileBytes as string,
-        'base64'
+        'base64',
       );
       const unzippedBytes = (await promisify(zlib.gunzip)(
-        decodedBytes
+        decodedBytes,
       )) as Uint8Array;
       const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
       assert.deepStrictEqual(decodedTimeProfile, outProfile);
@@ -335,10 +335,10 @@ describe('Profiler', () => {
       };
       const decodedBytes = Buffer.from(
         uploaded.profileBytes as string,
-        'base64'
+        'base64',
       );
       const unzippedBytes = (await promisify(zlib.gunzip)(
-        decodedBytes
+        decodedBytes,
       )) as Uint8Array;
       const outProfile = perftools.profiles.Profile.decode(unzippedBytes);
       assert.deepStrictEqual(decodedHeapProfile, outProfile);
@@ -387,7 +387,7 @@ describe('Profiler', () => {
           1,
           null,
           {},
-          {statusCode: 500, statusMessage: 'Error 500'}
+          {statusCode: 500, statusMessage: 'Error 500'},
         );
       const profiler = new Profiler(testConfig);
       await profiler.profileAndUpload(requestProf);
@@ -412,7 +412,7 @@ describe('Profiler', () => {
       assert.strictEqual(
         apiMock.isDone(),
         false,
-        'call to upload profile should not be retried'
+        'call to upload profile should not be retried',
       );
     });
     it('should send request to upload profile to default API without error.', async () => {
@@ -541,7 +541,7 @@ describe('Profiler', () => {
         assert.strictEqual(
           (err as Error).message,
           'Profile not valid: ' +
-            '{"name":"projects/12345678901/test-projectId"}.'
+            '{"name":"projects/12345678901/test-projectId"}.',
         );
       }
     });
@@ -601,9 +601,9 @@ describe('Profiler', () => {
         assert.deepStrictEqual(response, actualResponse);
         assert.deepStrictEqual(
           expRequestBody,
-          requestStub.firstCall.args[0].body
+          requestStub.firstCall.args[0].body,
         );
-      }
+      },
     );
     it(
       'should not have instance and zone in request body when instance and' +
@@ -634,9 +634,9 @@ describe('Profiler', () => {
         assert.deepStrictEqual(response, actualResponse);
         assert.deepStrictEqual(
           expRequestBody,
-          requestStub.firstCall.args[0].body
+          requestStub.firstCall.args[0].body,
         );
-      }
+      },
     );
     it('should keep additional fields in request profile.', async () => {
       const response = {
@@ -696,7 +696,7 @@ describe('Profiler', () => {
             1,
             undefined,
             {error: {details: [{retryDelay: '50s'}]}},
-            {statusCode: 409}
+            {statusCode: 409},
           );
 
         const profiler = new Profiler(testConfig);
@@ -706,10 +706,10 @@ describe('Profiler', () => {
         } catch (err) {
           assert.strictEqual(
             (err as BackoffResponseError).backoffMillis,
-            50000
+            50000,
           );
         }
-      }
+      },
     );
     it('should throw error when response undefined', async () => {
       requestStub = sinon
@@ -724,7 +724,7 @@ describe('Profiler', () => {
       } catch (err) {
         assert.strictEqual(
           (err as Error).message,
-          'Profile not valid: undefined.'
+          'Profile not valid: undefined.',
         );
       }
     });
@@ -772,7 +772,7 @@ describe('Profiler', () => {
       assert.strictEqual(
         0,
         delayMillis,
-        'No delay before asking to collect next profile'
+        'No delay before asking to collect next profile',
       );
     });
     it(
@@ -787,7 +787,7 @@ describe('Profiler', () => {
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.deepStrictEqual(EXPECTED_BACKOFF, delayMillis);
-      }
+      },
     );
     it('should reset backoff after success', async () => {
       const createProfileResponseBody = {
@@ -822,7 +822,7 @@ describe('Profiler', () => {
           1,
           new Error('error creating profile'),
           undefined,
-          undefined
+          undefined,
         );
       const profiler = new Profiler(testConfig);
       let delayMillis = await profiler.collectProfile();
@@ -847,12 +847,12 @@ describe('Profiler', () => {
             1,
             undefined,
             {error: {details: [{retryDelay: '50s'}]}},
-            {statusCode: 409}
+            {statusCode: 409},
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.strictEqual(50000, delayMillis);
-      }
+      },
     );
     it(
       'should return expected backoff when non-200 error and invalid server backoff' +
@@ -868,12 +868,12 @@ describe('Profiler', () => {
             {
               statusCode: 409,
               body: {message: 'some message'},
-            }
+            },
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.strictEqual(EXPECTED_BACKOFF, delayMillis);
-      }
+      },
     );
     it(
       'should return expected backoff when non-200 error and invalid server backoff' +
@@ -886,12 +886,12 @@ describe('Profiler', () => {
             1,
             undefined,
             {error: {details: [{retryDelay: 'not a duration'}]}},
-            {statusCode: 409}
+            {statusCode: 409},
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.strictEqual(EXPECTED_BACKOFF, delayMillis);
-      }
+      },
     );
     it(
       'should return backoff limit, when server specified backoff is greater' +
@@ -904,12 +904,12 @@ describe('Profiler', () => {
             1,
             undefined,
             {error: {details: [{retryDelay: '1000h'}]}},
-            {statusCode: 409}
+            {statusCode: 409},
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.strictEqual(ms('7d'), delayMillis);
-      }
+      },
     );
     it(
       'should indicate collectProfile should be called immediately if there' +
@@ -933,7 +933,7 @@ describe('Profiler', () => {
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
         assert.strictEqual(0, delayMillis);
-      }
+      },
     );
   });
 });

--- a/handwritten/datastore/src/v1/datastore_admin_client.ts
+++ b/handwritten/datastore/src/v1/datastore_admin_client.ts
@@ -28,10 +28,10 @@ import type {
   PaginationCallback,
   GaxCall,
 } from 'google-gax';
-import { Transform } from 'stream';
+import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -99,7 +99,7 @@ export class DatastoreAdminClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('datastore-admin');
@@ -112,9 +112,9 @@ export class DatastoreAdminClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
+  innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
-  datastoreAdminStub?: Promise<{ [name: string]: Function }>;
+  datastoreAdminStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of DatastoreAdminClient.
@@ -190,7 +190,7 @@ export class DatastoreAdminClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // Request numeric enum values if REST transport is used.
     opts.numericEnums = true;
@@ -342,7 +342,7 @@ export class DatastoreAdminClient {
       'google.datastore.admin.v1.DatastoreAdmin',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -382,7 +382,7 @@ export class DatastoreAdminClient {
           (this._protos as any).google.datastore.admin.v1.DatastoreAdmin,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -396,7 +396,7 @@ export class DatastoreAdminClient {
     ];
     for (const methodName of datastoreAdminStubMethods) {
       const callPromise = this.datastoreAdminStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               return Promise.reject('The client has already been closed.');
@@ -595,7 +595,7 @@ export class DatastoreAdminClient {
         project_id: request.projectId?.toString() ?? '',
         index_id: request.indexId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('getIndex request %j', request);
@@ -770,7 +770,7 @@ export class DatastoreAdminClient {
       this._gaxModule.routingHeader.fromParams({
         project_id: request.projectId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     const wrappedCallback:
@@ -827,7 +827,7 @@ export class DatastoreAdminClient {
     this._log.info('exportEntities long-running');
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        { name },
+        {name},
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
@@ -965,7 +965,7 @@ export class DatastoreAdminClient {
       this._gaxModule.routingHeader.fromParams({
         project_id: request.projectId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     const wrappedCallback:
@@ -1022,7 +1022,7 @@ export class DatastoreAdminClient {
     this._log.info('importEntities long-running');
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        { name },
+        {name},
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
@@ -1150,7 +1150,7 @@ export class DatastoreAdminClient {
       this._gaxModule.routingHeader.fromParams({
         project_id: request.projectId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     const wrappedCallback:
@@ -1207,7 +1207,7 @@ export class DatastoreAdminClient {
     this._log.info('createIndex long-running');
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        { name },
+        {name},
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
@@ -1332,7 +1332,7 @@ export class DatastoreAdminClient {
         project_id: request.projectId?.toString() ?? '',
         index_id: request.indexId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     const wrappedCallback:
@@ -1389,7 +1389,7 @@ export class DatastoreAdminClient {
     this._log.info('deleteIndex long-running');
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        { name },
+        {name},
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
@@ -1494,7 +1494,7 @@ export class DatastoreAdminClient {
       this._gaxModule.routingHeader.fromParams({
         project_id: request.projectId?.toString() ?? '',
       });
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     const wrappedCallback:
@@ -1563,7 +1563,7 @@ export class DatastoreAdminClient {
       });
     const defaultCallSettings = this._defaults['listIndexes'];
     const callSettings = defaultCallSettings.merge(options);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('listIndexes stream %j', request);
@@ -1614,7 +1614,7 @@ export class DatastoreAdminClient {
       });
     const defaultCallSettings = this._defaults['listIndexes'];
     const callSettings = defaultCallSettings.merge(options);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('listIndexes iterate %j', request);
@@ -1855,7 +1855,7 @@ export class DatastoreAdminClient {
    */
   close(): Promise<void> {
     if (this.datastoreAdminStub && !this._terminated) {
-      return this.datastoreAdminStub.then((stub) => {
+      return this.datastoreAdminStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/datastore/src/v1/datastore_client.ts
+++ b/handwritten/datastore/src/v1/datastore_client.ts
@@ -28,7 +28,7 @@ import type {
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
-import { loggingUtils as logging, decodeAnyProtosInArray } from 'google-gax';
+import {loggingUtils as logging, decodeAnyProtosInArray} from 'google-gax';
 
 /**
  * Client JSON configuration object, loaded from
@@ -56,7 +56,7 @@ export class DatastoreClient {
   private _gaxModule: typeof gax | typeof gax.fallback;
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
-  private _defaults: { [method: string]: gax.CallSettings };
+  private _defaults: {[method: string]: gax.CallSettings};
   private _universeDomain: string;
   private _servicePath: string;
   private _log = logging.log('datastore');
@@ -69,9 +69,9 @@ export class DatastoreClient {
     batching: {},
   };
   warn: (code: string, message: string, warnType?: string) => void;
-  innerApiCalls: { [name: string]: Function };
+  innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
-  datastoreStub?: Promise<{ [name: string]: Function }>;
+  datastoreStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of DatastoreClient.
@@ -147,7 +147,7 @@ export class DatastoreClient {
     const fallback =
       opts?.fallback ??
       (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({ servicePath, port, clientConfig, fallback }, opts);
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // Request numeric enum values if REST transport is used.
     opts.numericEnums = true;
@@ -243,7 +243,7 @@ export class DatastoreClient {
       'google.datastore.v1.Datastore',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      { 'x-goog-api-client': clientHeader.join(' ') },
+      {'x-goog-api-client': clientHeader.join(' ')},
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -283,7 +283,7 @@ export class DatastoreClient {
           (this._protos as any).google.datastore.v1.Datastore,
       this._opts,
       this._providedCustomServicePath,
-    ) as Promise<{ [method: string]: Function }>;
+    ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -299,7 +299,7 @@ export class DatastoreClient {
     ];
     for (const methodName of datastoreStubMethods) {
       const callPromise = this.datastoreStub.then(
-        (stub) =>
+        stub =>
           (...args: Array<{}>) => {
             if (this._terminated) {
               return Promise.reject('The client has already been closed.');
@@ -511,7 +511,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -521,13 +521,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('lookup request %j', request);
@@ -679,7 +679,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -689,13 +689,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('runQuery request %j', request);
@@ -843,7 +843,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -853,13 +853,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('runAggregationQuery request %j', request);
@@ -997,7 +997,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -1007,13 +1007,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('beginTransaction request %j', request);
@@ -1173,7 +1173,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -1183,13 +1183,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('commit request %j', request);
@@ -1324,7 +1324,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -1334,13 +1334,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('rollback request %j', request);
@@ -1476,7 +1476,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -1486,13 +1486,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('allocateIds request %j', request);
@@ -1628,7 +1628,7 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<project_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['project_id'] ?? fieldValue;
-          Object.assign(routingParameter, { project_id: parameterValue });
+          Object.assign(routingParameter, {project_id: parameterValue});
         }
       }
     }
@@ -1638,13 +1638,13 @@ export class DatastoreClient {
         const match = fieldValue.toString().match(RegExp('(?<database_id>.*)'));
         if (match) {
           const parameterValue = match.groups?.['database_id'] ?? fieldValue;
-          Object.assign(routingParameter, { database_id: parameterValue });
+          Object.assign(routingParameter, {database_id: parameterValue});
         }
       }
     }
     options.otherArgs.headers['x-goog-request-params'] =
       this._gaxModule.routingHeader.fromParams(routingParameter);
-    this.initialize().catch((err) => {
+    this.initialize().catch(err => {
       throw err;
     });
     this._log.info('reserveIds request %j', request);
@@ -1921,7 +1921,7 @@ export class DatastoreClient {
    */
   close(): Promise<void> {
     if (this.datastoreStub && !this._terminated) {
-      return this.datastoreStub.then((stub) => {
+      return this.datastoreStub.then(stub => {
         this._log.info('ending gRPC channel');
         this._terminated = true;
         stub.close();

--- a/handwritten/datastore/system-test/fixtures/sample/src/index.ts
+++ b/handwritten/datastore/system-test/fixtures/sample/src/index.ts
@@ -16,7 +16,7 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import { Datastore } from '@google-cloud/datastore';
+import {Datastore} from '@google-cloud/datastore';
 
 // check that the client class type name can be used
 function doStuffWithDatastore(client: Datastore) {

--- a/handwritten/datastore/system-test/install.ts
+++ b/handwritten/datastore/system-test/install.ts
@@ -16,9 +16,9 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import { packNTest } from 'pack-n-play';
-import { readFileSync } from 'fs';
-import { describe, it } from 'mocha';
+import {packNTest} from 'pack-n-play';
+import {readFileSync} from 'fs';
+import {describe, it} from 'mocha';
 
 describe('📦 pack-n-play test', () => {
   it('TypeScript code', async function () {

--- a/handwritten/datastore/test/gapic_datastore_admin_v1.ts
+++ b/handwritten/datastore/test/gapic_datastore_admin_v1.ts
@@ -19,13 +19,13 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as datastoreadminModule from '../src';
 
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
-import { protobuf, LROperation, operationsProtos } from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -45,7 +45,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -149,9 +149,9 @@ function stubAsyncIterationCall<ResponseType>(
             return Promise.reject(error);
           }
           if (counter >= responses!.length) {
-            return Promise.resolve({ done: true, value: undefined });
+            return Promise.resolve({done: true, value: undefined});
           }
-          return Promise.resolve({ done: false, value: responses![counter++] });
+          return Promise.resolve({done: false, value: responses![counter++]});
         },
       };
     },
@@ -271,7 +271,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.datastoreAdminStub, undefined);
@@ -279,12 +279,12 @@ describe('v1.DatastoreAdminClient', () => {
       assert(client.datastoreAdminStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.datastoreAdminStub);
@@ -293,14 +293,14 @@ describe('v1.DatastoreAdminClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.datastoreAdminStub, undefined);
@@ -309,7 +309,7 @@ describe('v1.DatastoreAdminClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -317,7 +317,7 @@ describe('v1.DatastoreAdminClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -329,7 +329,7 @@ describe('v1.DatastoreAdminClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -352,7 +352,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('getIndex', () => {
     it('invokes getIndex without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -388,7 +388,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes getIndex without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -440,7 +440,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes getIndex with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -473,7 +473,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes getIndex with closed client', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -491,7 +491,7 @@ describe('v1.DatastoreAdminClient', () => {
       );
       request.indexId = defaultValue2;
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.getIndex(request), expectedError);
@@ -501,7 +501,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('exportEntities', () => {
     it('invokes exportEntities without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -534,7 +534,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes exportEntities without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -588,7 +588,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes exportEntities with call error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -619,7 +619,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes exportEntities with LRO error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -652,7 +652,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkExportEntitiesProgress without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -660,8 +660,8 @@ describe('v1.DatastoreAdminClient', () => {
         new operationsProtos.google.longrunning.Operation(),
       );
       expectedResponse.name = 'test';
-      expectedResponse.response = { type_url: 'url', value: Buffer.from('') };
-      expectedResponse.metadata = { type_url: 'url', value: Buffer.from('') };
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkExportEntitiesProgress(
@@ -674,7 +674,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkExportEntitiesProgress with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -695,7 +695,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('importEntities', () => {
     it('invokes importEntities without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -728,7 +728,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes importEntities without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -782,7 +782,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes importEntities with call error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -813,7 +813,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes importEntities with LRO error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -846,7 +846,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkImportEntitiesProgress without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -854,8 +854,8 @@ describe('v1.DatastoreAdminClient', () => {
         new operationsProtos.google.longrunning.Operation(),
       );
       expectedResponse.name = 'test';
-      expectedResponse.response = { type_url: 'url', value: Buffer.from('') };
-      expectedResponse.metadata = { type_url: 'url', value: Buffer.from('') };
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkImportEntitiesProgress(
@@ -868,7 +868,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkImportEntitiesProgress with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -889,7 +889,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('createIndex', () => {
     it('invokes createIndex without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -921,7 +921,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes createIndex without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -975,7 +975,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes createIndex with call error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1006,7 +1006,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes createIndex with LRO error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1039,7 +1039,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkCreateIndexProgress without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1047,8 +1047,8 @@ describe('v1.DatastoreAdminClient', () => {
         new operationsProtos.google.longrunning.Operation(),
       );
       expectedResponse.name = 'test';
-      expectedResponse.response = { type_url: 'url', value: Buffer.from('') };
-      expectedResponse.metadata = { type_url: 'url', value: Buffer.from('') };
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkCreateIndexProgress(
@@ -1061,7 +1061,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkCreateIndexProgress with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1079,7 +1079,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('deleteIndex', () => {
     it('invokes deleteIndex without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1116,7 +1116,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes deleteIndex without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1175,7 +1175,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes deleteIndex with call error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1211,7 +1211,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes deleteIndex with LRO error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1249,7 +1249,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkDeleteIndexProgress without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1257,8 +1257,8 @@ describe('v1.DatastoreAdminClient', () => {
         new operationsProtos.google.longrunning.Operation(),
       );
       expectedResponse.name = 'test';
-      expectedResponse.response = { type_url: 'url', value: Buffer.from('') };
-      expectedResponse.metadata = { type_url: 'url', value: Buffer.from('') };
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkDeleteIndexProgress(
@@ -1271,7 +1271,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes checkDeleteIndexProgress with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1289,7 +1289,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('listIndexes', () => {
     it('invokes listIndexes without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1322,7 +1322,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes listIndexes without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1371,7 +1371,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes listIndexes with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1402,7 +1402,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes listIndexesStream without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1456,7 +1456,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('invokes listIndexesStream with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1507,7 +1507,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('uses async iteration with listIndexes without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1550,7 +1550,7 @@ describe('v1.DatastoreAdminClient', () => {
 
     it('uses async iteration with listIndexes with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1593,7 +1593,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('getOperation', () => {
     it('invokes getOperation without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1614,7 +1614,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes getOperation without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1642,7 +1642,7 @@ describe('v1.DatastoreAdminClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1652,7 +1652,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes getOperation with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1676,7 +1676,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('cancelOperation', () => {
     it('invokes cancelOperation without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1698,7 +1698,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes cancelOperation without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1726,7 +1726,7 @@ describe('v1.DatastoreAdminClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1736,7 +1736,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes cancelOperation with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1760,7 +1760,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('deleteOperation', () => {
     it('invokes deleteOperation without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1782,7 +1782,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes deleteOperation without error using callback', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1810,7 +1810,7 @@ describe('v1.DatastoreAdminClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1820,7 +1820,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('invokes deleteOperation with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1844,7 +1844,7 @@ describe('v1.DatastoreAdminClient', () => {
   describe('listOperationsAsync', () => {
     it('uses async iteration with listOperations without error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1879,7 +1879,7 @@ describe('v1.DatastoreAdminClient', () => {
     });
     it('uses async iteration with listOperations with error', async () => {
       const client = new datastoreadminModule.v1.DatastoreAdminClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/datastore/test/gapic_datastore_v1.ts
+++ b/handwritten/datastore/test/gapic_datastore_v1.ts
@@ -19,11 +19,11 @@
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import { describe, it } from 'mocha';
+import {SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
 import * as datastoreModule from '../src';
 
-import { protobuf, operationsProtos } from 'google-gax';
+import {protobuf, operationsProtos} from 'google-gax';
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
@@ -43,7 +43,7 @@ function getTypeDefaultValue(typeName: string, fields: string[]) {
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (
     instance.constructor as typeof protobuf.Message
-  ).toObject(instance as protobuf.Message<T>, { defaults: true });
+  ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject,
   ) as T;
@@ -77,9 +77,9 @@ function stubAsyncIterationCall<ResponseType>(
             return Promise.reject(error);
           }
           if (counter >= responses!.length) {
-            return Promise.resolve({ done: true, value: undefined });
+            return Promise.resolve({done: true, value: undefined});
           }
-          return Promise.resolve({ done: false, value: responses![counter++] });
+          return Promise.resolve({done: false, value: responses![counter++]});
         },
       };
     },
@@ -197,7 +197,7 @@ describe('v1.DatastoreClient', () => {
 
     it('has initialize method and supports deferred initialization', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.datastoreStub, undefined);
@@ -205,12 +205,12 @@ describe('v1.DatastoreClient', () => {
       assert(client.datastoreStub);
     });
 
-    it('has close method for the initialized client', (done) => {
+    it('has close method for the initialized client', done => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-      client.initialize().catch((err) => {
+      client.initialize().catch(err => {
         throw err;
       });
       assert(client.datastoreStub);
@@ -219,14 +219,14 @@ describe('v1.DatastoreClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
 
-    it('has close method for the non-initialized client', (done) => {
+    it('has close method for the non-initialized client', done => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       assert.strictEqual(client.datastoreStub, undefined);
@@ -235,7 +235,7 @@ describe('v1.DatastoreClient', () => {
         .then(() => {
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           throw err;
         });
     });
@@ -243,7 +243,7 @@ describe('v1.DatastoreClient', () => {
     it('has getProjectId method', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
@@ -255,7 +255,7 @@ describe('v1.DatastoreClient', () => {
     it('has getProjectId method with callback', async () => {
       const fakeProjectId = 'fake-project-id';
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       client.auth.getProjectId = sinon
@@ -278,7 +278,7 @@ describe('v1.DatastoreClient', () => {
   describe('lookup', () => {
     it('invokes lookup without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -306,7 +306,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes lookup without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -350,7 +350,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes lookup with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -375,7 +375,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes lookup with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -385,7 +385,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.lookup(request), expectedError);
@@ -395,7 +395,7 @@ describe('v1.DatastoreClient', () => {
   describe('runQuery', () => {
     it('invokes runQuery without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -423,7 +423,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runQuery without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -467,7 +467,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runQuery with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -492,7 +492,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runQuery with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -502,7 +502,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.runQuery(request), expectedError);
@@ -512,7 +512,7 @@ describe('v1.DatastoreClient', () => {
   describe('runAggregationQuery', () => {
     it('invokes runAggregationQuery without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -541,7 +541,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runAggregationQuery without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -585,7 +585,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runAggregationQuery with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -613,7 +613,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes runAggregationQuery with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -623,7 +623,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.runAggregationQuery(request), expectedError);
@@ -633,7 +633,7 @@ describe('v1.DatastoreClient', () => {
   describe('beginTransaction', () => {
     it('invokes beginTransaction without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -661,7 +661,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes beginTransaction without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -705,7 +705,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes beginTransaction with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -733,7 +733,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes beginTransaction with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -743,7 +743,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.beginTransaction(request), expectedError);
@@ -753,7 +753,7 @@ describe('v1.DatastoreClient', () => {
   describe('commit', () => {
     it('invokes commit without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -781,7 +781,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes commit without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -825,7 +825,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes commit with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -850,7 +850,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes commit with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -860,7 +860,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.commit(request), expectedError);
@@ -870,7 +870,7 @@ describe('v1.DatastoreClient', () => {
   describe('rollback', () => {
     it('invokes rollback without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -898,7 +898,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes rollback without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -942,7 +942,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes rollback with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -967,7 +967,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes rollback with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -977,7 +977,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.rollback(request), expectedError);
@@ -987,7 +987,7 @@ describe('v1.DatastoreClient', () => {
   describe('allocateIds', () => {
     it('invokes allocateIds without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1015,7 +1015,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes allocateIds without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1059,7 +1059,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes allocateIds with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1087,7 +1087,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes allocateIds with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1097,7 +1097,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.allocateIds(request), expectedError);
@@ -1107,7 +1107,7 @@ describe('v1.DatastoreClient', () => {
   describe('reserveIds', () => {
     it('invokes reserveIds without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1135,7 +1135,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes reserveIds without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1179,7 +1179,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes reserveIds with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1207,7 +1207,7 @@ describe('v1.DatastoreClient', () => {
 
     it('invokes reserveIds with closed client', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1217,7 +1217,7 @@ describe('v1.DatastoreClient', () => {
       // path template is empty
       request.databaseId = 'value';
       const expectedError = new Error('The client has already been closed.');
-      client.close().catch((err) => {
+      client.close().catch(err => {
         throw err;
       });
       await assert.rejects(client.reserveIds(request), expectedError);
@@ -1226,7 +1226,7 @@ describe('v1.DatastoreClient', () => {
   describe('getOperation', () => {
     it('invokes getOperation without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1247,7 +1247,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes getOperation without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1275,7 +1275,7 @@ describe('v1.DatastoreClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1285,7 +1285,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes getOperation with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1309,7 +1309,7 @@ describe('v1.DatastoreClient', () => {
   describe('cancelOperation', () => {
     it('invokes cancelOperation without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1331,7 +1331,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes cancelOperation without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1359,7 +1359,7 @@ describe('v1.DatastoreClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1369,7 +1369,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes cancelOperation with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1393,7 +1393,7 @@ describe('v1.DatastoreClient', () => {
   describe('deleteOperation', () => {
     it('invokes deleteOperation without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();
@@ -1415,7 +1415,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes deleteOperation without error using callback', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1443,7 +1443,7 @@ describe('v1.DatastoreClient', () => {
               }
             },
           )
-          .catch((err) => {
+          .catch(err => {
             throw err;
           });
       });
@@ -1453,7 +1453,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('invokes deleteOperation with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1477,7 +1477,7 @@ describe('v1.DatastoreClient', () => {
   describe('listOperationsAsync', () => {
     it('uses async iteration with listOperations without error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
@@ -1512,7 +1512,7 @@ describe('v1.DatastoreClient', () => {
     });
     it('uses async iteration with listOperations with error', async () => {
       const client = new datastoreModule.v1.DatastoreClient({
-        credentials: { client_email: 'bogus', private_key: 'bogus' },
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
       await client.initialize();

--- a/handwritten/google-cloud-dns/src/change.ts
+++ b/handwritten/google-cloud-dns/src/change.ts
@@ -234,7 +234,7 @@ export class Change extends ServiceObject {
    */
   create(
     configOrCallback?: CreateChangeRequest | CreateChangeCallback,
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     const config = typeof configOrCallback === 'object' ? configOrCallback : {};
     callback =

--- a/handwritten/google-cloud-dns/src/index.ts
+++ b/handwritten/google-cloud-dns/src/index.ts
@@ -41,7 +41,7 @@ export interface GetZonesCallback {
     err: Error | null,
     zones: Zone[] | null,
     nextQuery?: GetZonesRequest | null,
-    apiResponse?: Metadata
+    apiResponse?: Metadata,
   ): void;
 }
 
@@ -208,12 +208,12 @@ class DNS extends Service {
 
   createZone(
     name: string,
-    config: CreateZoneRequest
+    config: CreateZoneRequest,
   ): Promise<CreateZoneResponse>;
   createZone(
     name: string,
     config: CreateZoneRequest,
-    callback: GetZoneCallback
+    callback: GetZoneCallback,
   ): void;
   /**
    * Config to set for the zone.
@@ -275,7 +275,7 @@ class DNS extends Service {
   createZone(
     name: string,
     config: CreateZoneRequest,
-    callback?: GetZoneCallback
+    callback?: GetZoneCallback,
   ): void | Promise<CreateZoneResponse> {
     if (!name) {
       throw new Error('A zone name is required.');
@@ -300,7 +300,7 @@ class DNS extends Service {
         const zone = this.zone(resp.name);
         zone.metadata = resp;
         callback!(null, zone, resp);
-      }
+      },
     );
   }
 
@@ -355,7 +355,7 @@ class DNS extends Service {
    */
   getZones(
     queryOrCallback?: GetZonesRequest | GetZonesCallback,
-    callback?: GetZonesCallback
+    callback?: GetZonesCallback,
   ): void | Promise<GetZonesResponse> {
     const query = typeof queryOrCallback === 'object' ? queryOrCallback : {};
     callback =
@@ -383,7 +383,7 @@ class DNS extends Service {
           });
         }
         callback!(null, zones, nextQuery, resp);
-      }
+      },
     );
   }
 

--- a/handwritten/google-cloud-dns/src/record.ts
+++ b/handwritten/google-cloud-dns/src/record.ts
@@ -154,7 +154,7 @@ export class Record implements RecordObject {
    * });
    */
   delete(
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<DeleteRecordResponse> {
     this.zone_.deleteRecords(this, callback!);
   }

--- a/handwritten/google-cloud-dns/src/zone.ts
+++ b/handwritten/google-cloud-dns/src/zone.ts
@@ -96,7 +96,7 @@ export interface GetRecordsCallback {
     err: Error | null,
     records?: Record[] | null,
     nextQuery?: {} | null,
-    apiResponse?: Metadata
+    apiResponse?: Metadata,
   ): void;
 }
 
@@ -155,7 +155,7 @@ export interface GetChangesCallback {
     err: Error | null,
     changes?: Change[] | null,
     nextQuery?: {} | null,
-    apiResponse?: Metadata
+    apiResponse?: Metadata,
   ): void;
 }
 
@@ -184,7 +184,7 @@ type Without<T, K> = {
 // Using the Without type, we essentially make a new ServiceObject type that
 // doesn't contain any of the methods that have signatures we wish to override.
 type ZoneServiceObject = new (
-  config: ServiceObjectConfig
+  config: ServiceObjectConfig,
 ) => Without<ServiceObject<Zone>, 'create' | 'delete' | 'get'>;
 
 // This is used purely for making TypeScript think that the object we are
@@ -390,7 +390,7 @@ class Zone extends ZoneServiceObject {
   create(config: CreateZoneRequest, callback: CreateZoneCallback): void;
   create(
     config: CreateZoneRequest,
-    callback?: CreateZoneCallback
+    callback?: CreateZoneCallback,
   ): void | Promise<CreateZoneResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const args = [config, callback!] as any;
@@ -402,7 +402,7 @@ class Zone extends ZoneServiceObject {
   get(config: GetZoneRequest, callback: InstanceResponseCallback<Zone>): void;
   get(
     configOrCallback?: GetZoneRequest | InstanceResponseCallback<Zone>,
-    callback?: InstanceResponseCallback<Zone>
+    callback?: InstanceResponseCallback<Zone>,
   ): void | Promise<GetResponse<Zone>> {
     const config = typeof configOrCallback === 'object' ? configOrCallback : {};
     callback =
@@ -424,7 +424,7 @@ class Zone extends ZoneServiceObject {
    */
   addRecords(
     records: Record | Record[],
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     this.createChange({add: records}, callback!);
   }
@@ -447,7 +447,7 @@ class Zone extends ZoneServiceObject {
   createChange(config: CreateChangeRequest): Promise<CreateChangeResponse>;
   createChange(
     config: CreateChangeRequest,
-    callback: CreateChangeCallback
+    callback: CreateChangeCallback,
   ): void;
   /**
    * Create a change of resource record sets for the zone.
@@ -496,7 +496,7 @@ class Zone extends ZoneServiceObject {
    */
   createChange(
     config: CreateChangeRequest,
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     if (!config || (!config.add && !config.delete)) {
       throw new Error('Cannot create a change with no additions or deletions.');
@@ -525,13 +525,13 @@ class Zone extends ZoneServiceObject {
     const body = Object.assign(
       {
         additions: groupByType(
-          (arrify(config.add) as Record[]).map(x => x.toJSON())
+          (arrify(config.add) as Record[]).map(x => x.toJSON()),
         ),
         deletions: groupByType(
-          (arrify(config.delete) as Record[]).map(x => x.toJSON())
+          (arrify(config.delete) as Record[]).map(x => x.toJSON()),
         ),
       },
-      config
+      config,
     );
     delete body.add;
     delete body.delete;
@@ -549,7 +549,7 @@ class Zone extends ZoneServiceObject {
         const change = this.change(resp.id);
         change.metadata = resp;
         callback!(null, change, resp);
-      }
+      },
     );
   }
 
@@ -602,7 +602,7 @@ class Zone extends ZoneServiceObject {
    */
   delete(
     optionsOrCallback?: DeleteZoneConfig | DeleteZoneCallback,
-    callback?: DeleteZoneCallback
+    callback?: DeleteZoneCallback,
   ): void | Promise<DeleteZoneResponse> {
     const options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
@@ -623,12 +623,12 @@ class Zone extends ZoneServiceObject {
   }
 
   deleteRecords(
-    records?: Record | Record[] | string
+    records?: Record | Record[] | string,
   ): Promise<CreateChangeResponse>;
   deleteRecords(callback: CreateChangeCallback): void;
   deleteRecords(
     records: Record | Record[] | string,
-    callback: CreateChangeCallback
+    callback: CreateChangeCallback,
   ): void;
   /**
    * Delete records from this zone. This is a convenience wrapper around
@@ -710,7 +710,7 @@ class Zone extends ZoneServiceObject {
    */
   deleteRecords(
     recordsOrCallback?: Record | Record[] | string | CreateChangeCallback,
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     let records: Array<Record | string>;
     if (typeof recordsOrCallback === 'function') {
@@ -741,7 +741,7 @@ class Zone extends ZoneServiceObject {
    * @returns {Promise<CreateChangeResponse>}
    */
   empty(
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse | []> {
     this.getRecords((err, records) => {
       if (err) {
@@ -790,7 +790,7 @@ class Zone extends ZoneServiceObject {
    */
   export(
     localPath: string,
-    callback?: ZoneExportCallback
+    callback?: ZoneExportCallback,
   ): void | Promise<ZoneExportResponse> {
     this.getRecords((err, records) => {
       if (err) {
@@ -848,7 +848,7 @@ class Zone extends ZoneServiceObject {
    */
   getChanges(
     queryOrCallback?: GetChangesRequest | GetChangesCallback,
-    callback?: GetChangesCallback
+    callback?: GetChangesCallback,
   ): void | Promise<GetChangesResponse> {
     let query = queryOrCallback as GetChangesRequest;
     if (typeof query === 'function') {
@@ -881,17 +881,17 @@ class Zone extends ZoneServiceObject {
           });
         }
         callback!(null, changes, nextQuery, resp);
-      }
+      },
     );
   }
 
   getRecords(
-    query?: GetRecordsRequest | string | string[]
+    query?: GetRecordsRequest | string | string[],
   ): Promise<GetRecordsResponse>;
   getRecords(callback: GetRecordsCallback): void;
   getRecords(
     query: GetRecordsRequest | string | string[],
-    callback: GetRecordsCallback
+    callback: GetRecordsCallback,
   ): void;
   /**
    * Query object for listing records.
@@ -990,7 +990,7 @@ class Zone extends ZoneServiceObject {
       | GetRecordsCallback
       | string
       | string[],
-    callback?: GetRecordsCallback
+    callback?: GetRecordsCallback,
   ): void | Promise<GetRecordsResponse> {
     let query: string | string[] | GetRecordsRequest;
     if (typeof queryOrCallback === 'function') {
@@ -1037,7 +1037,7 @@ class Zone extends ZoneServiceObject {
           });
         }
         callback!(null, records, nextQuery, resp);
-      }
+      },
     );
   }
 
@@ -1074,7 +1074,7 @@ class Zone extends ZoneServiceObject {
    */
   import(
     localPath: string,
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     fs.readFile(localPath, 'utf-8', (err, file) => {
       if (err) {
@@ -1092,7 +1092,7 @@ class Zone extends ZoneServiceObject {
         recordTypeSet.forEach((record: any) => {
           record.ttl = record.ttl || defaultTTL;
           recordsToCreate.push(
-            Record.fromZoneRecord_(this, recordType, record)
+            Record.fromZoneRecord_(this, recordType, record),
           );
         });
       });
@@ -1157,12 +1157,12 @@ class Zone extends ZoneServiceObject {
 
   replaceRecords(
     recordType: string | string[],
-    newRecords: Record | Record[]
+    newRecords: Record | Record[],
   ): Promise<CreateChangeResponse>;
   replaceRecords(
     recordType: string | string[],
     newRecords: Record | Record[],
-    callback: CreateChangeCallback
+    callback: CreateChangeCallback,
   ): void;
   /**
    * Provide a record type that should be deleted and replaced with other
@@ -1220,7 +1220,7 @@ class Zone extends ZoneServiceObject {
   replaceRecords(
     recordType: string | string[],
     newRecords: Record | Record[],
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     this.getRecords(recordType, (err, recordsToDelete) => {
       if (err) {
@@ -1232,7 +1232,7 @@ class Zone extends ZoneServiceObject {
           add: newRecords,
           delete: recordsToDelete!,
         },
-        callback!
+        callback!,
       );
     });
   }
@@ -1240,7 +1240,7 @@ class Zone extends ZoneServiceObject {
   deleteRecordsByType_(recordTypes: string[]): Promise<CreateChangeResponse>;
   deleteRecordsByType_(
     recordTypes: string[],
-    callback: CreateChangeCallback
+    callback: CreateChangeCallback,
   ): void;
   /**
    * Delete records from the zone matching an array of types.
@@ -1262,7 +1262,7 @@ class Zone extends ZoneServiceObject {
    */
   deleteRecordsByType_(
     recordTypes: string[],
-    callback?: CreateChangeCallback
+    callback?: CreateChangeCallback,
   ): void | Promise<CreateChangeResponse> {
     this.getRecords(recordTypes, (err, records) => {
       if (err) {

--- a/handwritten/google-cloud-dns/system-test/dns.ts
+++ b/handwritten/google-cloud-dns/system-test/dns.ts
@@ -128,7 +128,7 @@ describe.skip('dns', () => {
         if (hoursOld > 1) {
           await zone.delete({force: true});
         }
-      })
+      }),
     );
     await ZONE.create({
       dnsName: DNS_DOMAIN,
@@ -179,7 +179,7 @@ describe.skip('dns', () => {
 
     it('should import records from a zone file', done => {
       const zoneFilename = require.resolve(
-        '../../system-test/data/zonefile.zone'
+        '../../system-test/data/zonefile.zone',
       );
       let zoneFileTemplate = fs.readFileSync(zoneFilename, 'utf-8');
       zoneFileTemplate = format(zoneFileTemplate, {
@@ -204,7 +204,7 @@ describe.skip('dns', () => {
 
               assert.strictEqual(
                 spfRecord.toJSON().rrdatas![0],
-                '"v=spf1" "mx:' + DNS_DOMAIN + '" "-all"'
+                '"v=spf1" "mx:' + DNS_DOMAIN + '" "-all"',
               );
 
               const txtRecord = records!.filter(record => {
@@ -213,7 +213,7 @@ describe.skip('dns', () => {
 
               assert.strictEqual(
                 txtRecord.toJSON().rrdatas![0],
-                '"google-site-verification=xxxxxxxxxxxxYYYYYYXXX"'
+                '"google-site-verification=xxxxxxxxxxxxYYYYYYXXX"',
               );
 
               done();
@@ -303,7 +303,7 @@ describe.skip('dns', () => {
         const onRecordsReceived = (
           err?: Error | null,
           records?: Record[] | null,
-          nextQuery?: {} | null
+          nextQuery?: {} | null,
         ) => {
           if (nextQuery) {
             ZONE.getRecords(nextQuery, onRecordsReceived);
@@ -316,7 +316,7 @@ describe.skip('dns', () => {
             type: 'cname',
             maxResults: 2,
           },
-          onRecordsReceived
+          onRecordsReceived,
         );
       });
     });

--- a/handwritten/google-cloud-dns/test/change.ts
+++ b/handwritten/google-cloud-dns/test/change.ts
@@ -119,7 +119,7 @@ describe('Change', () => {
             assert.strictEqual(change, null);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -145,7 +145,7 @@ describe('Change', () => {
             assert.strictEqual(change_, change);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
 

--- a/handwritten/google-cloud-dns/test/index.ts
+++ b/handwritten/google-cloud-dns/test/index.ts
@@ -135,7 +135,7 @@ describe('DNS', () => {
       assert.deepStrictEqual(
         calledWith.packageJson,
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        require('../../package.json')
+        require('../../package.json'),
       );
     });
 
@@ -226,7 +226,7 @@ describe('DNS', () => {
             assert.strictEqual(zone, null);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -265,7 +265,7 @@ describe('DNS', () => {
             assert.strictEqual(apiResponse_, apiResponse);
 
             done();
-          }
+          },
         );
       });
 
@@ -318,7 +318,7 @@ describe('DNS', () => {
             err: Error,
             zones: Zone[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.strictEqual(err, error);
             assert.strictEqual(zones, null);
@@ -326,7 +326,7 @@ describe('DNS', () => {
             assert.strictEqual(apiResponse_, apiResponse);
 
             done();
-          }
+          },
         );
       });
     });
@@ -377,7 +377,7 @@ describe('DNS', () => {
             nextQuery,
             Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
-            })
+            }),
           );
 
           done();
@@ -391,7 +391,7 @@ describe('DNS', () => {
             err: Error,
             zones: Zone[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.ifError(err);
             assert.strictEqual(zones[0], zone);
@@ -399,7 +399,7 @@ describe('DNS', () => {
             assert.strictEqual(apiResponse_, apiResponse);
 
             done();
-          }
+          },
         );
       });
 

--- a/handwritten/google-cloud-dns/test/zone.ts
+++ b/handwritten/google-cloud-dns/test/zone.ts
@@ -187,7 +187,7 @@ describe('Zone', () => {
 
       zone.createChange = (
         options: CreateChangeRequest,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(options.add, records);
         callback();
@@ -215,7 +215,7 @@ describe('Zone', () => {
           type: crypto.randomUUID(),
           rrdatas: [crypto.randomUUID(), crypto.randomUUID()],
         },
-        recordJson
+        recordJson,
       );
 
       return {
@@ -312,7 +312,7 @@ describe('Zone', () => {
             assert.strictEqual(err, error);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -342,7 +342,7 @@ describe('Zone', () => {
             assert.strictEqual(change_.metadata, apiResponse);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -390,7 +390,7 @@ describe('Zone', () => {
 
       zone.createChange = (
         options: CreateChangeRequest,
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(options.delete, [recordsToDelete]);
         callback();
@@ -462,7 +462,7 @@ describe('Zone', () => {
       it('should delete non-NS and non-SOA records', done => {
         zone.deleteRecords = (
           recordsToDelete: string[],
-          callback: Function
+          callback: Function,
         ) => {
           assert.deepStrictEqual(recordsToDelete, expectedRecordsToDelete);
           callback();
@@ -539,7 +539,7 @@ describe('Zone', () => {
         writeFileOverride = (
           path_: string,
           content: string,
-          encoding: string
+          encoding: string,
         ) => {
           assert.strictEqual(path_, path);
           assert.strictEqual(content, expectedZonefileContents);
@@ -559,7 +559,7 @@ describe('Zone', () => {
             path: string,
             content: string,
             encoding: string,
-            callback: Function
+            callback: Function,
           ) => {
             callback(error);
           };
@@ -579,7 +579,7 @@ describe('Zone', () => {
             path: string,
             content: string,
             encoding: string,
-            callback: Function
+            callback: Function,
           ) => {
             callback();
           };
@@ -648,12 +648,12 @@ describe('Zone', () => {
             err: Error,
             changes: Change[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.strictEqual(err, error);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -703,14 +703,14 @@ describe('Zone', () => {
             err: Error,
             changes: Change[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.ifError(err);
             assert.strictEqual(changes[0], change);
             assert.strictEqual(changes[0].metadata, apiResponse.changes[0]);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -734,12 +734,12 @@ describe('Zone', () => {
             err: Error,
             changes: Change[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.strictEqual(err, error);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
 
@@ -795,13 +795,13 @@ describe('Zone', () => {
             err: Error,
             records: Record[],
             nextQuery: {},
-            apiResponse_: Response
+            apiResponse_: Response,
           ) => {
             assert.ifError(err);
             assert.strictEqual(records[0], record);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
 
         it('should not require a query', done => {
@@ -866,7 +866,7 @@ describe('Zone', () => {
         readFileOverride = (
           path: string,
           encoding: string,
-          callback: Function
+          callback: Function,
         ) => {
           callback(error);
         };
@@ -897,7 +897,7 @@ describe('Zone', () => {
         readFileOverride = (
           path: string,
           encoding: string,
-          callback: Function
+          callback: Function,
         ) => {
           callback();
         };
@@ -906,7 +906,7 @@ describe('Zone', () => {
       it('should add records', done => {
         zone.addRecords = (
           recordsToCreate: FakeRecord[],
-          callback: Function
+          callback: Function,
         ) => {
           assert.strictEqual(recordsToCreate.length, 1);
           const recordToCreate = recordsToCreate[0];
@@ -998,7 +998,7 @@ describe('Zone', () => {
       it('should create a change', done => {
         zone.createChange = (
           options: CreateChangeRequest,
-          callback: Function
+          callback: Function,
         ) => {
           assert.strictEqual(options.add, recordsToCreate);
           assert.strictEqual(options.delete, recordsToDelete);

--- a/handwritten/logging/src/entry.ts
+++ b/handwritten/logging/src/entry.ts
@@ -183,7 +183,7 @@ class Entry {
       {
         timestamp: new Date(),
       },
-      metadata,
+      metadata
     );
     // JavaScript date has a very coarse granularity (millisecond), which makes
     // it quite likely that multiple log entries would have the same timestamp.

--- a/handwritten/logging/src/index.ts
+++ b/handwritten/logging/src/index.ts
@@ -103,7 +103,7 @@ export interface GetEntriesCallback {
     err: Error | null,
     entries?: Entry[],
     request?: google.logging.v2.IListLogEntriesRequest,
-    apiResponse?: google.logging.v2.IListLogEntriesResponse,
+    apiResponse?: google.logging.v2.IListLogEntriesResponse
   ): void;
 }
 
@@ -132,7 +132,7 @@ export interface GetLogsCallback {
     err: Error | null,
     entries?: Sink[],
     request?: google.logging.v2.IListLogsRequest,
-    apiResponse?: google.logging.v2.IListLogsResponse,
+    apiResponse?: google.logging.v2.IListLogsResponse
   ): void;
 }
 
@@ -156,7 +156,7 @@ export interface GetSinksCallback {
     err: Error | null,
     entries?: Sink[],
     request?: google.logging.v2.IListSinksRequest,
-    apiResponse?: google.logging.v2.IListSinksResponse,
+    apiResponse?: google.logging.v2.IListSinksResponse
   ): void;
 }
 export type Client = string;
@@ -289,7 +289,7 @@ class Logging {
         libVersion: version,
         scopes,
       },
-      options,
+      options
     );
     this.api = {};
     this.auth = new (gaxInstance ?? gax).GoogleAuth(options_);
@@ -297,11 +297,11 @@ class Logging {
     this.projectId = this.options.projectId || '{{projectId}}';
     this.configService = new v2.ConfigServiceV2Client(
       this.options,
-      gaxInstance,
+      gaxInstance
     );
     this.loggingService = new v2.LoggingServiceV2Client(
       this.options,
-      gaxInstance,
+      gaxInstance
     );
   }
 
@@ -339,7 +339,7 @@ class Logging {
   createSink(
     name: string,
     config: CreateSinkRequest,
-    callback: CreateSinkCallback,
+    callback: CreateSinkCallback
   ): void;
   // jscs:disable maximumLineLength
   /**
@@ -392,7 +392,7 @@ class Logging {
    */
   async createSink(
     name: string,
-    config: CreateSinkRequest,
+    config: CreateSinkRequest
   ): Promise<[Sink, LogSink]> {
     if (typeof name !== 'string') {
       throw new Error('A sink name must be provided.');
@@ -419,7 +419,7 @@ class Logging {
     await this.setProjectId(reqOpts);
     const [resp] = await this.configService.createSink(
       reqOpts,
-      config.gaxOptions,
+      config.gaxOptions
     );
     const sink = this.sink(resp.name);
     sink.metadata = resp;
@@ -573,7 +573,7 @@ class Logging {
   getEntries(callback: GetEntriesCallback): void;
   getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   async getEntries(
-    opts?: GetEntriesRequest | GetEntriesCallback,
+    opts?: GetEntriesRequest | GetEntriesCallback
   ): Promise<GetEntriesResponse> {
     const options = opts ? (opts as GetEntriesRequest) : {};
 
@@ -603,14 +603,14 @@ class Logging {
       {
         autoPaginate: options!.autoPaginate,
       },
-      options!.gaxOptions,
+      options!.gaxOptions
     );
     if (options?.maxResults) {
       gaxOptions = extend(
         {
           maxResults: options.maxResults,
         },
-        gaxOptions,
+        gaxOptions
       );
     }
     const resp = await this.loggingService.listLogEntries(reqOpts, gaxOptions);
@@ -676,12 +676,12 @@ class Logging {
           if (options.filter) {
             options.filter = `(${options.filter}) AND logName="${formatLogName(
               this.projectId,
-              options.log,
+              options.log
             )}"`;
           } else {
             options.filter = `logName="${formatLogName(
               this.projectId,
-              options.log,
+              options.log
             )}"`;
           }
           delete options.log;
@@ -690,7 +690,7 @@ class Logging {
           {
             orderBy: 'timestamp desc',
           },
-          options,
+          options
         );
         reqOpts.resourceNames = arrify(reqOpts.resourceNames!);
         reqOpts.resourceNames.push(`projects/${this.projectId}`);
@@ -700,12 +700,12 @@ class Logging {
           {
             autoPaginate: options.autoPaginate,
           },
-          options.gaxOptions,
+          options.gaxOptions
         );
 
         let gaxStream: ClientReadableStream<LogEntry>;
         requestStream = streamEvents<Duplex>(
-          new PassThrough({objectMode: true}),
+          new PassThrough({objectMode: true})
         );
         (requestStream as AbortableDuplex).abort = () => {
           if (gaxStream && gaxStream.cancel) {
@@ -718,7 +718,7 @@ class Logging {
             try {
               gaxStream = this.loggingService.listLogEntriesStream(
                 reqOpts,
-                gaxOptions,
+                gaxOptions
               );
             } catch (error) {
               requestStream.destroy(error as Error);
@@ -818,7 +818,7 @@ class Logging {
               suppressionInfo: chunk.suppressionInfo,
             };
             return resp;
-          })(),
+          })()
         );
       },
     });
@@ -830,12 +830,12 @@ class Logging {
         if (options.filter) {
           options.filter = `(${options.filter}) AND logName="${formatLogName(
             this.projectId,
-            options.log,
+            options.log
           )}"`;
         } else {
           options.filter = `logName="${formatLogName(
             this.projectId,
-            options.log,
+            options.log
           )}"`;
         }
       }
@@ -936,7 +936,7 @@ class Logging {
   getLogs(callback: GetLogsCallback): void;
   getLogs(options: GetLogsRequest, callback: GetLogsCallback): void;
   async getLogs(
-    opts?: GetLogsRequest | GetLogsCallback,
+    opts?: GetLogsRequest | GetLogsCallback
   ): Promise<GetLogsResponse> {
     const options = opts ? (opts as GetSinksRequest) : {};
     this.projectId = await this.auth.getProjectId();
@@ -949,7 +949,7 @@ class Logging {
       {
         autoPaginate: options.autoPaginate,
       },
-      options.gaxOptions,
+      options.gaxOptions
     );
     const resp = await this.loggingService.listLogs(reqOpts, gaxOptions);
     const [logs] = resp;
@@ -1017,12 +1017,12 @@ class Logging {
           {
             autoPaginate: options.autoPaginate,
           },
-          options.gaxOptions,
+          options.gaxOptions
         );
 
         let gaxStream: ClientReadableStream<Log>;
         requestStream = streamEvents<Duplex>(
-          new PassThrough({objectMode: true}),
+          new PassThrough({objectMode: true})
         );
         (requestStream as AbortableDuplex).abort = () => {
           if (gaxStream && gaxStream.cancel) {
@@ -1110,7 +1110,7 @@ class Logging {
   getSinks(callback: GetSinksCallback): void;
   getSinks(options: GetSinksRequest, callback: GetSinksCallback): void;
   async getSinks(
-    opts?: GetSinksRequest | GetSinksCallback,
+    opts?: GetSinksRequest | GetSinksCallback
   ): Promise<GetSinksResponse> {
     const options = opts ? (opts as GetSinksRequest) : {};
     this.projectId = await this.auth.getProjectId();
@@ -1123,7 +1123,7 @@ class Logging {
       {
         autoPaginate: options.autoPaginate,
       },
-      options.gaxOptions,
+      options.gaxOptions
     );
     const resp = await this.configService.listSinks(reqOpts, gaxOptions);
     const [sinks] = resp;
@@ -1200,12 +1200,12 @@ class Logging {
           {
             autoPaginate: options.autoPaginate,
           },
-          options.gaxOptions,
+          options.gaxOptions
         );
 
         let gaxStream: ClientReadableStream<LogSink>;
         requestStream = streamEvents<Duplex>(
-          new PassThrough({objectMode: true}),
+          new PassThrough({objectMode: true})
         );
         (requestStream as AbortableDuplex).abort = () => {
           if (gaxStream && gaxStream.cancel) {
@@ -1218,7 +1218,7 @@ class Logging {
             try {
               gaxStream = this.configService.listSinksStream(
                 reqOpts,
-                gaxOptions,
+                gaxOptions
               );
             } catch (error) {
               requestStream.destroy(error as Error);
@@ -1318,7 +1318,7 @@ class Logging {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   request<TResponse = any>(
     config: RequestConfig,
-    callback?: RequestCallback<TResponse>,
+    callback?: RequestCallback<TResponse>
   ) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
@@ -1354,7 +1354,7 @@ class Logging {
         const requestFn = gaxClient[config.method].bind(
           gaxClient,
           reqOpts,
-          config.gaxOpts,
+          config.gaxOpts
         );
         callback(null, requestFn);
       });
@@ -1480,7 +1480,7 @@ class Logging {
   async setDetectedResource() {
     if (!this.detectedResource) {
       this.detectedResource = await getDefaultResource(
-        this.auth as unknown as GoogleAuth,
+        this.auth as unknown as GoogleAuth
       );
     }
   }

--- a/handwritten/logging/src/log-sync.ts
+++ b/handwritten/logging/src/log-sync.ts
@@ -74,7 +74,7 @@ class LogSync implements LogSeverityFunctions {
     logging: Logging,
     name: string,
     transport?: Writable,
-    options?: LogSyncOptions,
+    options?: LogSyncOptions
   ) {
     options = options || {};
     this.formattedName_ = formatLogName(logging.projectId, name);
@@ -113,7 +113,7 @@ class LogSync implements LogSeverityFunctions {
   alert(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'ALERT'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -141,7 +141,7 @@ class LogSync implements LogSeverityFunctions {
   critical(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'CRITICAL'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -169,7 +169,7 @@ class LogSync implements LogSeverityFunctions {
   debug(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'DEBUG'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -197,7 +197,7 @@ class LogSync implements LogSeverityFunctions {
   emergency(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'EMERGENCY'),
-      options as WriteOptions,
+      options as WriteOptions
     );
   }
 
@@ -285,7 +285,7 @@ class LogSync implements LogSeverityFunctions {
   error(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'ERROR'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -313,7 +313,7 @@ class LogSync implements LogSeverityFunctions {
   info(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'INFO'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -341,7 +341,7 @@ class LogSync implements LogSeverityFunctions {
   notice(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'NOTICE'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -369,7 +369,7 @@ class LogSync implements LogSeverityFunctions {
   warning(entry: Entry | Entry[], options?: WriteOptions) {
     this.write(
       assignSeverityToEntries(entry, 'WARNING'),
-      options as WriteOptions,
+      options as WriteOptions
     );
   }
 
@@ -433,7 +433,7 @@ class LogSync implements LogSeverityFunctions {
         }
         return entry.toStructuredJSON(
           this.logging.projectId,
-          this.useMessageField_,
+          this.useMessageField_
         );
       });
       for (const entry of structuredEntries) {

--- a/handwritten/logging/src/log.ts
+++ b/handwritten/logging/src/log.ts
@@ -161,11 +161,11 @@ class Log implements LogSeverityFunctions {
         str =>
           str !== null &&
           !this.jsonFieldsToTruncate.includes(str) &&
-          str.startsWith('jsonPayload'),
+          str.startsWith('jsonPayload')
       );
       const uniqueSet = new Set(filteredList);
       this.jsonFieldsToTruncate = Array.from(uniqueSet).concat(
-        this.jsonFieldsToTruncate,
+        this.jsonFieldsToTruncate
       );
     }
 
@@ -218,16 +218,16 @@ class Log implements LogSeverityFunctions {
   alert(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   alert(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   alert(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'ALERT'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -263,21 +263,21 @@ class Log implements LogSeverityFunctions {
    */
   critical(
     entry: Entry | Entry[],
-    options?: WriteOptions,
+    options?: WriteOptions
   ): Promise<ApiResponse>;
   critical(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   critical(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   critical(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'CRITICAL'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -315,16 +315,16 @@ class Log implements LogSeverityFunctions {
   debug(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   debug(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   debug(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'DEBUG'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -375,7 +375,7 @@ class Log implements LogSeverityFunctions {
   delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   delete(callback: DeleteCallback): void;
   async delete(
-    gaxOptions?: CallOptions | DeleteCallback,
+    gaxOptions?: CallOptions | DeleteCallback
   ): Promise<ApiResponse> {
     const projectId = await this.logging.auth.getProjectId();
     this.formattedName_ = formatLogName(projectId, this.name);
@@ -385,7 +385,7 @@ class Log implements LogSeverityFunctions {
     return this.logging.loggingService.deleteLog(
       reqOpts,
       gaxOptions! as CallOptions,
-      this.defaultWriteDeleteCallback,
+      this.defaultWriteDeleteCallback
     );
   }
 
@@ -422,16 +422,16 @@ class Log implements LogSeverityFunctions {
   emergency(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   emergency(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   emergency(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'EMERGENCY'),
-      options as WriteOptions,
+      options as WriteOptions
     );
   }
 
@@ -550,16 +550,16 @@ class Log implements LogSeverityFunctions {
   error(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   error(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   error(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'ERROR'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -611,7 +611,7 @@ class Log implements LogSeverityFunctions {
   getEntries(callback: GetEntriesCallback): void;
   getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   async getEntries(
-    opts?: GetEntriesRequest | GetEntriesCallback,
+    opts?: GetEntriesRequest | GetEntriesCallback
   ): Promise<GetEntriesResponse> {
     const options = extend({}, opts as GetEntriesRequest);
     const projectId = await this.logging.auth.getProjectId();
@@ -665,7 +665,7 @@ class Log implements LogSeverityFunctions {
       {
         log: this.name,
       },
-      options,
+      options
     );
     return this.logging.getEntriesStream(options);
   }
@@ -711,7 +711,7 @@ class Log implements LogSeverityFunctions {
       {
         log: this.name,
       },
-      options,
+      options
     );
     return this.logging.tailEntries(options);
   }
@@ -750,16 +750,16 @@ class Log implements LogSeverityFunctions {
   info(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   info(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   info(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'INFO'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -797,16 +797,16 @@ class Log implements LogSeverityFunctions {
   notice(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   notice(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   notice(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'NOTICE'),
-      options! as WriteOptions,
+      options! as WriteOptions
     );
   }
 
@@ -844,16 +844,16 @@ class Log implements LogSeverityFunctions {
   warning(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   warning(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   warning(
     entry: Entry | Entry[],
-    options?: WriteOptions | ApiResponseCallback,
+    options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
       assignSeverityToEntries(entry, 'WARNING'),
-      options as WriteOptions,
+      options as WriteOptions
     );
   }
 
@@ -964,12 +964,12 @@ class Log implements LogSeverityFunctions {
   write(
     entry: Entry | Entry[],
     options: WriteOptions,
-    callback: ApiResponseCallback,
+    callback: ApiResponseCallback
   ): void;
   write(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   async write(
     entry: Entry | Entry[],
-    opts?: WriteOptions | ApiResponseCallback,
+    opts?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     const options = opts ? (opts as WriteOptions) : {};
     // Extract projectId & resource from Logging - inject & memoize if not.
@@ -993,7 +993,7 @@ class Log implements LogSeverityFunctions {
         entries: decoratedEntries,
         resource,
       },
-      options,
+      options
     );
     delete reqOpts.gaxOptions;
     // Propagate maxRetries properly into writeLogEntries call
@@ -1002,13 +1002,13 @@ class Log implements LogSeverityFunctions {
         {
           maxRetries: this.logging.options.maxRetries,
         },
-        options.gaxOptions,
+        options.gaxOptions
       );
     }
     return this.logging.loggingService.writeLogEntries(
       reqOpts,
       options.gaxOptions,
-      this.defaultWriteDeleteCallback,
+      this.defaultWriteDeleteCallback
     );
   }
 
@@ -1051,7 +1051,7 @@ class Log implements LogSeverityFunctions {
         {
           removeCircular: this.removeCircular_,
         },
-        this.logging.projectId,
+        this.logging.projectId
       );
     });
   }
@@ -1077,7 +1077,7 @@ class Log implements LogSeverityFunctions {
       if (entry.textPayload) {
         entry.textPayload = entry.textPayload.slice(
           0,
-          Math.max(entry.textPayload.length - delta, 0),
+          Math.max(entry.textPayload.length - delta, 0)
         );
       } else {
         for (const field of this.jsonFieldsToTruncate) {
@@ -1086,7 +1086,7 @@ class Log implements LogSeverityFunctions {
             dotProp.set(
               entry,
               field,
-              msg.slice(0, Math.max(msg.length - delta, 0)),
+              msg.slice(0, Math.max(msg.length - delta, 0))
             );
             delta -= Math.min(msg.length, delta);
             if (delta <= 0) {
@@ -1109,7 +1109,7 @@ class Log implements LogSeverityFunctions {
    */
   static assignSeverityToEntries_(
     entries: Entry | Entry[],
-    severity: string,
+    severity: string
   ): Entry[] {
     return assignSeverityToEntries(entries, severity);
   }

--- a/handwritten/logging/src/middleware/express/make-middleware.ts
+++ b/handwritten/logging/src/middleware/express/make-middleware.ts
@@ -48,14 +48,14 @@ export function makeMiddleware<LoggerType>(
   makeChildLogger: (
     trace: string,
     span?: string,
-    traceSampled?: boolean,
+    traceSampled?: boolean
   ) => LoggerType,
   emitRequestLog?: (
     httpRequest: CloudLoggingHttpRequest,
     trace: string,
     span?: string,
-    traceSampled?: boolean,
-  ) => void,
+    traceSampled?: boolean
+  ) => void
 ) {
   return (req: ServerRequest, res: http.ServerResponse, next: Function) => {
     // TODO(ofrobots): use high-resolution timer.
@@ -70,7 +70,7 @@ export function makeMiddleware<LoggerType>(
     (req as AnnotatedRequestType<LoggerType>).log = makeChildLogger(
       traceContext.trace,
       traceContext.spanId,
-      traceContext.traceSampled,
+      traceContext.traceSampled
     );
 
     // Emit a 'Request Log' on the parent logger, with detected trace and
@@ -83,7 +83,7 @@ export function makeMiddleware<LoggerType>(
           httpRequest,
           traceContext.trace,
           traceContext.spanId,
-          traceContext.traceSampled,
+          traceContext.traceSampled
         );
       });
     }

--- a/handwritten/logging/src/sink.ts
+++ b/handwritten/logging/src/sink.ts
@@ -168,7 +168,7 @@ class Sink {
   delete(callback: DeleteCallback): void;
   delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   async delete(
-    gaxOptions?: CallOptions | DeleteCallback,
+    gaxOptions?: CallOptions | DeleteCallback
   ): Promise<DeleteResponse> {
     const projectId = await this.logging.auth.getProjectId();
     this.formattedName_ = 'projects/' + projectId + '/sinks/' + this.name;
@@ -177,7 +177,7 @@ class Sink {
     };
     return this.logging.configService.deleteSink(
       reqOpts,
-      gaxOptions as CallOptions,
+      gaxOptions as CallOptions
     );
   }
 
@@ -227,7 +227,7 @@ class Sink {
   getMetadata(callback: SinkMetadataCallback): void;
   getMetadata(gaxOptions: CallOptions, callback: SinkMetadataCallback): void;
   async getMetadata(
-    gaxOptions?: CallOptions | SinkMetadataCallback,
+    gaxOptions?: CallOptions | SinkMetadataCallback
   ): Promise<SinkMetadataResponse> {
     const projectId = await this.logging.auth.getProjectId();
     this.formattedName_ = 'projects/' + projectId + '/sinks/' + this.name;
@@ -237,7 +237,7 @@ class Sink {
 
     [this.metadata] = await this.logging.configService.getSink(
       reqOpts,
-      gaxOptions as CallOptions,
+      gaxOptions as CallOptions
     );
     return [this.metadata!];
   }
@@ -359,7 +359,7 @@ class Sink {
     };
     [this.metadata] = await this.logging.configService.updateSink(
       reqOpts,
-      metadata.gaxOptions,
+      metadata.gaxOptions
     );
     return [this.metadata!];
   }

--- a/handwritten/logging/src/utils/common.ts
+++ b/handwritten/logging/src/utils/common.ts
@@ -141,7 +141,7 @@ export class ObjectToStructConverter {
             [
               'This object contains a circular reference. To automatically',
               'remove it, set the `removeCircular` option to true.',
-            ].join(' '),
+            ].join(' ')
           );
         }
         convertedValue = {

--- a/handwritten/logging/src/utils/context.ts
+++ b/handwritten/logging/src/utils/context.ts
@@ -59,7 +59,7 @@ export interface HeaderWrapper {
  * @param req
  */
 export function makeHeaderWrapper(
-  req: http.IncomingMessage,
+  req: http.IncomingMessage
 ): HeaderWrapper | null {
   if (!req.headers) return null;
   const wrapper = {
@@ -95,7 +95,7 @@ export interface CloudTraceContext {
 export function getOrInjectContext(
   req: http.IncomingMessage,
   projectId: string,
-  inject?: boolean,
+  inject?: boolean
 ): CloudTraceContext {
   const defaultContext = toCloudTraceContext({}, projectId);
 
@@ -129,7 +129,7 @@ export function getOrInjectContext(
 function toCloudTraceContext(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   anyContext: any,
-  projectId: string,
+  projectId: string
 ): CloudTraceContext {
   const context: CloudTraceContext = {
     trace: '',
@@ -162,7 +162,7 @@ function makeCloudTraceHeader(): string {
  * @param projectId
  */
 export function getContextFromOtelContext(
-  projectId: string,
+  projectId: string
 ): CloudTraceContext | null {
   const spanContext = trace.getActiveSpan()?.spanContext();
   const FLAG_SAMPLED = 1; // 00000001
@@ -188,7 +188,7 @@ export function getContextFromOtelContext(
  */
 export function getContextFromXCloudTrace(
   headerWrapper: HeaderWrapper,
-  projectId: string,
+  projectId: string
 ): CloudTraceContext | null {
   const context = parseXCloudTraceHeader(headerWrapper);
   if (!context) return null;
@@ -205,7 +205,7 @@ export function getContextFromXCloudTrace(
  */
 export function getContextFromTraceParent(
   headerWrapper: HeaderWrapper,
-  projectId: string,
+  projectId: string
 ): CloudTraceContext | null {
   const context = parseTraceParentHeader(headerWrapper);
   if (!context) return null;
@@ -218,7 +218,7 @@ export function getContextFromTraceParent(
  * @param headerWrapper
  */
 export function parseXCloudTraceHeader(
-  headerWrapper: HeaderWrapper,
+  headerWrapper: HeaderWrapper
 ): CloudTraceContext | null {
   const regex = /([a-f\d]+)?(\/?([a-f\d]+))?(;?o=(\d))?/;
   const match = headerWrapper
@@ -240,14 +240,14 @@ export function parseXCloudTraceHeader(
  * @param headerWrapper
  */
 export function parseTraceParentHeader(
-  headerWrapper: HeaderWrapper,
+  headerWrapper: HeaderWrapper
 ): CloudTraceContext | null {
   const VERSION_PART = '(?!ff)[\\da-f]{2}';
   const TRACE_ID_PART = '(?![0]{32})[\\da-f]{32}';
   const PARENT_ID_PART = '(?![0]{16})[\\da-f]{16}';
   const FLAGS_PART = '[\\da-f]{2}';
   const TRACE_PARENT_REGEX = new RegExp(
-    `^\\s?(${VERSION_PART})-(${TRACE_ID_PART})-(${PARENT_ID_PART})-(${FLAGS_PART})(-.*)?\\s?$`,
+    `^\\s?(${VERSION_PART})-(${TRACE_ID_PART})-(${PARENT_ID_PART})-(${FLAGS_PART})(-.*)?\\s?$`
   );
   const match = headerWrapper
     .getHeader(W3C_TRACE_PARENT_HEADER)

--- a/handwritten/logging/src/utils/event-id.ts
+++ b/handwritten/logging/src/utils/event-id.ts
@@ -16,7 +16,8 @@
 
 import * as crypto from 'crypto';
 
-const chars = '.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+const chars =
+  '.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
 
 function encode(data: Uint8Array): string {
   // Code for this encode method is copied verbatim from the eventid package.

--- a/handwritten/logging/src/utils/http-request.ts
+++ b/handwritten/logging/src/utils/http-request.ts
@@ -61,7 +61,7 @@ export interface ServerRequest extends http.IncomingMessage {
 export function makeHttpRequestData(
   req: ServerRequest | http.IncomingMessage,
   res?: http.ServerResponse,
-  latencyMilliseconds?: number,
+  latencyMilliseconds?: number
 ): CloudLoggingHttpRequest {
   let requestUrl,
     protocol,
@@ -112,7 +112,7 @@ export function makeHttpRequestData(
     referer ? {referer} : null,
     responseSize ? {responseSize} : null,
     status ? {status} : null,
-    latency ? {latency} : null,
+    latency ? {latency} : null
   );
 }
 

--- a/handwritten/logging/src/utils/instrumentation.ts
+++ b/handwritten/logging/src/utils/instrumentation.ts
@@ -50,7 +50,7 @@ export type InstrumentationInfo = {name: string; version: string};
  * instrumentation info and boolean flag indicating if instrumentation was added or not in this call
  */
 export function populateInstrumentationInfo(
-  entry: Entry | Entry[],
+  entry: Entry | Entry[]
 ): [Entry[], boolean] {
   // Check if instrumentation data was already written once. This prevents also inspection of
   // the entries for instrumentation data to prevent perf degradation
@@ -102,7 +102,7 @@ export function populateInstrumentationInfo(
  */
 export function createDiagnosticEntry(
   libraryName: string | undefined,
-  libraryVersion: string | undefined,
+  libraryVersion: string | undefined
 ): Entry {
   // Validate the libraryName first and make sure it starts with 'nodejs' prefix.
   if (!libraryName || !libraryName.startsWith(NODEJS_LIBRARY_NAME_PREFIX)) {
@@ -116,7 +116,7 @@ export function createDiagnosticEntry(
           name: truncateValue(libraryName, maxDiagnosticValueLen),
           version: truncateValue(
             libraryVersion ?? getNodejsLibraryVersion(),
-            maxDiagnosticValueLen,
+            maxDiagnosticValueLen
           ),
         },
       ],
@@ -131,7 +131,7 @@ export function createDiagnosticEntry(
  * @returns {InstrumentationInfo} The updated list of InstrumentationInfo.
  */
 function validateAndUpdateInstrumentation(
-  infoList: InstrumentationInfo[],
+  infoList: InstrumentationInfo[]
 ): InstrumentationInfo[] {
   const finalInfo: InstrumentationInfo[] = [];
   // First, iterate through given list of libraries and for each entry perform validations and transformations.

--- a/handwritten/logging/src/utils/log-common.ts
+++ b/handwritten/logging/src/utils/log-common.ts
@@ -54,17 +54,17 @@ export type LogSeverityFunctions = {
  * @param labels
  */
 export function snakecaseKeys(
-  labels: {[p: string]: string} | null | undefined,
+  labels: {[p: string]: string} | null | undefined
 ) {
   for (const key in labels) {
     const replaced = key.replace(
       /[A-Z]/g,
-      letter => `_${letter.toLowerCase()}`,
+      letter => `_${letter.toLowerCase()}`
     );
     Object.defineProperty(
       labels,
       replaced,
-      Object.getOwnPropertyDescriptor(labels, key) as PropertyDescriptor,
+      Object.getOwnPropertyDescriptor(labels, key) as PropertyDescriptor
     );
     if (replaced !== key) {
       delete labels[key];
@@ -83,7 +83,7 @@ export function snakecaseKeys(
  */
 export function assignSeverityToEntries(
   entries: Entry | Entry[],
-  severity: string,
+  severity: string
 ): Entry[] {
   return (arrify(entries) as Entry[]).map(entry => {
     const metadata = extend(true, {}, entry.metadata, {

--- a/handwritten/logging/src/utils/metadata.ts
+++ b/handwritten/logging/src/utils/metadata.ts
@@ -211,7 +211,7 @@ export async function getDefaultResource(auth: GoogleAuth) {
  * https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext}.
  */
 export async function detectServiceContext(
-  auth: GoogleAuth,
+  auth: GoogleAuth
 ): Promise<ServiceContext | null> {
   const env = await auth.getEnv();
   switch (env) {

--- a/handwritten/logging/src/v2/config_service_v2_client.ts
+++ b/handwritten/logging/src/v2/config_service_v2_client.ts
@@ -109,7 +109,7 @@ export class ConfigServiceV2Client {
    */
   constructor(
     opts?: ClientOptions,
-    gaxInstance?: typeof gax | typeof gax.fallback,
+    gaxInstance?: typeof gax | typeof gax.fallback
   ) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
@@ -119,7 +119,7 @@ export class ConfigServiceV2Client {
       opts?.universe_domain !== opts?.universeDomain
     ) {
       throw new Error(
-        'Please set either universe_domain or universeDomain, but not both.',
+        'Please set either universe_domain or universeDomain, but not both.'
       );
     }
     const universeDomainEnvVar =
@@ -203,114 +203,114 @@ export class ConfigServiceV2Client {
     // Create useful helper objects for these.
     this.pathTemplates = {
       billingAccountCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/cmekSettings',
+        'billingAccounts/{billing_account}/cmekSettings'
       ),
       billingAccountExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/exclusions/{exclusion}',
+        'billingAccounts/{billing_account}/exclusions/{exclusion}'
       ),
       billingAccountLocationBucketPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
         ),
       billingAccountLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       billingAccountLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/logs/{log}',
+        'billingAccounts/{billing_account}/logs/{log}'
       ),
       billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/settings',
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/sinks/{sink}',
+        'billingAccounts/{billing_account}/sinks/{sink}'
       ),
       folderCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/cmekSettings',
+        'folders/{folder}/cmekSettings'
       ),
       folderExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/exclusions/{exclusion}',
+        'folders/{folder}/exclusions/{exclusion}'
       ),
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
       folderLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/logs/{log}',
+        'folders/{folder}/logs/{log}'
       ),
       folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/settings',
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/sinks/{sink}',
+        'folders/{folder}/sinks/{sink}'
       ),
       locationPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}',
+        'projects/{project}/locations/{location}'
       ),
       logMetricPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/metrics/{metric}',
+        'projects/{project}/metrics/{metric}'
       ),
       organizationCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/cmekSettings',
+        'organizations/{organization}/cmekSettings'
       ),
       organizationExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/exclusions/{exclusion}',
+        'organizations/{organization}/exclusions/{exclusion}'
       ),
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/locations/{location}/buckets/{bucket}',
+        'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
       organizationLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       organizationLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/logs/{log}',
+        'organizations/{organization}/logs/{log}'
       ),
       organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/settings',
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/sinks/{sink}',
+        'organizations/{organization}/sinks/{sink}'
       ),
       projectPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}',
+        'projects/{project}'
       ),
       projectCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/cmekSettings',
+        'projects/{project}/cmekSettings'
       ),
       projectExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/exclusions/{exclusion}',
+        'projects/{project}/exclusions/{exclusion}'
       ),
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}',
+        'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
       projectLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/logs/{log}',
+        'projects/{project}/logs/{log}'
       ),
       projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/settings',
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/sinks/{sink}',
+        'projects/{project}/sinks/{sink}'
       ),
     };
 
@@ -321,27 +321,27 @@ export class ConfigServiceV2Client {
       listBuckets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'buckets',
+        'buckets'
       ),
       listViews: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'views',
+        'views'
       ),
       listSinks: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'sinks',
+        'sinks'
       ),
       listLinks: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'links',
+        'links'
       ),
       listExclusions: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'exclusions',
+        'exclusions'
       ),
     };
 
@@ -405,61 +405,61 @@ export class ConfigServiceV2Client {
       .lro(lroOptions)
       .operationsClient(opts);
     const createBucketAsyncResponse = protoFilesRoot.lookup(
-      '.google.logging.v2.LogBucket',
+      '.google.logging.v2.LogBucket'
     ) as gax.protobuf.Type;
     const createBucketAsyncMetadata = protoFilesRoot.lookup(
-      '.google.logging.v2.BucketMetadata',
+      '.google.logging.v2.BucketMetadata'
     ) as gax.protobuf.Type;
     const updateBucketAsyncResponse = protoFilesRoot.lookup(
-      '.google.logging.v2.LogBucket',
+      '.google.logging.v2.LogBucket'
     ) as gax.protobuf.Type;
     const updateBucketAsyncMetadata = protoFilesRoot.lookup(
-      '.google.logging.v2.BucketMetadata',
+      '.google.logging.v2.BucketMetadata'
     ) as gax.protobuf.Type;
     const createLinkResponse = protoFilesRoot.lookup(
-      '.google.logging.v2.Link',
+      '.google.logging.v2.Link'
     ) as gax.protobuf.Type;
     const createLinkMetadata = protoFilesRoot.lookup(
-      '.google.logging.v2.LinkMetadata',
+      '.google.logging.v2.LinkMetadata'
     ) as gax.protobuf.Type;
     const deleteLinkResponse = protoFilesRoot.lookup(
-      '.google.protobuf.Empty',
+      '.google.protobuf.Empty'
     ) as gax.protobuf.Type;
     const deleteLinkMetadata = protoFilesRoot.lookup(
-      '.google.logging.v2.LinkMetadata',
+      '.google.logging.v2.LinkMetadata'
     ) as gax.protobuf.Type;
     const copyLogEntriesResponse = protoFilesRoot.lookup(
-      '.google.logging.v2.CopyLogEntriesResponse',
+      '.google.logging.v2.CopyLogEntriesResponse'
     ) as gax.protobuf.Type;
     const copyLogEntriesMetadata = protoFilesRoot.lookup(
-      '.google.logging.v2.CopyLogEntriesMetadata',
+      '.google.logging.v2.CopyLogEntriesMetadata'
     ) as gax.protobuf.Type;
 
     this.descriptors.longrunning = {
       createBucketAsync: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         createBucketAsyncResponse.decode.bind(createBucketAsyncResponse),
-        createBucketAsyncMetadata.decode.bind(createBucketAsyncMetadata),
+        createBucketAsyncMetadata.decode.bind(createBucketAsyncMetadata)
       ),
       updateBucketAsync: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         updateBucketAsyncResponse.decode.bind(updateBucketAsyncResponse),
-        updateBucketAsyncMetadata.decode.bind(updateBucketAsyncMetadata),
+        updateBucketAsyncMetadata.decode.bind(updateBucketAsyncMetadata)
       ),
       createLink: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         createLinkResponse.decode.bind(createLinkResponse),
-        createLinkMetadata.decode.bind(createLinkMetadata),
+        createLinkMetadata.decode.bind(createLinkMetadata)
       ),
       deleteLink: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         deleteLinkResponse.decode.bind(deleteLinkResponse),
-        deleteLinkMetadata.decode.bind(deleteLinkMetadata),
+        deleteLinkMetadata.decode.bind(deleteLinkMetadata)
       ),
       copyLogEntries: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         copyLogEntriesResponse.decode.bind(copyLogEntriesResponse),
-        copyLogEntriesMetadata.decode.bind(copyLogEntriesMetadata),
+        copyLogEntriesMetadata.decode.bind(copyLogEntriesMetadata)
       ),
     };
 
@@ -468,7 +468,7 @@ export class ConfigServiceV2Client {
       'google.logging.v2.ConfigServiceV2',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      {'x-goog-api-client': clientHeader.join(' ')},
+      {'x-goog-api-client': clientHeader.join(' ')}
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -502,12 +502,12 @@ export class ConfigServiceV2Client {
     this.configServiceV2Stub = this._gaxGrpc.createStub(
       this._opts.fallback
         ? (this._protos as protobuf.Root).lookupService(
-            'google.logging.v2.ConfigServiceV2',
+            'google.logging.v2.ConfigServiceV2'
           )
         : // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.logging.v2.ConfigServiceV2,
       this._opts,
-      this._providedCustomServicePath,
+      this._providedCustomServicePath
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -558,7 +558,7 @@ export class ConfigServiceV2Client {
           },
         (err: Error | null | undefined) => () => {
           throw err;
-        },
+        }
       );
 
       const descriptor =
@@ -569,7 +569,7 @@ export class ConfigServiceV2Client {
         callPromise,
         this._defaults[methodName],
         descriptor,
-        this._opts.fallback,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -590,7 +590,7 @@ export class ConfigServiceV2Client {
     ) {
       process.emitWarning(
         'Static servicePath is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -608,7 +608,7 @@ export class ConfigServiceV2Client {
     ) {
       process.emitWarning(
         'Static apiEndpoint is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -655,7 +655,7 @@ export class ConfigServiceV2Client {
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
-    callback?: Callback<string, undefined, undefined>,
+    callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
     if (callback) {
       this.auth.getProjectId(callback);
@@ -694,7 +694,7 @@ export class ConfigServiceV2Client {
    */
   getBucket(
     request?: protos.google.logging.v2.IGetBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -709,7 +709,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IGetBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getBucket(
     request: protos.google.logging.v2.IGetBucketRequest,
@@ -717,7 +717,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IGetBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getBucket(
     request?: protos.google.logging.v2.IGetBucketRequest,
@@ -732,7 +732,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IGetBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -791,7 +791,7 @@ export class ConfigServiceV2Client {
    */
   createBucket(
     request?: protos.google.logging.v2.ICreateBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -806,7 +806,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.ICreateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createBucket(
     request: protos.google.logging.v2.ICreateBucketRequest,
@@ -814,7 +814,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.ICreateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createBucket(
     request?: protos.google.logging.v2.ICreateBucketRequest,
@@ -829,7 +829,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.ICreateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -898,7 +898,7 @@ export class ConfigServiceV2Client {
    */
   updateBucket(
     request?: protos.google.logging.v2.IUpdateBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -913,7 +913,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IUpdateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateBucket(
     request: protos.google.logging.v2.IUpdateBucketRequest,
@@ -921,7 +921,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IUpdateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateBucket(
     request?: protos.google.logging.v2.IUpdateBucketRequest,
@@ -936,7 +936,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogBucket,
       protos.google.logging.v2.IUpdateBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket,
@@ -993,7 +993,7 @@ export class ConfigServiceV2Client {
    */
   deleteBucket(
     request?: protos.google.logging.v2.IDeleteBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1008,7 +1008,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteBucket(
     request: protos.google.logging.v2.IDeleteBucketRequest,
@@ -1016,7 +1016,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteBucket(
     request?: protos.google.logging.v2.IDeleteBucketRequest,
@@ -1031,7 +1031,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1085,7 +1085,7 @@ export class ConfigServiceV2Client {
    */
   undeleteBucket(
     request?: protos.google.logging.v2.IUndeleteBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1100,7 +1100,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IUndeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   undeleteBucket(
     request: protos.google.logging.v2.IUndeleteBucketRequest,
@@ -1108,7 +1108,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IUndeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   undeleteBucket(
     request?: protos.google.logging.v2.IUndeleteBucketRequest,
@@ -1123,7 +1123,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IUndeleteBucketRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1173,7 +1173,7 @@ export class ConfigServiceV2Client {
    */
   getView(
     request?: protos.google.logging.v2.IGetViewRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1188,7 +1188,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IGetViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getView(
     request: protos.google.logging.v2.IGetViewRequest,
@@ -1196,7 +1196,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IGetViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getView(
     request?: protos.google.logging.v2.IGetViewRequest,
@@ -1211,7 +1211,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IGetViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1268,7 +1268,7 @@ export class ConfigServiceV2Client {
    */
   createView(
     request?: protos.google.logging.v2.ICreateViewRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1283,7 +1283,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.ICreateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createView(
     request: protos.google.logging.v2.ICreateViewRequest,
@@ -1291,7 +1291,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.ICreateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createView(
     request?: protos.google.logging.v2.ICreateViewRequest,
@@ -1306,7 +1306,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.ICreateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1371,7 +1371,7 @@ export class ConfigServiceV2Client {
    */
   updateView(
     request?: protos.google.logging.v2.IUpdateViewRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1386,7 +1386,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IUpdateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateView(
     request: protos.google.logging.v2.IUpdateViewRequest,
@@ -1394,7 +1394,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IUpdateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateView(
     request?: protos.google.logging.v2.IUpdateViewRequest,
@@ -1409,7 +1409,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogView,
       protos.google.logging.v2.IUpdateViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogView,
@@ -1462,7 +1462,7 @@ export class ConfigServiceV2Client {
    */
   deleteView(
     request?: protos.google.logging.v2.IDeleteViewRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1477,7 +1477,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteView(
     request: protos.google.logging.v2.IDeleteViewRequest,
@@ -1485,7 +1485,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteView(
     request?: protos.google.logging.v2.IDeleteViewRequest,
@@ -1500,7 +1500,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteViewRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1553,7 +1553,7 @@ export class ConfigServiceV2Client {
    */
   getSink(
     request?: protos.google.logging.v2.IGetSinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1568,7 +1568,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IGetSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getSink(
     request: protos.google.logging.v2.IGetSinkRequest,
@@ -1576,7 +1576,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IGetSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getSink(
     request?: protos.google.logging.v2.IGetSinkRequest,
@@ -1591,7 +1591,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IGetSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1664,7 +1664,7 @@ export class ConfigServiceV2Client {
    */
   createSink(
     request?: protos.google.logging.v2.ICreateSinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1679,7 +1679,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.ICreateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createSink(
     request: protos.google.logging.v2.ICreateSinkRequest,
@@ -1687,7 +1687,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.ICreateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createSink(
     request?: protos.google.logging.v2.ICreateSinkRequest,
@@ -1702,7 +1702,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.ICreateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1792,7 +1792,7 @@ export class ConfigServiceV2Client {
    */
   updateSink(
     request?: protos.google.logging.v2.IUpdateSinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1807,7 +1807,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IUpdateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateSink(
     request: protos.google.logging.v2.IUpdateSinkRequest,
@@ -1815,7 +1815,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IUpdateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateSink(
     request?: protos.google.logging.v2.IUpdateSinkRequest,
@@ -1830,7 +1830,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogSink,
       protos.google.logging.v2.IUpdateSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogSink,
@@ -1885,7 +1885,7 @@ export class ConfigServiceV2Client {
    */
   deleteSink(
     request?: protos.google.logging.v2.IDeleteSinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1900,7 +1900,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteSink(
     request: protos.google.logging.v2.IDeleteSinkRequest,
@@ -1908,7 +1908,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteSink(
     request?: protos.google.logging.v2.IDeleteSinkRequest,
@@ -1923,7 +1923,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteSinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -1972,7 +1972,7 @@ export class ConfigServiceV2Client {
    */
   getLink(
     request?: protos.google.logging.v2.IGetLinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILink,
@@ -1987,7 +1987,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILink,
       protos.google.logging.v2.IGetLinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getLink(
     request: protos.google.logging.v2.IGetLinkRequest,
@@ -1995,7 +1995,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILink,
       protos.google.logging.v2.IGetLinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getLink(
     request?: protos.google.logging.v2.IGetLinkRequest,
@@ -2010,7 +2010,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILink,
       protos.google.logging.v2.IGetLinkRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILink,
@@ -2063,7 +2063,7 @@ export class ConfigServiceV2Client {
    */
   getExclusion(
     request?: protos.google.logging.v2.IGetExclusionRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2078,7 +2078,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IGetExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getExclusion(
     request: protos.google.logging.v2.IGetExclusionRequest,
@@ -2086,7 +2086,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IGetExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getExclusion(
     request?: protos.google.logging.v2.IGetExclusionRequest,
@@ -2101,7 +2101,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IGetExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2160,7 +2160,7 @@ export class ConfigServiceV2Client {
    */
   createExclusion(
     request?: protos.google.logging.v2.ICreateExclusionRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2175,7 +2175,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.ICreateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createExclusion(
     request: protos.google.logging.v2.ICreateExclusionRequest,
@@ -2183,7 +2183,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.ICreateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createExclusion(
     request?: protos.google.logging.v2.ICreateExclusionRequest,
@@ -2198,7 +2198,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.ICreateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2264,7 +2264,7 @@ export class ConfigServiceV2Client {
    */
   updateExclusion(
     request?: protos.google.logging.v2.IUpdateExclusionRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2279,7 +2279,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IUpdateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateExclusion(
     request: protos.google.logging.v2.IUpdateExclusionRequest,
@@ -2287,7 +2287,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IUpdateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateExclusion(
     request?: protos.google.logging.v2.IUpdateExclusionRequest,
@@ -2302,7 +2302,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ILogExclusion,
       protos.google.logging.v2.IUpdateExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion,
@@ -2355,7 +2355,7 @@ export class ConfigServiceV2Client {
    */
   deleteExclusion(
     request?: protos.google.logging.v2.IDeleteExclusionRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -2370,7 +2370,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteExclusion(
     request: protos.google.logging.v2.IDeleteExclusionRequest,
@@ -2378,7 +2378,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteExclusion(
     request?: protos.google.logging.v2.IDeleteExclusionRequest,
@@ -2393,7 +2393,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteExclusionRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -2460,7 +2460,7 @@ export class ConfigServiceV2Client {
    */
   getCmekSettings(
     request?: protos.google.logging.v2.IGetCmekSettingsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ICmekSettings,
@@ -2475,7 +2475,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IGetCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getCmekSettings(
     request: protos.google.logging.v2.IGetCmekSettingsRequest,
@@ -2483,7 +2483,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IGetCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getCmekSettings(
     request?: protos.google.logging.v2.IGetCmekSettingsRequest,
@@ -2498,7 +2498,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IGetCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ICmekSettings,
@@ -2583,7 +2583,7 @@ export class ConfigServiceV2Client {
    */
   updateCmekSettings(
     request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ICmekSettings,
@@ -2598,7 +2598,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IUpdateCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateCmekSettings(
     request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
@@ -2606,7 +2606,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IUpdateCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateCmekSettings(
     request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
@@ -2623,7 +2623,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ICmekSettings,
       protos.google.logging.v2.IUpdateCmekSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ICmekSettings,
@@ -2690,7 +2690,7 @@ export class ConfigServiceV2Client {
    */
   getSettings(
     request?: protos.google.logging.v2.IGetSettingsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ISettings,
@@ -2705,7 +2705,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IGetSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getSettings(
     request: protos.google.logging.v2.IGetSettingsRequest,
@@ -2713,7 +2713,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IGetSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getSettings(
     request?: protos.google.logging.v2.IGetSettingsRequest,
@@ -2728,7 +2728,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IGetSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ISettings,
@@ -2811,7 +2811,7 @@ export class ConfigServiceV2Client {
    */
   updateSettings(
     request?: protos.google.logging.v2.IUpdateSettingsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ISettings,
@@ -2826,7 +2826,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IUpdateSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateSettings(
     request: protos.google.logging.v2.IUpdateSettingsRequest,
@@ -2834,7 +2834,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IUpdateSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateSettings(
     request?: protos.google.logging.v2.IUpdateSettingsRequest,
@@ -2849,7 +2849,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.ISettings,
       protos.google.logging.v2.IUpdateSettingsRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ISettings,
@@ -2912,7 +2912,7 @@ export class ConfigServiceV2Client {
    */
   createBucketAsync(
     request?: protos.google.logging.v2.ICreateBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       LROperation<
@@ -2933,7 +2933,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createBucketAsync(
     request: protos.google.logging.v2.ICreateBucketRequest,
@@ -2944,7 +2944,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createBucketAsync(
     request?: protos.google.logging.v2.ICreateBucketRequest,
@@ -2965,7 +2965,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       LROperation<
@@ -3006,7 +3006,7 @@ export class ConfigServiceV2Client {
    * region_tag:logging_v2_generated_ConfigServiceV2_CreateBucketAsync_async
    */
   async checkCreateBucketAsyncProgress(
-    name: string,
+    name: string
   ): Promise<
     LROperation<
       protos.google.logging.v2.LogBucket,
@@ -3015,13 +3015,13 @@ export class ConfigServiceV2Client {
   > {
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        {name},
+        {name}
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
       operation,
       this.descriptors.longrunning.createBucketAsync,
-      this._gaxModule.createDefaultBackoffSettings(),
+      this._gaxModule.createDefaultBackoffSettings()
     );
     return decodeOperation as LROperation<
       protos.google.logging.v2.LogBucket,
@@ -3073,7 +3073,7 @@ export class ConfigServiceV2Client {
    */
   updateBucketAsync(
     request?: protos.google.logging.v2.IUpdateBucketRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       LROperation<
@@ -3094,7 +3094,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateBucketAsync(
     request: protos.google.logging.v2.IUpdateBucketRequest,
@@ -3105,7 +3105,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateBucketAsync(
     request?: protos.google.logging.v2.IUpdateBucketRequest,
@@ -3126,7 +3126,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       LROperation<
@@ -3167,7 +3167,7 @@ export class ConfigServiceV2Client {
    * region_tag:logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_async
    */
   async checkUpdateBucketAsyncProgress(
-    name: string,
+    name: string
   ): Promise<
     LROperation<
       protos.google.logging.v2.LogBucket,
@@ -3176,13 +3176,13 @@ export class ConfigServiceV2Client {
   > {
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        {name},
+        {name}
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
       operation,
       this.descriptors.longrunning.updateBucketAsync,
-      this._gaxModule.createDefaultBackoffSettings(),
+      this._gaxModule.createDefaultBackoffSettings()
     );
     return decodeOperation as LROperation<
       protos.google.logging.v2.LogBucket,
@@ -3222,7 +3222,7 @@ export class ConfigServiceV2Client {
    */
   createLink(
     request?: protos.google.logging.v2.ICreateLinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       LROperation<
@@ -3243,7 +3243,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createLink(
     request: protos.google.logging.v2.ICreateLinkRequest,
@@ -3254,7 +3254,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createLink(
     request?: protos.google.logging.v2.ICreateLinkRequest,
@@ -3275,7 +3275,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       LROperation<
@@ -3316,7 +3316,7 @@ export class ConfigServiceV2Client {
    * region_tag:logging_v2_generated_ConfigServiceV2_CreateLink_async
    */
   async checkCreateLinkProgress(
-    name: string,
+    name: string
   ): Promise<
     LROperation<
       protos.google.logging.v2.Link,
@@ -3325,13 +3325,13 @@ export class ConfigServiceV2Client {
   > {
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        {name},
+        {name}
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
       operation,
       this.descriptors.longrunning.createLink,
-      this._gaxModule.createDefaultBackoffSettings(),
+      this._gaxModule.createDefaultBackoffSettings()
     );
     return decodeOperation as LROperation<
       protos.google.logging.v2.Link,
@@ -3364,7 +3364,7 @@ export class ConfigServiceV2Client {
    */
   deleteLink(
     request?: protos.google.logging.v2.IDeleteLinkRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       LROperation<
@@ -3385,7 +3385,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLink(
     request: protos.google.logging.v2.IDeleteLinkRequest,
@@ -3396,7 +3396,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLink(
     request?: protos.google.logging.v2.IDeleteLinkRequest,
@@ -3417,7 +3417,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       LROperation<
@@ -3458,7 +3458,7 @@ export class ConfigServiceV2Client {
    * region_tag:logging_v2_generated_ConfigServiceV2_DeleteLink_async
    */
   async checkDeleteLinkProgress(
-    name: string,
+    name: string
   ): Promise<
     LROperation<
       protos.google.protobuf.Empty,
@@ -3467,13 +3467,13 @@ export class ConfigServiceV2Client {
   > {
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        {name},
+        {name}
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
       operation,
       this.descriptors.longrunning.deleteLink,
-      this._gaxModule.createDefaultBackoffSettings(),
+      this._gaxModule.createDefaultBackoffSettings()
     );
     return decodeOperation as LROperation<
       protos.google.protobuf.Empty,
@@ -3509,7 +3509,7 @@ export class ConfigServiceV2Client {
    */
   copyLogEntries(
     request?: protos.google.logging.v2.ICopyLogEntriesRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       LROperation<
@@ -3530,7 +3530,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   copyLogEntries(
     request: protos.google.logging.v2.ICopyLogEntriesRequest,
@@ -3541,7 +3541,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   copyLogEntries(
     request?: protos.google.logging.v2.ICopyLogEntriesRequest,
@@ -3562,7 +3562,7 @@ export class ConfigServiceV2Client {
       >,
       protos.google.longrunning.IOperation | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       LROperation<
@@ -3599,7 +3599,7 @@ export class ConfigServiceV2Client {
    * region_tag:logging_v2_generated_ConfigServiceV2_CopyLogEntries_async
    */
   async checkCopyLogEntriesProgress(
-    name: string,
+    name: string
   ): Promise<
     LROperation<
       protos.google.logging.v2.CopyLogEntriesResponse,
@@ -3608,13 +3608,13 @@ export class ConfigServiceV2Client {
   > {
     const request =
       new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest(
-        {name},
+        {name}
       );
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new this._gaxModule.Operation(
       operation,
       this.descriptors.longrunning.copyLogEntries,
-      this._gaxModule.createDefaultBackoffSettings(),
+      this._gaxModule.createDefaultBackoffSettings()
     );
     return decodeOperation as LROperation<
       protos.google.logging.v2.CopyLogEntriesResponse,
@@ -3660,7 +3660,7 @@ export class ConfigServiceV2Client {
    */
   listBuckets(
     request?: protos.google.logging.v2.IListBucketsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket[],
@@ -3675,7 +3675,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListBucketsRequest,
       protos.google.logging.v2.IListBucketsResponse | null | undefined,
       protos.google.logging.v2.ILogBucket
-    >,
+    >
   ): void;
   listBuckets(
     request: protos.google.logging.v2.IListBucketsRequest,
@@ -3683,7 +3683,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListBucketsRequest,
       protos.google.logging.v2.IListBucketsResponse | null | undefined,
       protos.google.logging.v2.ILogBucket
-    >,
+    >
   ): void;
   listBuckets(
     request?: protos.google.logging.v2.IListBucketsRequest,
@@ -3698,7 +3698,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListBucketsRequest,
       protos.google.logging.v2.IListBucketsResponse | null | undefined,
       protos.google.logging.v2.ILogBucket
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogBucket[],
@@ -3762,7 +3762,7 @@ export class ConfigServiceV2Client {
    */
   listBucketsStream(
     request?: protos.google.logging.v2.IListBucketsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -3778,7 +3778,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listBuckets.createStream(
       this.innerApiCalls.listBuckets as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -3822,7 +3822,7 @@ export class ConfigServiceV2Client {
    */
   listBucketsAsync(
     request?: protos.google.logging.v2.IListBucketsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogBucket> {
     request = request || {};
     options = options || {};
@@ -3838,7 +3838,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listBuckets.asyncIterate(
       this.innerApiCalls['listBuckets'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
   }
   /**
@@ -3874,7 +3874,7 @@ export class ConfigServiceV2Client {
    */
   listViews(
     request?: protos.google.logging.v2.IListViewsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogView[],
@@ -3889,7 +3889,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListViewsRequest,
       protos.google.logging.v2.IListViewsResponse | null | undefined,
       protos.google.logging.v2.ILogView
-    >,
+    >
   ): void;
   listViews(
     request: protos.google.logging.v2.IListViewsRequest,
@@ -3897,7 +3897,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListViewsRequest,
       protos.google.logging.v2.IListViewsResponse | null | undefined,
       protos.google.logging.v2.ILogView
-    >,
+    >
   ): void;
   listViews(
     request?: protos.google.logging.v2.IListViewsRequest,
@@ -3912,7 +3912,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListViewsRequest,
       protos.google.logging.v2.IListViewsResponse | null | undefined,
       protos.google.logging.v2.ILogView
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogView[],
@@ -3970,7 +3970,7 @@ export class ConfigServiceV2Client {
    */
   listViewsStream(
     request?: protos.google.logging.v2.IListViewsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -3986,7 +3986,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listViews.createStream(
       this.innerApiCalls.listViews as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -4024,7 +4024,7 @@ export class ConfigServiceV2Client {
    */
   listViewsAsync(
     request?: protos.google.logging.v2.IListViewsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogView> {
     request = request || {};
     options = options || {};
@@ -4040,7 +4040,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listViews.asyncIterate(
       this.innerApiCalls['listViews'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogView>;
   }
   /**
@@ -4078,7 +4078,7 @@ export class ConfigServiceV2Client {
    */
   listSinks(
     request?: protos.google.logging.v2.IListSinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogSink[],
@@ -4093,7 +4093,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListSinksRequest,
       protos.google.logging.v2.IListSinksResponse | null | undefined,
       protos.google.logging.v2.ILogSink
-    >,
+    >
   ): void;
   listSinks(
     request: protos.google.logging.v2.IListSinksRequest,
@@ -4101,7 +4101,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListSinksRequest,
       protos.google.logging.v2.IListSinksResponse | null | undefined,
       protos.google.logging.v2.ILogSink
-    >,
+    >
   ): void;
   listSinks(
     request?: protos.google.logging.v2.IListSinksRequest,
@@ -4116,7 +4116,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListSinksRequest,
       protos.google.logging.v2.IListSinksResponse | null | undefined,
       protos.google.logging.v2.ILogSink
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogSink[],
@@ -4176,7 +4176,7 @@ export class ConfigServiceV2Client {
    */
   listSinksStream(
     request?: protos.google.logging.v2.IListSinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -4192,7 +4192,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listSinks.createStream(
       this.innerApiCalls.listSinks as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -4232,7 +4232,7 @@ export class ConfigServiceV2Client {
    */
   listSinksAsync(
     request?: protos.google.logging.v2.IListSinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogSink> {
     request = request || {};
     options = options || {};
@@ -4248,7 +4248,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listSinks.asyncIterate(
       this.innerApiCalls['listSinks'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
   /**
@@ -4283,7 +4283,7 @@ export class ConfigServiceV2Client {
    */
   listLinks(
     request?: protos.google.logging.v2.IListLinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILink[],
@@ -4298,7 +4298,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListLinksRequest,
       protos.google.logging.v2.IListLinksResponse | null | undefined,
       protos.google.logging.v2.ILink
-    >,
+    >
   ): void;
   listLinks(
     request: protos.google.logging.v2.IListLinksRequest,
@@ -4306,7 +4306,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListLinksRequest,
       protos.google.logging.v2.IListLinksResponse | null | undefined,
       protos.google.logging.v2.ILink
-    >,
+    >
   ): void;
   listLinks(
     request?: protos.google.logging.v2.IListLinksRequest,
@@ -4321,7 +4321,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListLinksRequest,
       protos.google.logging.v2.IListLinksResponse | null | undefined,
       protos.google.logging.v2.ILink
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILink[],
@@ -4378,7 +4378,7 @@ export class ConfigServiceV2Client {
    */
   listLinksStream(
     request?: protos.google.logging.v2.IListLinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -4394,7 +4394,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listLinks.createStream(
       this.innerApiCalls.listLinks as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -4431,7 +4431,7 @@ export class ConfigServiceV2Client {
    */
   listLinksAsync(
     request?: protos.google.logging.v2.IListLinksRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILink> {
     request = request || {};
     options = options || {};
@@ -4447,7 +4447,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listLinks.asyncIterate(
       this.innerApiCalls['listLinks'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILink>;
   }
   /**
@@ -4485,7 +4485,7 @@ export class ConfigServiceV2Client {
    */
   listExclusions(
     request?: protos.google.logging.v2.IListExclusionsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion[],
@@ -4500,7 +4500,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListExclusionsRequest,
       protos.google.logging.v2.IListExclusionsResponse | null | undefined,
       protos.google.logging.v2.ILogExclusion
-    >,
+    >
   ): void;
   listExclusions(
     request: protos.google.logging.v2.IListExclusionsRequest,
@@ -4508,7 +4508,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListExclusionsRequest,
       protos.google.logging.v2.IListExclusionsResponse | null | undefined,
       protos.google.logging.v2.ILogExclusion
-    >,
+    >
   ): void;
   listExclusions(
     request?: protos.google.logging.v2.IListExclusionsRequest,
@@ -4523,7 +4523,7 @@ export class ConfigServiceV2Client {
       protos.google.logging.v2.IListExclusionsRequest,
       protos.google.logging.v2.IListExclusionsResponse | null | undefined,
       protos.google.logging.v2.ILogExclusion
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogExclusion[],
@@ -4583,7 +4583,7 @@ export class ConfigServiceV2Client {
    */
   listExclusionsStream(
     request?: protos.google.logging.v2.IListExclusionsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -4599,7 +4599,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listExclusions.createStream(
       this.innerApiCalls.listExclusions as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -4639,7 +4639,7 @@ export class ConfigServiceV2Client {
    */
   listExclusionsAsync(
     request?: protos.google.logging.v2.IListExclusionsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogExclusion> {
     request = request || {};
     options = options || {};
@@ -4655,7 +4655,7 @@ export class ConfigServiceV2Client {
     return this.descriptors.page.listExclusions.asyncIterate(
       this.innerApiCalls['listExclusions'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogExclusion>;
   }
   /**
@@ -4701,7 +4701,7 @@ export class ConfigServiceV2Client {
       protos.google.longrunning.Operation,
       protos.google.longrunning.GetOperationRequest,
       {} | null | undefined
-    >,
+    >
   ): Promise<[protos.google.longrunning.Operation]> {
     return this.operationsClient.getOperation(request, options, callback);
   }
@@ -4737,7 +4737,7 @@ export class ConfigServiceV2Client {
    */
   listOperationsAsync(
     request: protos.google.longrunning.ListOperationsRequest,
-    options?: gax.CallOptions,
+    options?: gax.CallOptions
   ): AsyncIterable<protos.google.longrunning.ListOperationsResponse> {
     return this.operationsClient.listOperationsAsync(request, options);
   }
@@ -4785,7 +4785,7 @@ export class ConfigServiceV2Client {
       protos.google.longrunning.CancelOperationRequest,
       protos.google.protobuf.Empty,
       {} | undefined | null
-    >,
+    >
   ): Promise<protos.google.protobuf.Empty> {
     return this.operationsClient.cancelOperation(request, options, callback);
   }
@@ -4828,7 +4828,7 @@ export class ConfigServiceV2Client {
       protos.google.protobuf.Empty,
       protos.google.longrunning.DeleteOperationRequest,
       {} | null | undefined
-    >,
+    >
   ): Promise<protos.google.protobuf.Empty> {
     return this.operationsClient.deleteOperation(request, options, callback);
   }
@@ -4857,10 +4857,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountCmekSettingsName(
-    billingAccountCmekSettingsName: string,
+    billingAccountCmekSettingsName: string
   ) {
     return this.pathTemplates.billingAccountCmekSettingsPathTemplate.match(
-      billingAccountCmekSettingsName,
+      billingAccountCmekSettingsName
     ).billing_account;
   }
 
@@ -4886,10 +4886,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).billing_account;
   }
 
@@ -4901,10 +4901,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).exclusion;
   }
 
@@ -4919,7 +4919,7 @@ export class ConfigServiceV2Client {
   billingAccountLocationBucketPath(
     billingAccount: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.render({
       billing_account: billingAccount,
@@ -4936,10 +4936,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).billing_account;
   }
 
@@ -4951,10 +4951,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).location;
   }
 
@@ -4966,10 +4966,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).bucket;
   }
 
@@ -4986,7 +4986,7 @@ export class ConfigServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.render(
       {
@@ -4994,7 +4994,7 @@ export class ConfigServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -5006,10 +5006,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).billing_account;
   }
 
@@ -5021,10 +5021,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).location;
   }
 
@@ -5036,10 +5036,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).bucket;
   }
 
@@ -5051,10 +5051,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).link;
   }
 
@@ -5071,7 +5071,7 @@ export class ConfigServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render(
       {
@@ -5079,7 +5079,7 @@ export class ConfigServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -5091,10 +5091,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).billing_account;
   }
 
@@ -5106,10 +5106,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).location;
   }
 
@@ -5121,10 +5121,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).bucket;
   }
 
@@ -5136,10 +5136,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).view;
   }
 
@@ -5166,7 +5166,7 @@ export class ConfigServiceV2Client {
    */
   matchBillingAccountFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).billing_account;
   }
 
@@ -5179,7 +5179,7 @@ export class ConfigServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).log;
   }
 
@@ -5203,10 +5203,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSettingsName(
-    billingAccountSettingsName: string,
+    billingAccountSettingsName: string
   ) {
     return this.pathTemplates.billingAccountSettingsPathTemplate.match(
-      billingAccountSettingsName,
+      billingAccountSettingsName
     ).billing_account;
   }
 
@@ -5232,10 +5232,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSinkName(
-    billingAccountSinkName: string,
+    billingAccountSinkName: string
   ) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).billing_account;
   }
 
@@ -5248,7 +5248,7 @@ export class ConfigServiceV2Client {
    */
   matchSinkFromBillingAccountSinkName(billingAccountSinkName: string) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).sink;
   }
 
@@ -5273,7 +5273,7 @@ export class ConfigServiceV2Client {
    */
   matchFolderFromFolderCmekSettingsName(folderCmekSettingsName: string) {
     return this.pathTemplates.folderCmekSettingsPathTemplate.match(
-      folderCmekSettingsName,
+      folderCmekSettingsName
     ).folder;
   }
 
@@ -5300,7 +5300,7 @@ export class ConfigServiceV2Client {
    */
   matchFolderFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).folder;
   }
 
@@ -5313,7 +5313,7 @@ export class ConfigServiceV2Client {
    */
   matchExclusionFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).exclusion;
   }
 
@@ -5342,7 +5342,7 @@ export class ConfigServiceV2Client {
    */
   matchFolderFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).folder;
   }
 
@@ -5355,7 +5355,7 @@ export class ConfigServiceV2Client {
    */
   matchLocationFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).location;
   }
 
@@ -5368,7 +5368,7 @@ export class ConfigServiceV2Client {
    */
   matchBucketFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).bucket;
   }
 
@@ -5385,7 +5385,7 @@ export class ConfigServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.render({
       folder: folder,
@@ -5403,10 +5403,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).folder;
   }
 
@@ -5418,10 +5418,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).location;
   }
 
@@ -5433,10 +5433,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).bucket;
   }
 
@@ -5448,10 +5448,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).link;
   }
 
@@ -5468,7 +5468,7 @@ export class ConfigServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
       folder: folder,
@@ -5486,10 +5486,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).folder;
   }
 
@@ -5501,10 +5501,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).location;
   }
 
@@ -5516,10 +5516,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).bucket;
   }
 
@@ -5531,10 +5531,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).view;
   }
 
@@ -5595,7 +5595,7 @@ export class ConfigServiceV2Client {
    */
   matchFolderFromFolderSettingsName(folderSettingsName: string) {
     return this.pathTemplates.folderSettingsPathTemplate.match(
-      folderSettingsName,
+      folderSettingsName
     ).folder;
   }
 
@@ -5729,10 +5729,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationCmekSettingsName(
-    organizationCmekSettingsName: string,
+    organizationCmekSettingsName: string
   ) {
     return this.pathTemplates.organizationCmekSettingsPathTemplate.match(
-      organizationCmekSettingsName,
+      organizationCmekSettingsName
     ).organization;
   }
 
@@ -5758,10 +5758,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).organization;
   }
 
@@ -5773,10 +5773,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).exclusion;
   }
 
@@ -5791,7 +5791,7 @@ export class ConfigServiceV2Client {
   organizationLocationBucketPath(
     organization: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.render({
       organization: organization,
@@ -5808,10 +5808,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).organization;
   }
 
@@ -5823,10 +5823,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).location;
   }
 
@@ -5838,10 +5838,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).bucket;
   }
 
@@ -5858,7 +5858,7 @@ export class ConfigServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.render(
       {
@@ -5866,7 +5866,7 @@ export class ConfigServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -5878,10 +5878,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).organization;
   }
 
@@ -5893,10 +5893,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).location;
   }
 
@@ -5908,10 +5908,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).bucket;
   }
 
@@ -5923,10 +5923,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).link;
   }
 
@@ -5943,7 +5943,7 @@ export class ConfigServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.render(
       {
@@ -5951,7 +5951,7 @@ export class ConfigServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -5963,10 +5963,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).organization;
   }
 
@@ -5978,10 +5978,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).location;
   }
 
@@ -5993,10 +5993,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).bucket;
   }
 
@@ -6008,10 +6008,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).view;
   }
 
@@ -6038,7 +6038,7 @@ export class ConfigServiceV2Client {
    */
   matchOrganizationFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).organization;
   }
 
@@ -6051,7 +6051,7 @@ export class ConfigServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).log;
   }
 
@@ -6075,10 +6075,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationSettingsName(
-    organizationSettingsName: string,
+    organizationSettingsName: string
   ) {
     return this.pathTemplates.organizationSettingsPathTemplate.match(
-      organizationSettingsName,
+      organizationSettingsName
     ).organization;
   }
 
@@ -6105,7 +6105,7 @@ export class ConfigServiceV2Client {
    */
   matchOrganizationFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).organization;
   }
 
@@ -6118,7 +6118,7 @@ export class ConfigServiceV2Client {
    */
   matchSinkFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).sink;
   }
 
@@ -6166,7 +6166,7 @@ export class ConfigServiceV2Client {
    */
   matchProjectFromProjectCmekSettingsName(projectCmekSettingsName: string) {
     return this.pathTemplates.projectCmekSettingsPathTemplate.match(
-      projectCmekSettingsName,
+      projectCmekSettingsName
     ).project;
   }
 
@@ -6193,7 +6193,7 @@ export class ConfigServiceV2Client {
    */
   matchProjectFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).project;
   }
 
@@ -6206,7 +6206,7 @@ export class ConfigServiceV2Client {
    */
   matchExclusionFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).exclusion;
   }
 
@@ -6235,7 +6235,7 @@ export class ConfigServiceV2Client {
    */
   matchProjectFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).project;
   }
 
@@ -6247,10 +6247,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketName(
-    projectLocationBucketName: string,
+    projectLocationBucketName: string
   ) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).location;
   }
 
@@ -6263,7 +6263,7 @@ export class ConfigServiceV2Client {
    */
   matchBucketFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).bucket;
   }
 
@@ -6280,7 +6280,7 @@ export class ConfigServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.render({
       project: project,
@@ -6298,10 +6298,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).project;
   }
 
@@ -6313,10 +6313,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).location;
   }
 
@@ -6328,10 +6328,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).bucket;
   }
 
@@ -6343,10 +6343,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).link;
   }
 
@@ -6363,7 +6363,7 @@ export class ConfigServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
       project: project,
@@ -6381,10 +6381,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).project;
   }
 
@@ -6396,10 +6396,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).location;
   }
 
@@ -6411,10 +6411,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).bucket;
   }
 
@@ -6426,10 +6426,10 @@ export class ConfigServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).view;
   }
 
@@ -6491,7 +6491,7 @@ export class ConfigServiceV2Client {
    */
   matchProjectFromProjectSettingsName(projectSettingsName: string) {
     return this.pathTemplates.projectSettingsPathTemplate.match(
-      projectSettingsName,
+      projectSettingsName
     ).project;
   }
 

--- a/handwritten/logging/src/v2/logging_service_v2_client.ts
+++ b/handwritten/logging/src/v2/logging_service_v2_client.ts
@@ -106,7 +106,7 @@ export class LoggingServiceV2Client {
    */
   constructor(
     opts?: ClientOptions,
-    gaxInstance?: typeof gax | typeof gax.fallback,
+    gaxInstance?: typeof gax | typeof gax.fallback
   ) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
@@ -116,7 +116,7 @@ export class LoggingServiceV2Client {
       opts?.universe_domain !== opts?.universeDomain
     ) {
       throw new Error(
-        'Please set either universe_domain or universeDomain, but not both.',
+        'Please set either universe_domain or universeDomain, but not both.'
       );
     }
     const universeDomainEnvVar =
@@ -200,111 +200,111 @@ export class LoggingServiceV2Client {
     // Create useful helper objects for these.
     this.pathTemplates = {
       billingAccountCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/cmekSettings',
+        'billingAccounts/{billing_account}/cmekSettings'
       ),
       billingAccountExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/exclusions/{exclusion}',
+        'billingAccounts/{billing_account}/exclusions/{exclusion}'
       ),
       billingAccountLocationBucketPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
         ),
       billingAccountLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       billingAccountLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/logs/{log}',
+        'billingAccounts/{billing_account}/logs/{log}'
       ),
       billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/settings',
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/sinks/{sink}',
+        'billingAccounts/{billing_account}/sinks/{sink}'
       ),
       folderCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/cmekSettings',
+        'folders/{folder}/cmekSettings'
       ),
       folderExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/exclusions/{exclusion}',
+        'folders/{folder}/exclusions/{exclusion}'
       ),
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
       folderLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/logs/{log}',
+        'folders/{folder}/logs/{log}'
       ),
       folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/settings',
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/sinks/{sink}',
+        'folders/{folder}/sinks/{sink}'
       ),
       logMetricPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/metrics/{metric}',
+        'projects/{project}/metrics/{metric}'
       ),
       organizationCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/cmekSettings',
+        'organizations/{organization}/cmekSettings'
       ),
       organizationExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/exclusions/{exclusion}',
+        'organizations/{organization}/exclusions/{exclusion}'
       ),
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/locations/{location}/buckets/{bucket}',
+        'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
       organizationLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       organizationLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/logs/{log}',
+        'organizations/{organization}/logs/{log}'
       ),
       organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/settings',
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/sinks/{sink}',
+        'organizations/{organization}/sinks/{sink}'
       ),
       projectPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}',
+        'projects/{project}'
       ),
       projectCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/cmekSettings',
+        'projects/{project}/cmekSettings'
       ),
       projectExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/exclusions/{exclusion}',
+        'projects/{project}/exclusions/{exclusion}'
       ),
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}',
+        'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
       projectLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/logs/{log}',
+        'projects/{project}/logs/{log}'
       ),
       projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/settings',
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/sinks/{sink}',
+        'projects/{project}/sinks/{sink}'
       ),
     };
 
@@ -315,17 +315,17 @@ export class LoggingServiceV2Client {
       listLogEntries: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'entries',
+        'entries'
       ),
       listMonitoredResourceDescriptors: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'resourceDescriptors',
+        'resourceDescriptors'
       ),
       listLogs: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'logNames',
+        'logNames'
       ),
     };
 
@@ -335,7 +335,7 @@ export class LoggingServiceV2Client {
       tailLogEntries: new this._gaxModule.StreamDescriptor(
         this._gaxModule.StreamType.BIDI_STREAMING,
         !!opts.fallback,
-        !!opts.gaxServerStreamingRetries,
+        !!opts.gaxServerStreamingRetries
       ),
     };
 
@@ -350,8 +350,8 @@ export class LoggingServiceV2Client {
         null,
         this._gaxModule.GrpcClient.createByteLengthFunction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          protoFilesRoot.lookupType('google.logging.v2.LogEntry') as any,
-        ),
+          protoFilesRoot.lookupType('google.logging.v2.LogEntry') as any
+        )
       ),
     };
 
@@ -360,7 +360,7 @@ export class LoggingServiceV2Client {
       'google.logging.v2.LoggingServiceV2',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      {'x-goog-api-client': clientHeader.join(' ')},
+      {'x-goog-api-client': clientHeader.join(' ')}
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -394,12 +394,12 @@ export class LoggingServiceV2Client {
     this.loggingServiceV2Stub = this._gaxGrpc.createStub(
       this._opts.fallback
         ? (this._protos as protobuf.Root).lookupService(
-            'google.logging.v2.LoggingServiceV2',
+            'google.logging.v2.LoggingServiceV2'
           )
         : // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.logging.v2.LoggingServiceV2,
       this._opts,
-      this._providedCustomServicePath,
+      this._providedCustomServicePath
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -423,8 +423,8 @@ export class LoggingServiceV2Client {
                   stream.emit(
                     'error',
                     new this._gaxModule.GoogleError(
-                      'The client has already been closed.',
-                    ),
+                      'The client has already been closed.'
+                    )
                   );
                 });
                 return stream;
@@ -436,7 +436,7 @@ export class LoggingServiceV2Client {
           },
         (err: Error | null | undefined) => () => {
           throw err;
-        },
+        }
       );
 
       const descriptor =
@@ -448,7 +448,7 @@ export class LoggingServiceV2Client {
         callPromise,
         this._defaults[methodName],
         descriptor,
-        this._opts.fallback,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -469,7 +469,7 @@ export class LoggingServiceV2Client {
     ) {
       process.emitWarning(
         'Static servicePath is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -487,7 +487,7 @@ export class LoggingServiceV2Client {
     ) {
       process.emitWarning(
         'Static apiEndpoint is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -535,7 +535,7 @@ export class LoggingServiceV2Client {
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
-    callback?: Callback<string, undefined, undefined>,
+    callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
     if (callback) {
       this.auth.getProjectId(callback);
@@ -580,7 +580,7 @@ export class LoggingServiceV2Client {
    */
   deleteLog(
     request?: protos.google.logging.v2.IDeleteLogRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -595,7 +595,7 @@ export class LoggingServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLog(
     request: protos.google.logging.v2.IDeleteLogRequest,
@@ -603,7 +603,7 @@ export class LoggingServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLog(
     request?: protos.google.logging.v2.IDeleteLogRequest,
@@ -618,7 +618,7 @@ export class LoggingServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -735,7 +735,7 @@ export class LoggingServiceV2Client {
    */
   writeLogEntries(
     request?: protos.google.logging.v2.IWriteLogEntriesRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.IWriteLogEntriesResponse,
@@ -750,7 +750,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IWriteLogEntriesResponse,
       protos.google.logging.v2.IWriteLogEntriesRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   writeLogEntries(
     request: protos.google.logging.v2.IWriteLogEntriesRequest,
@@ -758,7 +758,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IWriteLogEntriesResponse,
       protos.google.logging.v2.IWriteLogEntriesRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   writeLogEntries(
     request?: protos.google.logging.v2.IWriteLogEntriesRequest,
@@ -773,7 +773,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IWriteLogEntriesResponse,
       protos.google.logging.v2.IWriteLogEntriesRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.IWriteLogEntriesResponse,
@@ -879,7 +879,7 @@ export class LoggingServiceV2Client {
    */
   listLogEntries(
     request?: protos.google.logging.v2.IListLogEntriesRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogEntry[],
@@ -894,7 +894,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogEntriesRequest,
       protos.google.logging.v2.IListLogEntriesResponse | null | undefined,
       protos.google.logging.v2.ILogEntry
-    >,
+    >
   ): void;
   listLogEntries(
     request: protos.google.logging.v2.IListLogEntriesRequest,
@@ -902,7 +902,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogEntriesRequest,
       protos.google.logging.v2.IListLogEntriesResponse | null | undefined,
       protos.google.logging.v2.ILogEntry
-    >,
+    >
   ): void;
   listLogEntries(
     request?: protos.google.logging.v2.IListLogEntriesRequest,
@@ -917,7 +917,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogEntriesRequest,
       protos.google.logging.v2.IListLogEntriesResponse | null | undefined,
       protos.google.logging.v2.ILogEntry
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogEntry[],
@@ -998,7 +998,7 @@ export class LoggingServiceV2Client {
    */
   listLogEntriesStream(
     request?: protos.google.logging.v2.IListLogEntriesRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -1010,7 +1010,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listLogEntries.createStream(
       this.innerApiCalls.listLogEntries as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -1075,7 +1075,7 @@ export class LoggingServiceV2Client {
    */
   listLogEntriesAsync(
     request?: protos.google.logging.v2.IListLogEntriesRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogEntry> {
     request = request || {};
     options = options || {};
@@ -1087,7 +1087,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listLogEntries.asyncIterate(
       this.innerApiCalls['listLogEntries'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogEntry>;
   }
   /**
@@ -1118,7 +1118,7 @@ export class LoggingServiceV2Client {
    */
   listMonitoredResourceDescriptors(
     request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.api.IMonitoredResourceDescriptor[],
@@ -1135,7 +1135,7 @@ export class LoggingServiceV2Client {
       | null
       | undefined,
       protos.google.api.IMonitoredResourceDescriptor
-    >,
+    >
   ): void;
   listMonitoredResourceDescriptors(
     request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
@@ -1145,7 +1145,7 @@ export class LoggingServiceV2Client {
       | null
       | undefined,
       protos.google.api.IMonitoredResourceDescriptor
-    >,
+    >
   ): void;
   listMonitoredResourceDescriptors(
     request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
@@ -1164,7 +1164,7 @@ export class LoggingServiceV2Client {
       | null
       | undefined,
       protos.google.api.IMonitoredResourceDescriptor
-    >,
+    >
   ): Promise<
     [
       protos.google.api.IMonitoredResourceDescriptor[],
@@ -1187,7 +1187,7 @@ export class LoggingServiceV2Client {
     return this.innerApiCalls.listMonitoredResourceDescriptors(
       request,
       options,
-      callback,
+      callback
     );
   }
 
@@ -1217,7 +1217,7 @@ export class LoggingServiceV2Client {
    */
   listMonitoredResourceDescriptorsStream(
     request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -1230,7 +1230,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listMonitoredResourceDescriptors.createStream(
       this.innerApiCalls.listMonitoredResourceDescriptors as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -1263,7 +1263,7 @@ export class LoggingServiceV2Client {
    */
   listMonitoredResourceDescriptorsAsync(
     request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.api.IMonitoredResourceDescriptor> {
     request = request || {};
     options = options || {};
@@ -1276,7 +1276,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listMonitoredResourceDescriptors.asyncIterate(
       this.innerApiCalls['listMonitoredResourceDescriptors'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
   /**
@@ -1331,7 +1331,7 @@ export class LoggingServiceV2Client {
    */
   listLogs(
     request?: protos.google.logging.v2.IListLogsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       string[],
@@ -1346,7 +1346,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogsRequest,
       protos.google.logging.v2.IListLogsResponse | null | undefined,
       string
-    >,
+    >
   ): void;
   listLogs(
     request: protos.google.logging.v2.IListLogsRequest,
@@ -1354,7 +1354,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogsRequest,
       protos.google.logging.v2.IListLogsResponse | null | undefined,
       string
-    >,
+    >
   ): void;
   listLogs(
     request?: protos.google.logging.v2.IListLogsRequest,
@@ -1369,7 +1369,7 @@ export class LoggingServiceV2Client {
       protos.google.logging.v2.IListLogsRequest,
       protos.google.logging.v2.IListLogsResponse | null | undefined,
       string
-    >,
+    >
   ): Promise<
     [
       string[],
@@ -1445,7 +1445,7 @@ export class LoggingServiceV2Client {
    */
   listLogsStream(
     request?: protos.google.logging.v2.IListLogsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -1461,7 +1461,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listLogs.createStream(
       this.innerApiCalls.listLogs as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -1517,7 +1517,7 @@ export class LoggingServiceV2Client {
    */
   listLogsAsync(
     request?: protos.google.logging.v2.IListLogsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<string> {
     request = request || {};
     options = options || {};
@@ -1533,7 +1533,7 @@ export class LoggingServiceV2Client {
     return this.descriptors.page.listLogs.asyncIterate(
       this.innerApiCalls['listLogs'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<string>;
   }
   // --------------------
@@ -1560,10 +1560,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountCmekSettingsName(
-    billingAccountCmekSettingsName: string,
+    billingAccountCmekSettingsName: string
   ) {
     return this.pathTemplates.billingAccountCmekSettingsPathTemplate.match(
-      billingAccountCmekSettingsName,
+      billingAccountCmekSettingsName
     ).billing_account;
   }
 
@@ -1589,10 +1589,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).billing_account;
   }
 
@@ -1604,10 +1604,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).exclusion;
   }
 
@@ -1622,7 +1622,7 @@ export class LoggingServiceV2Client {
   billingAccountLocationBucketPath(
     billingAccount: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.render({
       billing_account: billingAccount,
@@ -1639,10 +1639,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).billing_account;
   }
 
@@ -1654,10 +1654,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).location;
   }
 
@@ -1669,10 +1669,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).bucket;
   }
 
@@ -1689,7 +1689,7 @@ export class LoggingServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.render(
       {
@@ -1697,7 +1697,7 @@ export class LoggingServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -1709,10 +1709,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).billing_account;
   }
 
@@ -1724,10 +1724,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).location;
   }
 
@@ -1739,10 +1739,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).bucket;
   }
 
@@ -1754,10 +1754,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).link;
   }
 
@@ -1774,7 +1774,7 @@ export class LoggingServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render(
       {
@@ -1782,7 +1782,7 @@ export class LoggingServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -1794,10 +1794,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).billing_account;
   }
 
@@ -1809,10 +1809,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).location;
   }
 
@@ -1824,10 +1824,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).bucket;
   }
 
@@ -1839,10 +1839,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).view;
   }
 
@@ -1869,7 +1869,7 @@ export class LoggingServiceV2Client {
    */
   matchBillingAccountFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).billing_account;
   }
 
@@ -1882,7 +1882,7 @@ export class LoggingServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).log;
   }
 
@@ -1906,10 +1906,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSettingsName(
-    billingAccountSettingsName: string,
+    billingAccountSettingsName: string
   ) {
     return this.pathTemplates.billingAccountSettingsPathTemplate.match(
-      billingAccountSettingsName,
+      billingAccountSettingsName
     ).billing_account;
   }
 
@@ -1935,10 +1935,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSinkName(
-    billingAccountSinkName: string,
+    billingAccountSinkName: string
   ) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).billing_account;
   }
 
@@ -1951,7 +1951,7 @@ export class LoggingServiceV2Client {
    */
   matchSinkFromBillingAccountSinkName(billingAccountSinkName: string) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).sink;
   }
 
@@ -1976,7 +1976,7 @@ export class LoggingServiceV2Client {
    */
   matchFolderFromFolderCmekSettingsName(folderCmekSettingsName: string) {
     return this.pathTemplates.folderCmekSettingsPathTemplate.match(
-      folderCmekSettingsName,
+      folderCmekSettingsName
     ).folder;
   }
 
@@ -2003,7 +2003,7 @@ export class LoggingServiceV2Client {
    */
   matchFolderFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).folder;
   }
 
@@ -2016,7 +2016,7 @@ export class LoggingServiceV2Client {
    */
   matchExclusionFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).exclusion;
   }
 
@@ -2045,7 +2045,7 @@ export class LoggingServiceV2Client {
    */
   matchFolderFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).folder;
   }
 
@@ -2058,7 +2058,7 @@ export class LoggingServiceV2Client {
    */
   matchLocationFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).location;
   }
 
@@ -2071,7 +2071,7 @@ export class LoggingServiceV2Client {
    */
   matchBucketFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).bucket;
   }
 
@@ -2088,7 +2088,7 @@ export class LoggingServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.render({
       folder: folder,
@@ -2106,10 +2106,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).folder;
   }
 
@@ -2121,10 +2121,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).location;
   }
 
@@ -2136,10 +2136,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).bucket;
   }
 
@@ -2151,10 +2151,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).link;
   }
 
@@ -2171,7 +2171,7 @@ export class LoggingServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
       folder: folder,
@@ -2189,10 +2189,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).folder;
   }
 
@@ -2204,10 +2204,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).location;
   }
 
@@ -2219,10 +2219,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).bucket;
   }
 
@@ -2234,10 +2234,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).view;
   }
 
@@ -2298,7 +2298,7 @@ export class LoggingServiceV2Client {
    */
   matchFolderFromFolderSettingsName(folderSettingsName: string) {
     return this.pathTemplates.folderSettingsPathTemplate.match(
-      folderSettingsName,
+      folderSettingsName
     ).folder;
   }
 
@@ -2396,10 +2396,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationCmekSettingsName(
-    organizationCmekSettingsName: string,
+    organizationCmekSettingsName: string
   ) {
     return this.pathTemplates.organizationCmekSettingsPathTemplate.match(
-      organizationCmekSettingsName,
+      organizationCmekSettingsName
     ).organization;
   }
 
@@ -2425,10 +2425,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).organization;
   }
 
@@ -2440,10 +2440,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).exclusion;
   }
 
@@ -2458,7 +2458,7 @@ export class LoggingServiceV2Client {
   organizationLocationBucketPath(
     organization: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.render({
       organization: organization,
@@ -2475,10 +2475,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).organization;
   }
 
@@ -2490,10 +2490,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).location;
   }
 
@@ -2505,10 +2505,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).bucket;
   }
 
@@ -2525,7 +2525,7 @@ export class LoggingServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.render(
       {
@@ -2533,7 +2533,7 @@ export class LoggingServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -2545,10 +2545,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).organization;
   }
 
@@ -2560,10 +2560,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).location;
   }
 
@@ -2575,10 +2575,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).bucket;
   }
 
@@ -2590,10 +2590,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).link;
   }
 
@@ -2610,7 +2610,7 @@ export class LoggingServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.render(
       {
@@ -2618,7 +2618,7 @@ export class LoggingServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -2630,10 +2630,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).organization;
   }
 
@@ -2645,10 +2645,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).location;
   }
 
@@ -2660,10 +2660,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).bucket;
   }
 
@@ -2675,10 +2675,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).view;
   }
 
@@ -2705,7 +2705,7 @@ export class LoggingServiceV2Client {
    */
   matchOrganizationFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).organization;
   }
 
@@ -2718,7 +2718,7 @@ export class LoggingServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).log;
   }
 
@@ -2742,10 +2742,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationSettingsName(
-    organizationSettingsName: string,
+    organizationSettingsName: string
   ) {
     return this.pathTemplates.organizationSettingsPathTemplate.match(
-      organizationSettingsName,
+      organizationSettingsName
     ).organization;
   }
 
@@ -2772,7 +2772,7 @@ export class LoggingServiceV2Client {
    */
   matchOrganizationFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).organization;
   }
 
@@ -2785,7 +2785,7 @@ export class LoggingServiceV2Client {
    */
   matchSinkFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).sink;
   }
 
@@ -2833,7 +2833,7 @@ export class LoggingServiceV2Client {
    */
   matchProjectFromProjectCmekSettingsName(projectCmekSettingsName: string) {
     return this.pathTemplates.projectCmekSettingsPathTemplate.match(
-      projectCmekSettingsName,
+      projectCmekSettingsName
     ).project;
   }
 
@@ -2860,7 +2860,7 @@ export class LoggingServiceV2Client {
    */
   matchProjectFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).project;
   }
 
@@ -2873,7 +2873,7 @@ export class LoggingServiceV2Client {
    */
   matchExclusionFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).exclusion;
   }
 
@@ -2902,7 +2902,7 @@ export class LoggingServiceV2Client {
    */
   matchProjectFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).project;
   }
 
@@ -2914,10 +2914,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketName(
-    projectLocationBucketName: string,
+    projectLocationBucketName: string
   ) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).location;
   }
 
@@ -2930,7 +2930,7 @@ export class LoggingServiceV2Client {
    */
   matchBucketFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).bucket;
   }
 
@@ -2947,7 +2947,7 @@ export class LoggingServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.render({
       project: project,
@@ -2965,10 +2965,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).project;
   }
 
@@ -2980,10 +2980,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).location;
   }
 
@@ -2995,10 +2995,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).bucket;
   }
 
@@ -3010,10 +3010,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).link;
   }
 
@@ -3030,7 +3030,7 @@ export class LoggingServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
       project: project,
@@ -3048,10 +3048,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).project;
   }
 
@@ -3063,10 +3063,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).location;
   }
 
@@ -3078,10 +3078,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).bucket;
   }
 
@@ -3093,10 +3093,10 @@ export class LoggingServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).view;
   }
 
@@ -3158,7 +3158,7 @@ export class LoggingServiceV2Client {
    */
   matchProjectFromProjectSettingsName(projectSettingsName: string) {
     return this.pathTemplates.projectSettingsPathTemplate.match(
-      projectSettingsName,
+      projectSettingsName
     ).project;
   }
 

--- a/handwritten/logging/src/v2/metrics_service_v2_client.ts
+++ b/handwritten/logging/src/v2/metrics_service_v2_client.ts
@@ -106,7 +106,7 @@ export class MetricsServiceV2Client {
    */
   constructor(
     opts?: ClientOptions,
-    gaxInstance?: typeof gax | typeof gax.fallback,
+    gaxInstance?: typeof gax | typeof gax.fallback
   ) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
@@ -116,7 +116,7 @@ export class MetricsServiceV2Client {
       opts?.universe_domain !== opts?.universeDomain
     ) {
       throw new Error(
-        'Please set either universe_domain or universeDomain, but not both.',
+        'Please set either universe_domain or universeDomain, but not both.'
       );
     }
     const universeDomainEnvVar =
@@ -200,111 +200,111 @@ export class MetricsServiceV2Client {
     // Create useful helper objects for these.
     this.pathTemplates = {
       billingAccountCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/cmekSettings',
+        'billingAccounts/{billing_account}/cmekSettings'
       ),
       billingAccountExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/exclusions/{exclusion}',
+        'billingAccounts/{billing_account}/exclusions/{exclusion}'
       ),
       billingAccountLocationBucketPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
         ),
       billingAccountLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       billingAccountLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}',
+          'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/logs/{log}',
+        'billingAccounts/{billing_account}/logs/{log}'
       ),
       billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/settings',
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'billingAccounts/{billing_account}/sinks/{sink}',
+        'billingAccounts/{billing_account}/sinks/{sink}'
       ),
       folderCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/cmekSettings',
+        'folders/{folder}/cmekSettings'
       ),
       folderExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/exclusions/{exclusion}',
+        'folders/{folder}/exclusions/{exclusion}'
       ),
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
       folderLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}',
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/logs/{log}',
+        'folders/{folder}/logs/{log}'
       ),
       folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/settings',
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'folders/{folder}/sinks/{sink}',
+        'folders/{folder}/sinks/{sink}'
       ),
       logMetricPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/metrics/{metric}',
+        'projects/{project}/metrics/{metric}'
       ),
       organizationCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/cmekSettings',
+        'organizations/{organization}/cmekSettings'
       ),
       organizationExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/exclusions/{exclusion}',
+        'organizations/{organization}/exclusions/{exclusion}'
       ),
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/locations/{location}/buckets/{bucket}',
+        'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
       organizationLocationBucketLinkPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}'
         ),
       organizationLocationBucketViewPathTemplate:
         new this._gaxModule.PathTemplate(
-          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}',
+          'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
         ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/logs/{log}',
+        'organizations/{organization}/logs/{log}'
       ),
       organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/settings',
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'organizations/{organization}/sinks/{sink}',
+        'organizations/{organization}/sinks/{sink}'
       ),
       projectPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}',
+        'projects/{project}'
       ),
       projectCmekSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/cmekSettings',
+        'projects/{project}/cmekSettings'
       ),
       projectExclusionPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/exclusions/{exclusion}',
+        'projects/{project}/exclusions/{exclusion}'
       ),
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}',
+        'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
       projectLocationBucketLinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}'
       ),
       projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}',
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
       ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/logs/{log}',
+        'projects/{project}/logs/{log}'
       ),
       projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/settings',
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
-        'projects/{project}/sinks/{sink}',
+        'projects/{project}/sinks/{sink}'
       ),
     };
 
@@ -315,7 +315,7 @@ export class MetricsServiceV2Client {
       listLogMetrics: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
-        'metrics',
+        'metrics'
       ),
     };
 
@@ -324,7 +324,7 @@ export class MetricsServiceV2Client {
       'google.logging.v2.MetricsServiceV2',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
-      {'x-goog-api-client': clientHeader.join(' ')},
+      {'x-goog-api-client': clientHeader.join(' ')}
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -358,12 +358,12 @@ export class MetricsServiceV2Client {
     this.metricsServiceV2Stub = this._gaxGrpc.createStub(
       this._opts.fallback
         ? (this._protos as protobuf.Root).lookupService(
-            'google.logging.v2.MetricsServiceV2',
+            'google.logging.v2.MetricsServiceV2'
           )
         : // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.logging.v2.MetricsServiceV2,
       this._opts,
-      this._providedCustomServicePath,
+      this._providedCustomServicePath
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -387,7 +387,7 @@ export class MetricsServiceV2Client {
           },
         (err: Error | null | undefined) => () => {
           throw err;
-        },
+        }
       );
 
       const descriptor = this.descriptors.page[methodName] || undefined;
@@ -395,7 +395,7 @@ export class MetricsServiceV2Client {
         callPromise,
         this._defaults[methodName],
         descriptor,
-        this._opts.fallback,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -416,7 +416,7 @@ export class MetricsServiceV2Client {
     ) {
       process.emitWarning(
         'Static servicePath is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -434,7 +434,7 @@ export class MetricsServiceV2Client {
     ) {
       process.emitWarning(
         'Static apiEndpoint is deprecated, please use the instance method instead.',
-        'DeprecationWarning',
+        'DeprecationWarning'
       );
     }
     return 'logging.googleapis.com';
@@ -482,7 +482,7 @@ export class MetricsServiceV2Client {
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
-    callback?: Callback<string, undefined, undefined>,
+    callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
     if (callback) {
       this.auth.getProjectId(callback);
@@ -514,7 +514,7 @@ export class MetricsServiceV2Client {
    */
   getLogMetric(
     request?: protos.google.logging.v2.IGetLogMetricRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -529,7 +529,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IGetLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getLogMetric(
     request: protos.google.logging.v2.IGetLogMetricRequest,
@@ -537,7 +537,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IGetLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   getLogMetric(
     request?: protos.google.logging.v2.IGetLogMetricRequest,
@@ -552,7 +552,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IGetLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -603,7 +603,7 @@ export class MetricsServiceV2Client {
    */
   createLogMetric(
     request?: protos.google.logging.v2.ICreateLogMetricRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -618,7 +618,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.ICreateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createLogMetric(
     request: protos.google.logging.v2.ICreateLogMetricRequest,
@@ -626,7 +626,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.ICreateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   createLogMetric(
     request?: protos.google.logging.v2.ICreateLogMetricRequest,
@@ -641,7 +641,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.ICreateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -693,7 +693,7 @@ export class MetricsServiceV2Client {
    */
   updateLogMetric(
     request?: protos.google.logging.v2.IUpdateLogMetricRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -708,7 +708,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IUpdateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateLogMetric(
     request: protos.google.logging.v2.IUpdateLogMetricRequest,
@@ -716,7 +716,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IUpdateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   updateLogMetric(
     request?: protos.google.logging.v2.IUpdateLogMetricRequest,
@@ -731,7 +731,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.ILogMetric,
       protos.google.logging.v2.IUpdateLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric,
@@ -777,7 +777,7 @@ export class MetricsServiceV2Client {
    */
   deleteLogMetric(
     request?: protos.google.logging.v2.IDeleteLogMetricRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -792,7 +792,7 @@ export class MetricsServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLogMetric(
     request: protos.google.logging.v2.IDeleteLogMetricRequest,
@@ -800,7 +800,7 @@ export class MetricsServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): void;
   deleteLogMetric(
     request?: protos.google.logging.v2.IDeleteLogMetricRequest,
@@ -815,7 +815,7 @@ export class MetricsServiceV2Client {
       protos.google.protobuf.IEmpty,
       protos.google.logging.v2.IDeleteLogMetricRequest | null | undefined,
       {} | null | undefined
-    >,
+    >
   ): Promise<
     [
       protos.google.protobuf.IEmpty,
@@ -874,7 +874,7 @@ export class MetricsServiceV2Client {
    */
   listLogMetrics(
     request?: protos.google.logging.v2.IListLogMetricsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric[],
@@ -889,7 +889,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.IListLogMetricsRequest,
       protos.google.logging.v2.IListLogMetricsResponse | null | undefined,
       protos.google.logging.v2.ILogMetric
-    >,
+    >
   ): void;
   listLogMetrics(
     request: protos.google.logging.v2.IListLogMetricsRequest,
@@ -897,7 +897,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.IListLogMetricsRequest,
       protos.google.logging.v2.IListLogMetricsResponse | null | undefined,
       protos.google.logging.v2.ILogMetric
-    >,
+    >
   ): void;
   listLogMetrics(
     request?: protos.google.logging.v2.IListLogMetricsRequest,
@@ -912,7 +912,7 @@ export class MetricsServiceV2Client {
       protos.google.logging.v2.IListLogMetricsRequest,
       protos.google.logging.v2.IListLogMetricsResponse | null | undefined,
       protos.google.logging.v2.ILogMetric
-    >,
+    >
   ): Promise<
     [
       protos.google.logging.v2.ILogMetric[],
@@ -969,7 +969,7 @@ export class MetricsServiceV2Client {
    */
   listLogMetricsStream(
     request?: protos.google.logging.v2.IListLogMetricsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): Transform {
     request = request || {};
     options = options || {};
@@ -985,7 +985,7 @@ export class MetricsServiceV2Client {
     return this.descriptors.page.listLogMetrics.createStream(
       this.innerApiCalls.listLogMetrics as GaxCall,
       request,
-      callSettings,
+      callSettings
     );
   }
 
@@ -1022,7 +1022,7 @@ export class MetricsServiceV2Client {
    */
   listLogMetricsAsync(
     request?: protos.google.logging.v2.IListLogMetricsRequest,
-    options?: CallOptions,
+    options?: CallOptions
   ): AsyncIterable<protos.google.logging.v2.ILogMetric> {
     request = request || {};
     options = options || {};
@@ -1038,7 +1038,7 @@ export class MetricsServiceV2Client {
     return this.descriptors.page.listLogMetrics.asyncIterate(
       this.innerApiCalls['listLogMetrics'] as GaxCall,
       request as {},
-      callSettings,
+      callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogMetric>;
   }
   // --------------------
@@ -1065,10 +1065,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountCmekSettingsName(
-    billingAccountCmekSettingsName: string,
+    billingAccountCmekSettingsName: string
   ) {
     return this.pathTemplates.billingAccountCmekSettingsPathTemplate.match(
-      billingAccountCmekSettingsName,
+      billingAccountCmekSettingsName
     ).billing_account;
   }
 
@@ -1094,10 +1094,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).billing_account;
   }
 
@@ -1109,10 +1109,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromBillingAccountExclusionName(
-    billingAccountExclusionName: string,
+    billingAccountExclusionName: string
   ) {
     return this.pathTemplates.billingAccountExclusionPathTemplate.match(
-      billingAccountExclusionName,
+      billingAccountExclusionName
     ).exclusion;
   }
 
@@ -1127,7 +1127,7 @@ export class MetricsServiceV2Client {
   billingAccountLocationBucketPath(
     billingAccount: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.render({
       billing_account: billingAccount,
@@ -1144,10 +1144,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).billing_account;
   }
 
@@ -1159,10 +1159,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).location;
   }
 
@@ -1174,10 +1174,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketName(
-    billingAccountLocationBucketName: string,
+    billingAccountLocationBucketName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketPathTemplate.match(
-      billingAccountLocationBucketName,
+      billingAccountLocationBucketName
     ).bucket;
   }
 
@@ -1194,7 +1194,7 @@ export class MetricsServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.render(
       {
@@ -1202,7 +1202,7 @@ export class MetricsServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -1214,10 +1214,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).billing_account;
   }
 
@@ -1229,10 +1229,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).location;
   }
 
@@ -1244,10 +1244,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).bucket;
   }
 
@@ -1259,10 +1259,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromBillingAccountLocationBucketLinkName(
-    billingAccountLocationBucketLinkName: string,
+    billingAccountLocationBucketLinkName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketLinkPathTemplate.match(
-      billingAccountLocationBucketLinkName,
+      billingAccountLocationBucketLinkName
     ).link;
   }
 
@@ -1279,7 +1279,7 @@ export class MetricsServiceV2Client {
     billingAccount: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render(
       {
@@ -1287,7 +1287,7 @@ export class MetricsServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -1299,10 +1299,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).billing_account;
   }
 
@@ -1314,10 +1314,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).location;
   }
 
@@ -1329,10 +1329,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).bucket;
   }
 
@@ -1344,10 +1344,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromBillingAccountLocationBucketViewName(
-    billingAccountLocationBucketViewName: string,
+    billingAccountLocationBucketViewName: string
   ) {
     return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(
-      billingAccountLocationBucketViewName,
+      billingAccountLocationBucketViewName
     ).view;
   }
 
@@ -1374,7 +1374,7 @@ export class MetricsServiceV2Client {
    */
   matchBillingAccountFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).billing_account;
   }
 
@@ -1387,7 +1387,7 @@ export class MetricsServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(
-      billingAccountLogName,
+      billingAccountLogName
     ).log;
   }
 
@@ -1411,10 +1411,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSettingsName(
-    billingAccountSettingsName: string,
+    billingAccountSettingsName: string
   ) {
     return this.pathTemplates.billingAccountSettingsPathTemplate.match(
-      billingAccountSettingsName,
+      billingAccountSettingsName
     ).billing_account;
   }
 
@@ -1440,10 +1440,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the billing_account.
    */
   matchBillingAccountFromBillingAccountSinkName(
-    billingAccountSinkName: string,
+    billingAccountSinkName: string
   ) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).billing_account;
   }
 
@@ -1456,7 +1456,7 @@ export class MetricsServiceV2Client {
    */
   matchSinkFromBillingAccountSinkName(billingAccountSinkName: string) {
     return this.pathTemplates.billingAccountSinkPathTemplate.match(
-      billingAccountSinkName,
+      billingAccountSinkName
     ).sink;
   }
 
@@ -1481,7 +1481,7 @@ export class MetricsServiceV2Client {
    */
   matchFolderFromFolderCmekSettingsName(folderCmekSettingsName: string) {
     return this.pathTemplates.folderCmekSettingsPathTemplate.match(
-      folderCmekSettingsName,
+      folderCmekSettingsName
     ).folder;
   }
 
@@ -1508,7 +1508,7 @@ export class MetricsServiceV2Client {
    */
   matchFolderFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).folder;
   }
 
@@ -1521,7 +1521,7 @@ export class MetricsServiceV2Client {
    */
   matchExclusionFromFolderExclusionName(folderExclusionName: string) {
     return this.pathTemplates.folderExclusionPathTemplate.match(
-      folderExclusionName,
+      folderExclusionName
     ).exclusion;
   }
 
@@ -1550,7 +1550,7 @@ export class MetricsServiceV2Client {
    */
   matchFolderFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).folder;
   }
 
@@ -1563,7 +1563,7 @@ export class MetricsServiceV2Client {
    */
   matchLocationFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).location;
   }
 
@@ -1576,7 +1576,7 @@ export class MetricsServiceV2Client {
    */
   matchBucketFromFolderLocationBucketName(folderLocationBucketName: string) {
     return this.pathTemplates.folderLocationBucketPathTemplate.match(
-      folderLocationBucketName,
+      folderLocationBucketName
     ).bucket;
   }
 
@@ -1593,7 +1593,7 @@ export class MetricsServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.render({
       folder: folder,
@@ -1611,10 +1611,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).folder;
   }
 
@@ -1626,10 +1626,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).location;
   }
 
@@ -1641,10 +1641,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).bucket;
   }
 
@@ -1656,10 +1656,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromFolderLocationBucketLinkName(
-    folderLocationBucketLinkName: string,
+    folderLocationBucketLinkName: string
   ) {
     return this.pathTemplates.folderLocationBucketLinkPathTemplate.match(
-      folderLocationBucketLinkName,
+      folderLocationBucketLinkName
     ).link;
   }
 
@@ -1676,7 +1676,7 @@ export class MetricsServiceV2Client {
     folder: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
       folder: folder,
@@ -1694,10 +1694,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the folder.
    */
   matchFolderFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).folder;
   }
 
@@ -1709,10 +1709,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).location;
   }
 
@@ -1724,10 +1724,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).bucket;
   }
 
@@ -1739,10 +1739,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromFolderLocationBucketViewName(
-    folderLocationBucketViewName: string,
+    folderLocationBucketViewName: string
   ) {
     return this.pathTemplates.folderLocationBucketViewPathTemplate.match(
-      folderLocationBucketViewName,
+      folderLocationBucketViewName
     ).view;
   }
 
@@ -1803,7 +1803,7 @@ export class MetricsServiceV2Client {
    */
   matchFolderFromFolderSettingsName(folderSettingsName: string) {
     return this.pathTemplates.folderSettingsPathTemplate.match(
-      folderSettingsName,
+      folderSettingsName
     ).folder;
   }
 
@@ -1901,10 +1901,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationCmekSettingsName(
-    organizationCmekSettingsName: string,
+    organizationCmekSettingsName: string
   ) {
     return this.pathTemplates.organizationCmekSettingsPathTemplate.match(
-      organizationCmekSettingsName,
+      organizationCmekSettingsName
     ).organization;
   }
 
@@ -1930,10 +1930,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).organization;
   }
 
@@ -1945,10 +1945,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the exclusion.
    */
   matchExclusionFromOrganizationExclusionName(
-    organizationExclusionName: string,
+    organizationExclusionName: string
   ) {
     return this.pathTemplates.organizationExclusionPathTemplate.match(
-      organizationExclusionName,
+      organizationExclusionName
     ).exclusion;
   }
 
@@ -1963,7 +1963,7 @@ export class MetricsServiceV2Client {
   organizationLocationBucketPath(
     organization: string,
     location: string,
-    bucket: string,
+    bucket: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.render({
       organization: organization,
@@ -1980,10 +1980,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).organization;
   }
 
@@ -1995,10 +1995,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).location;
   }
 
@@ -2010,10 +2010,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketName(
-    organizationLocationBucketName: string,
+    organizationLocationBucketName: string
   ) {
     return this.pathTemplates.organizationLocationBucketPathTemplate.match(
-      organizationLocationBucketName,
+      organizationLocationBucketName
     ).bucket;
   }
 
@@ -2030,7 +2030,7 @@ export class MetricsServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.render(
       {
@@ -2038,7 +2038,7 @@ export class MetricsServiceV2Client {
         location: location,
         bucket: bucket,
         link: link,
-      },
+      }
     );
   }
 
@@ -2050,10 +2050,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).organization;
   }
 
@@ -2065,10 +2065,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).location;
   }
 
@@ -2080,10 +2080,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).bucket;
   }
 
@@ -2095,10 +2095,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromOrganizationLocationBucketLinkName(
-    organizationLocationBucketLinkName: string,
+    organizationLocationBucketLinkName: string
   ) {
     return this.pathTemplates.organizationLocationBucketLinkPathTemplate.match(
-      organizationLocationBucketLinkName,
+      organizationLocationBucketLinkName
     ).link;
   }
 
@@ -2115,7 +2115,7 @@ export class MetricsServiceV2Client {
     organization: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.render(
       {
@@ -2123,7 +2123,7 @@ export class MetricsServiceV2Client {
         location: location,
         bucket: bucket,
         view: view,
-      },
+      }
     );
   }
 
@@ -2135,10 +2135,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).organization;
   }
 
@@ -2150,10 +2150,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).location;
   }
 
@@ -2165,10 +2165,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).bucket;
   }
 
@@ -2180,10 +2180,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromOrganizationLocationBucketViewName(
-    organizationLocationBucketViewName: string,
+    organizationLocationBucketViewName: string
   ) {
     return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(
-      organizationLocationBucketViewName,
+      organizationLocationBucketViewName
     ).view;
   }
 
@@ -2210,7 +2210,7 @@ export class MetricsServiceV2Client {
    */
   matchOrganizationFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).organization;
   }
 
@@ -2223,7 +2223,7 @@ export class MetricsServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(
-      organizationLogName,
+      organizationLogName
     ).log;
   }
 
@@ -2247,10 +2247,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the organization.
    */
   matchOrganizationFromOrganizationSettingsName(
-    organizationSettingsName: string,
+    organizationSettingsName: string
   ) {
     return this.pathTemplates.organizationSettingsPathTemplate.match(
-      organizationSettingsName,
+      organizationSettingsName
     ).organization;
   }
 
@@ -2277,7 +2277,7 @@ export class MetricsServiceV2Client {
    */
   matchOrganizationFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).organization;
   }
 
@@ -2290,7 +2290,7 @@ export class MetricsServiceV2Client {
    */
   matchSinkFromOrganizationSinkName(organizationSinkName: string) {
     return this.pathTemplates.organizationSinkPathTemplate.match(
-      organizationSinkName,
+      organizationSinkName
     ).sink;
   }
 
@@ -2338,7 +2338,7 @@ export class MetricsServiceV2Client {
    */
   matchProjectFromProjectCmekSettingsName(projectCmekSettingsName: string) {
     return this.pathTemplates.projectCmekSettingsPathTemplate.match(
-      projectCmekSettingsName,
+      projectCmekSettingsName
     ).project;
   }
 
@@ -2365,7 +2365,7 @@ export class MetricsServiceV2Client {
    */
   matchProjectFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).project;
   }
 
@@ -2378,7 +2378,7 @@ export class MetricsServiceV2Client {
    */
   matchExclusionFromProjectExclusionName(projectExclusionName: string) {
     return this.pathTemplates.projectExclusionPathTemplate.match(
-      projectExclusionName,
+      projectExclusionName
     ).exclusion;
   }
 
@@ -2407,7 +2407,7 @@ export class MetricsServiceV2Client {
    */
   matchProjectFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).project;
   }
 
@@ -2419,10 +2419,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketName(
-    projectLocationBucketName: string,
+    projectLocationBucketName: string
   ) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).location;
   }
 
@@ -2435,7 +2435,7 @@ export class MetricsServiceV2Client {
    */
   matchBucketFromProjectLocationBucketName(projectLocationBucketName: string) {
     return this.pathTemplates.projectLocationBucketPathTemplate.match(
-      projectLocationBucketName,
+      projectLocationBucketName
     ).bucket;
   }
 
@@ -2452,7 +2452,7 @@ export class MetricsServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    link: string,
+    link: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.render({
       project: project,
@@ -2470,10 +2470,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).project;
   }
 
@@ -2485,10 +2485,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).location;
   }
 
@@ -2500,10 +2500,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).bucket;
   }
 
@@ -2515,10 +2515,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the link.
    */
   matchLinkFromProjectLocationBucketLinkName(
-    projectLocationBucketLinkName: string,
+    projectLocationBucketLinkName: string
   ) {
     return this.pathTemplates.projectLocationBucketLinkPathTemplate.match(
-      projectLocationBucketLinkName,
+      projectLocationBucketLinkName
     ).link;
   }
 
@@ -2535,7 +2535,7 @@ export class MetricsServiceV2Client {
     project: string,
     location: string,
     bucket: string,
-    view: string,
+    view: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
       project: project,
@@ -2553,10 +2553,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the project.
    */
   matchProjectFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).project;
   }
 
@@ -2568,10 +2568,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the location.
    */
   matchLocationFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).location;
   }
 
@@ -2583,10 +2583,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the bucket.
    */
   matchBucketFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).bucket;
   }
 
@@ -2598,10 +2598,10 @@ export class MetricsServiceV2Client {
    * @returns {string} A string representing the view.
    */
   matchViewFromProjectLocationBucketViewName(
-    projectLocationBucketViewName: string,
+    projectLocationBucketViewName: string
   ) {
     return this.pathTemplates.projectLocationBucketViewPathTemplate.match(
-      projectLocationBucketViewName,
+      projectLocationBucketViewName
     ).view;
   }
 
@@ -2663,7 +2663,7 @@ export class MetricsServiceV2Client {
    */
   matchProjectFromProjectSettingsName(projectSettingsName: string) {
     return this.pathTemplates.projectSettingsPathTemplate.match(
-      projectSettingsName,
+      projectSettingsName
     ).project;
   }
 

--- a/handwritten/logging/system-test/install.ts
+++ b/handwritten/logging/system-test/install.ts
@@ -28,7 +28,7 @@ describe('📦 pack-n-play test', () => {
       sample: {
         description: 'TypeScript user can use the type definitions',
         ts: readFileSync(
-          './system-test/fixtures/sample/src/index.ts',
+          './system-test/fixtures/sample/src/index.ts'
         ).toString(),
       },
     };
@@ -42,7 +42,7 @@ describe('📦 pack-n-play test', () => {
       sample: {
         description: 'JavaScript user can use the library',
         cjs: readFileSync(
-          './system-test/fixtures/sample/src/index.js',
+          './system-test/fixtures/sample/src/index.js'
         ).toString(),
       },
     };

--- a/handwritten/logging/system-test/logging.ts
+++ b/handwritten/logging/system-test/logging.ts
@@ -169,7 +169,7 @@ describe('Logging', () => {
       // tests are being run, so let's not care about that.
       apiResponse.destination = apiResponse.destination!.replace(
         /projects\/[^/]*\//,
-        '',
+        ''
       );
       assert.strictEqual(apiResponse.destination, destination);
     });
@@ -186,7 +186,7 @@ describe('Logging', () => {
       // tests are being run, so let's not care about that.
       assert.strictEqual(
         apiResponse.destination!.replace(/projects\/[^/]*\//, ''),
-        destination.replace(/projects\/[^/]*\//, ''),
+        destination.replace(/projects\/[^/]*\//, '')
       );
     });
 
@@ -324,7 +324,7 @@ describe('Logging', () => {
     function getEntriesFromLog(
       log: Log,
       config: {numExpectedMessages: number},
-      callback: (err: Error | null, entries?: Entry[]) => void,
+      callback: (err: Error | null, entries?: Entry[]) => void
     ) {
       let numAttempts = 0;
 
@@ -352,7 +352,7 @@ describe('Logging', () => {
             }
 
             callback(null, entries);
-          },
+          }
         );
       }
     }
@@ -422,10 +422,10 @@ describe('Logging', () => {
               entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
                 instrumentation.INSTRUMENTATION_SOURCE_KEY
               ]?.[0]?.['name'],
-              instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+              instrumentation.NODEJS_LIBRARY_NAME_PREFIX
             );
             done();
-          },
+          }
         );
       });
     });
@@ -469,7 +469,7 @@ describe('Logging', () => {
           assert.strictEqual(
             resp.entries.length,
             1,
-            `Expected 1 tailed entry; Got ${resp.entries.length}.`,
+            `Expected 1 tailed entry; Got ${resp.entries.length}.`
           );
           clearInterval(logInterval);
           stream.end();
@@ -498,7 +498,7 @@ describe('Logging', () => {
             assert.ifError(err);
             assert.strictEqual(entries!.length, logEntriesExpected.length);
             done();
-          },
+          }
         );
       });
 
@@ -577,7 +577,7 @@ describe('Logging', () => {
             ]);
 
             done();
-          },
+          }
         );
       });
     });
@@ -601,7 +601,7 @@ describe('Logging', () => {
             assert.ifError(err);
             assert.deepStrictEqual(
               entries!.map(x => x.data),
-              ['3', '2', '1'],
+              ['3', '2', '1']
             );
             done();
           });
@@ -627,10 +627,10 @@ describe('Logging', () => {
             assert.ifError(err);
             assert.deepStrictEqual(
               entries!.reverse().map(x => x.data),
-              messages,
+              messages
             );
             done();
-          },
+          }
         );
       })();
     });
@@ -711,7 +711,7 @@ describe('Logging', () => {
           const entry = entries![0];
           assert.strictEqual(
             entry.metadata.httpRequest?.status,
-            metadata.httpRequest.status,
+            metadata.httpRequest.status
           );
           assert.deepStrictEqual(entry.data, {});
           done();
@@ -742,7 +742,7 @@ describe('Logging', () => {
             assert.strictEqual(entry.metadata.httpRequest?.protocol, 'http:');
             assert.strictEqual(
               entry.metadata.trace,
-              `projects/${PROJECT_ID}/traces/1`,
+              `projects/${PROJECT_ID}/traces/1`
             );
             assert.strictEqual(entry.metadata.spanId, '2');
             assert.strictEqual(entry.metadata.traceSampled, true);
@@ -776,7 +776,7 @@ describe('Logging', () => {
             assert.strictEqual(entry.metadata.httpRequest?.protocol, 'http:');
             assert.strictEqual(
               entry.metadata.trace,
-              `projects/${PROJECT_ID}/traces/0af7651916cd43dd8448eb211c80319c`,
+              `projects/${PROJECT_ID}/traces/0af7651916cd43dd8448eb211c80319c`
             );
             assert.strictEqual(entry.metadata.spanId, 'b7ad6b7169203331');
             assert.strictEqual(entry.metadata.traceSampled, true);
@@ -825,7 +825,7 @@ describe('Logging', () => {
               assert.strictEqual(entry.metadata.spanId, metadata.spanId);
               assert.strictEqual(
                 entry.metadata.traceSampled,
-                metadata.traceSampled,
+                metadata.traceSampled
               );
             });
           });
@@ -850,7 +850,7 @@ describe('Logging', () => {
               assert.strictEqual(entry.data, spanTestMessage);
               assert.strictEqual(
                 entry.metadata.trace,
-                `projects/${PROJECT_ID}/traces/${traceId}`,
+                `projects/${PROJECT_ID}/traces/${traceId}`
               );
               assert.strictEqual(entry.metadata.spanId, spanId);
               assert.strictEqual(entry.metadata.traceSampled, traceSampled);
@@ -890,19 +890,19 @@ describe('Logging', () => {
                   assert.strictEqual(entry.data, 'some log message');
                   assert.strictEqual(
                     entry.metadata.httpRequest?.requestUrl,
-                    URL,
+                    URL
                   );
                   assert.strictEqual(
                     entry.metadata.httpRequest?.protocol,
-                    'http:',
+                    'http:'
                   );
                   assert.strictEqual(
                     entry.metadata.trace,
-                    `projects/${PROJECT_ID}/traces/${traceId}`,
+                    `projects/${PROJECT_ID}/traces/${traceId}`
                   );
                   assert.strictEqual(entry.metadata.spanId, spanId);
                   assert.strictEqual(entry.metadata.traceSampled, traceSampled);
-                },
+                }
               );
             });
           });
@@ -937,19 +937,19 @@ describe('Logging', () => {
                   assert.strictEqual(entry.data, 'some log message');
                   assert.strictEqual(
                     entry.metadata.httpRequest?.requestUrl,
-                    URL,
+                    URL
                   );
                   assert.strictEqual(
                     entry.metadata.httpRequest?.protocol,
-                    'http:',
+                    'http:'
                   );
                   assert.strictEqual(
                     entry.metadata.trace,
-                    `projects/${PROJECT_ID}/traces/${traceId}`,
+                    `projects/${PROJECT_ID}/traces/${traceId}`
                   );
                   assert.strictEqual(entry.metadata.spanId, spanId);
                   assert.strictEqual(entry.metadata.traceSampled, traceSampled);
-                },
+                }
               );
             });
           });
@@ -999,7 +999,7 @@ describe('Logging', () => {
             },
           },
         },
-        done,
+        done
       );
     });
 
@@ -1068,8 +1068,8 @@ describe('Logging', () => {
       await log.write(logEntries[0], options);
       assert.ok(
         /gax\/[0-9]+\.[\w.-]+ gapic\/[0-9]+\.[\w.-]+ gl-node\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+ gccl\/[0-9]+\.[\w.-]+/.test(
-          http2spy.requests[0]['x-goog-api-client'][0],
-        ),
+          http2spy.requests[0]['x-goog-api-client'][0]
+        )
       );
     });
   });

--- a/handwritten/logging/test/entry.ts
+++ b/handwritten/logging/test/entry.ts
@@ -222,7 +222,7 @@ describe('Entry', () => {
     it('should pass removeCircular to objToStruct_', done => {
       fakeObjToStruct = (
         obj: {},
-        options: common.ObjectToStructConverterConfig,
+        options: common.ObjectToStructConverterConfig
       ) => {
         assert.strictEqual(options.removeCircular, true);
         done();
@@ -335,12 +335,12 @@ describe('Entry', () => {
             const json = entry.toJSON();
             assert.strictEqual(
               json.trace,
-              `projects//traces/${span.spanContext().traceId}`,
+              `projects//traces/${span.spanContext().traceId}`
             );
             assert.strictEqual(json.spanId, span.spanContext().spanId);
             assert.strictEqual(
               json.traceSampled,
-              (span.spanContext().traceFlags & 1) !== 0,
+              (span.spanContext().traceFlags & 1) !== 0
             );
           });
       });
@@ -360,12 +360,12 @@ describe('Entry', () => {
             const json = entry.toJSON();
             assert.strictEqual(
               json.trace,
-              `projects//traces/${span.spanContext().traceId}`,
+              `projects//traces/${span.spanContext().traceId}`
             );
             assert.strictEqual(json.spanId, span.spanContext().spanId);
             assert.strictEqual(
               json.traceSampled,
-              (span.spanContext().traceFlags & 1) !== 0,
+              (span.spanContext().traceFlags & 1) !== 0
             );
           });
       });
@@ -413,7 +413,7 @@ describe('Entry', () => {
       entry.data = 'this is a log';
       const json = entry.toStructuredJSON();
       assert(
-        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!)),
+        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!))
       );
       delete json.timestamp;
       const expectedJSON = {
@@ -441,7 +441,7 @@ describe('Entry', () => {
       entry.metadata.timestamp = new Date();
       const json = entry.toStructuredJSON();
       assert(
-        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!)),
+        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!))
       );
     });
 
@@ -513,15 +513,15 @@ describe('Entry', () => {
             const json = entry.toStructuredJSON();
             assert.strictEqual(
               json[entryTypes.TRACE_KEY],
-              `projects//traces/${span.spanContext().traceId}`,
+              `projects//traces/${span.spanContext().traceId}`
             );
             assert.strictEqual(
               json[entryTypes.SPAN_ID_KEY],
-              span.spanContext().spanId,
+              span.spanContext().spanId
             );
             assert.strictEqual(
               json[entryTypes.TRACE_SAMPLED_KEY],
-              (span.spanContext().traceFlags & 1) !== 0,
+              (span.spanContext().traceFlags & 1) !== 0
             );
           });
       });
@@ -541,15 +541,15 @@ describe('Entry', () => {
             const json = entry.toStructuredJSON();
             assert.strictEqual(
               json[entryTypes.TRACE_KEY],
-              `projects//traces/${span.spanContext().traceId}`,
+              `projects//traces/${span.spanContext().traceId}`
             );
             assert.strictEqual(
               json[entryTypes.SPAN_ID_KEY],
-              span.spanContext().spanId,
+              span.spanContext().spanId
             );
             assert.strictEqual(
               json[entryTypes.TRACE_SAMPLED_KEY],
-              (span.spanContext().traceFlags & 1) !== 0,
+              (span.spanContext().traceFlags & 1) !== 0
             );
           });
       });
@@ -571,7 +571,7 @@ describe('Entry', () => {
             assert.strictEqual(json[entryTypes.SPAN_ID_KEY], expected.spanId);
             assert.strictEqual(
               json[entryTypes.TRACE_SAMPLED_KEY],
-              expected.traceSampled,
+              expected.traceSampled
             );
           });
       });

--- a/handwritten/logging/test/gapic_config_service_v2_v2.ts
+++ b/handwritten/logging/test/gapic_config_service_v2_v2.ts
@@ -30,7 +30,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(
-  require('../protos/protos.json'),
+  require('../protos/protos.json')
 ).resolveAll();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -47,7 +47,7 @@ function generateSampleMessage<T extends object>(instance: T) {
     instance.constructor as typeof protobuf.Message
   ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
-    filledObject,
+    filledObject
   ) as T;
 }
 
@@ -59,7 +59,7 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
 
 function stubSimpleCallWithCallback<ResponseType>(
   response?: ResponseType,
-  error?: Error,
+  error?: Error
 ) {
   return error
     ? sinon.stub().callsArgWith(2, error)
@@ -69,7 +69,7 @@ function stubSimpleCallWithCallback<ResponseType>(
 function stubLongRunningCall<ResponseType>(
   response?: ResponseType,
   callError?: Error,
-  lroError?: Error,
+  lroError?: Error
 ) {
   const innerStub = lroError
     ? sinon.stub().rejects(lroError)
@@ -85,7 +85,7 @@ function stubLongRunningCall<ResponseType>(
 function stubLongRunningCallWithCallback<ResponseType>(
   response?: ResponseType,
   callError?: Error,
-  lroError?: Error,
+  lroError?: Error
 ) {
   const innerStub = lroError
     ? sinon.stub().rejects(lroError)
@@ -100,7 +100,7 @@ function stubLongRunningCallWithCallback<ResponseType>(
 
 function stubPageStreamingCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   const pagingStub = sinon.stub();
   if (responses) {
@@ -138,7 +138,7 @@ function stubPageStreamingCall<ResponseType>(
 
 function stubAsyncIterationCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   let counter = 0;
   const asyncIterable = {
@@ -345,16 +345,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetBucketRequest(),
+        new protos.google.logging.v2.GetBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.getBucket = stubSimpleCall(expectedResponse);
       const [response] = await client.getBucket(request);
@@ -376,16 +376,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetBucketRequest(),
+        new protos.google.logging.v2.GetBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.getBucket =
         stubSimpleCallWithCallback(expectedResponse);
@@ -394,14 +394,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogBucket | null,
+            result?: protos.google.logging.v2.ILogBucket | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -423,11 +423,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetBucketRequest(),
+        new protos.google.logging.v2.GetBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
@@ -451,11 +451,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetBucketRequest(),
+        new protos.google.logging.v2.GetBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -472,16 +472,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.createBucket = stubSimpleCall(expectedResponse);
       const [response] = await client.createBucket(request);
@@ -503,16 +503,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.createBucket =
         stubSimpleCallWithCallback(expectedResponse);
@@ -521,14 +521,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogBucket | null,
+            result?: protos.google.logging.v2.ILogBucket | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -550,18 +550,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createBucket = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createBucket(request), expectedError);
       const actualRequest = (
@@ -581,11 +581,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -602,16 +602,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.updateBucket = stubSimpleCall(expectedResponse);
       const [response] = await client.updateBucket(request);
@@ -633,16 +633,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogBucket(),
+        new protos.google.logging.v2.LogBucket()
       );
       client.innerApiCalls.updateBucket =
         stubSimpleCallWithCallback(expectedResponse);
@@ -651,14 +651,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogBucket | null,
+            result?: protos.google.logging.v2.ILogBucket | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -680,18 +680,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateBucket = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateBucket(request), expectedError);
       const actualRequest = (
@@ -711,11 +711,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -732,16 +732,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteBucketRequest(),
+        new protos.google.logging.v2.DeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteBucket = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteBucket(request);
@@ -763,16 +763,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteBucketRequest(),
+        new protos.google.logging.v2.DeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteBucket =
         stubSimpleCallWithCallback(expectedResponse);
@@ -781,14 +781,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -810,18 +810,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteBucketRequest(),
+        new protos.google.logging.v2.DeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteBucket = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteBucket(request), expectedError);
       const actualRequest = (
@@ -841,11 +841,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteBucketRequest(),
+        new protos.google.logging.v2.DeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -862,16 +862,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UndeleteBucketRequest(),
+        new protos.google.logging.v2.UndeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UndeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.undeleteBucket = stubSimpleCall(expectedResponse);
       const [response] = await client.undeleteBucket(request);
@@ -893,16 +893,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UndeleteBucketRequest(),
+        new protos.google.logging.v2.UndeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UndeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.undeleteBucket =
         stubSimpleCallWithCallback(expectedResponse);
@@ -911,14 +911,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -940,18 +940,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UndeleteBucketRequest(),
+        new protos.google.logging.v2.UndeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UndeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.undeleteBucket = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.undeleteBucket(request), expectedError);
       const actualRequest = (
@@ -971,11 +971,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UndeleteBucketRequest(),
+        new protos.google.logging.v2.UndeleteBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UndeleteBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -992,22 +992,22 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetViewRequest(),
+        new protos.google.logging.v2.GetViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.getView = stubSimpleCall(expectedResponse);
       const [response] = await client.getView(request);
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getView as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1023,16 +1023,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetViewRequest(),
+        new protos.google.logging.v2.GetViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.getView =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1041,20 +1041,20 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogView | null,
+            result?: protos.google.logging.v2.ILogView | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getView as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1070,11 +1070,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetViewRequest(),
+        new protos.google.logging.v2.GetViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
@@ -1082,7 +1082,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.getView = stubSimpleCall(undefined, expectedError);
       await assert.rejects(client.getView(request), expectedError);
       const actualRequest = (client.innerApiCalls.getView as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1098,11 +1098,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetViewRequest(),
+        new protos.google.logging.v2.GetViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1119,16 +1119,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateViewRequest(),
+        new protos.google.logging.v2.CreateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateViewRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.createView = stubSimpleCall(expectedResponse);
       const [response] = await client.createView(request);
@@ -1150,16 +1150,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateViewRequest(),
+        new protos.google.logging.v2.CreateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateViewRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.createView =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1168,14 +1168,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogView | null,
+            result?: protos.google.logging.v2.ILogView | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1197,18 +1197,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateViewRequest(),
+        new protos.google.logging.v2.CreateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateViewRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createView = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createView(request), expectedError);
       const actualRequest = (
@@ -1228,11 +1228,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateViewRequest(),
+        new protos.google.logging.v2.CreateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateViewRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1249,16 +1249,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateViewRequest(),
+        new protos.google.logging.v2.UpdateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.updateView = stubSimpleCall(expectedResponse);
       const [response] = await client.updateView(request);
@@ -1280,16 +1280,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateViewRequest(),
+        new protos.google.logging.v2.UpdateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogView(),
+        new protos.google.logging.v2.LogView()
       );
       client.innerApiCalls.updateView =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1298,14 +1298,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogView | null,
+            result?: protos.google.logging.v2.ILogView | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1327,18 +1327,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateViewRequest(),
+        new protos.google.logging.v2.UpdateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateView = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateView(request), expectedError);
       const actualRequest = (
@@ -1358,11 +1358,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateViewRequest(),
+        new protos.google.logging.v2.UpdateViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1379,16 +1379,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteViewRequest(),
+        new protos.google.logging.v2.DeleteViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteView = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteView(request);
@@ -1410,16 +1410,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteViewRequest(),
+        new protos.google.logging.v2.DeleteViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteView =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1428,14 +1428,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1457,18 +1457,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteViewRequest(),
+        new protos.google.logging.v2.DeleteViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteView = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteView(request), expectedError);
       const actualRequest = (
@@ -1488,11 +1488,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteViewRequest(),
+        new protos.google.logging.v2.DeleteViewRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteViewRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1509,22 +1509,22 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSinkRequest(),
+        new protos.google.logging.v2.GetSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.getSink = stubSimpleCall(expectedResponse);
       const [response] = await client.getSink(request);
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getSink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1540,16 +1540,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSinkRequest(),
+        new protos.google.logging.v2.GetSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.getSink =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1558,20 +1558,20 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogSink | null,
+            result?: protos.google.logging.v2.ILogSink | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getSink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1587,11 +1587,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSinkRequest(),
+        new protos.google.logging.v2.GetSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
@@ -1599,7 +1599,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.getSink = stubSimpleCall(undefined, expectedError);
       await assert.rejects(client.getSink(request), expectedError);
       const actualRequest = (client.innerApiCalls.getSink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -1615,11 +1615,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSinkRequest(),
+        new protos.google.logging.v2.GetSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1636,16 +1636,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateSinkRequest(),
+        new protos.google.logging.v2.CreateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateSinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.createSink = stubSimpleCall(expectedResponse);
       const [response] = await client.createSink(request);
@@ -1667,16 +1667,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateSinkRequest(),
+        new protos.google.logging.v2.CreateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateSinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.createSink =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1685,14 +1685,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogSink | null,
+            result?: protos.google.logging.v2.ILogSink | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1714,18 +1714,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateSinkRequest(),
+        new protos.google.logging.v2.CreateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateSinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createSink = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createSink(request), expectedError);
       const actualRequest = (
@@ -1745,11 +1745,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateSinkRequest(),
+        new protos.google.logging.v2.CreateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateSinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1766,16 +1766,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSinkRequest(),
+        new protos.google.logging.v2.UpdateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.updateSink = stubSimpleCall(expectedResponse);
       const [response] = await client.updateSink(request);
@@ -1797,16 +1797,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSinkRequest(),
+        new protos.google.logging.v2.UpdateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogSink(),
+        new protos.google.logging.v2.LogSink()
       );
       client.innerApiCalls.updateSink =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1815,14 +1815,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogSink | null,
+            result?: protos.google.logging.v2.ILogSink | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1844,18 +1844,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSinkRequest(),
+        new protos.google.logging.v2.UpdateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateSink = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateSink(request), expectedError);
       const actualRequest = (
@@ -1875,11 +1875,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSinkRequest(),
+        new protos.google.logging.v2.UpdateSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -1896,16 +1896,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteSinkRequest(),
+        new protos.google.logging.v2.DeleteSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteSink = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteSink(request);
@@ -1927,16 +1927,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteSinkRequest(),
+        new protos.google.logging.v2.DeleteSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteSink =
         stubSimpleCallWithCallback(expectedResponse);
@@ -1945,14 +1945,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1974,18 +1974,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteSinkRequest(),
+        new protos.google.logging.v2.DeleteSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteSink = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteSink(request), expectedError);
       const actualRequest = (
@@ -2005,11 +2005,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteSinkRequest(),
+        new protos.google.logging.v2.DeleteSinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteSinkRequest',
-        ['sinkName'],
+        ['sinkName']
       );
       request.sinkName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2026,22 +2026,22 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLinkRequest(),
+        new protos.google.logging.v2.GetLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Link(),
+        new protos.google.logging.v2.Link()
       );
       client.innerApiCalls.getLink = stubSimpleCall(expectedResponse);
       const [response] = await client.getLink(request);
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getLink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -2057,16 +2057,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLinkRequest(),
+        new protos.google.logging.v2.GetLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Link(),
+        new protos.google.logging.v2.Link()
       );
       client.innerApiCalls.getLink =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2075,20 +2075,20 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILink | null,
+            result?: protos.google.logging.v2.ILink | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
       assert.deepStrictEqual(response, expectedResponse);
       const actualRequest = (client.innerApiCalls.getLink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -2104,11 +2104,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLinkRequest(),
+        new protos.google.logging.v2.GetLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
@@ -2116,7 +2116,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.getLink = stubSimpleCall(undefined, expectedError);
       await assert.rejects(client.getLink(request), expectedError);
       const actualRequest = (client.innerApiCalls.getLink as SinonStub).getCall(
-        0,
+        0
       ).args[0];
       assert.deepStrictEqual(actualRequest, request);
       const actualHeaderRequestParams = (
@@ -2132,11 +2132,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLinkRequest(),
+        new protos.google.logging.v2.GetLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2153,16 +2153,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetExclusionRequest(),
+        new protos.google.logging.v2.GetExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.getExclusion = stubSimpleCall(expectedResponse);
       const [response] = await client.getExclusion(request);
@@ -2184,16 +2184,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetExclusionRequest(),
+        new protos.google.logging.v2.GetExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.getExclusion =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2202,14 +2202,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogExclusion | null,
+            result?: protos.google.logging.v2.ILogExclusion | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2231,18 +2231,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetExclusionRequest(),
+        new protos.google.logging.v2.GetExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.getExclusion = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.getExclusion(request), expectedError);
       const actualRequest = (
@@ -2262,11 +2262,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetExclusionRequest(),
+        new protos.google.logging.v2.GetExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2283,16 +2283,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateExclusionRequest(),
+        new protos.google.logging.v2.CreateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateExclusionRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.createExclusion = stubSimpleCall(expectedResponse);
       const [response] = await client.createExclusion(request);
@@ -2314,16 +2314,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateExclusionRequest(),
+        new protos.google.logging.v2.CreateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateExclusionRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.createExclusion =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2332,14 +2332,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogExclusion | null,
+            result?: protos.google.logging.v2.ILogExclusion | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2361,18 +2361,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateExclusionRequest(),
+        new protos.google.logging.v2.CreateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateExclusionRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createExclusion = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createExclusion(request), expectedError);
       const actualRequest = (
@@ -2392,11 +2392,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateExclusionRequest(),
+        new protos.google.logging.v2.CreateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateExclusionRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2413,16 +2413,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateExclusionRequest(),
+        new protos.google.logging.v2.UpdateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.updateExclusion = stubSimpleCall(expectedResponse);
       const [response] = await client.updateExclusion(request);
@@ -2444,16 +2444,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateExclusionRequest(),
+        new protos.google.logging.v2.UpdateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogExclusion(),
+        new protos.google.logging.v2.LogExclusion()
       );
       client.innerApiCalls.updateExclusion =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2462,14 +2462,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogExclusion | null,
+            result?: protos.google.logging.v2.ILogExclusion | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2491,18 +2491,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateExclusionRequest(),
+        new protos.google.logging.v2.UpdateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateExclusion = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateExclusion(request), expectedError);
       const actualRequest = (
@@ -2522,11 +2522,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateExclusionRequest(),
+        new protos.google.logging.v2.UpdateExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2543,16 +2543,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteExclusionRequest(),
+        new protos.google.logging.v2.DeleteExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteExclusion = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteExclusion(request);
@@ -2574,16 +2574,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteExclusionRequest(),
+        new protos.google.logging.v2.DeleteExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteExclusion =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2592,14 +2592,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2621,18 +2621,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteExclusionRequest(),
+        new protos.google.logging.v2.DeleteExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteExclusion = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteExclusion(request), expectedError);
       const actualRequest = (
@@ -2652,11 +2652,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteExclusionRequest(),
+        new protos.google.logging.v2.DeleteExclusionRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteExclusionRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2673,16 +2673,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetCmekSettingsRequest(),
+        new protos.google.logging.v2.GetCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.CmekSettings(),
+        new protos.google.logging.v2.CmekSettings()
       );
       client.innerApiCalls.getCmekSettings = stubSimpleCall(expectedResponse);
       const [response] = await client.getCmekSettings(request);
@@ -2704,16 +2704,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetCmekSettingsRequest(),
+        new protos.google.logging.v2.GetCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.CmekSettings(),
+        new protos.google.logging.v2.CmekSettings()
       );
       client.innerApiCalls.getCmekSettings =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2722,14 +2722,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ICmekSettings | null,
+            result?: protos.google.logging.v2.ICmekSettings | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2751,18 +2751,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetCmekSettingsRequest(),
+        new protos.google.logging.v2.GetCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.getCmekSettings = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.getCmekSettings(request), expectedError);
       const actualRequest = (
@@ -2782,11 +2782,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetCmekSettingsRequest(),
+        new protos.google.logging.v2.GetCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2803,16 +2803,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateCmekSettingsRequest(),
+        new protos.google.logging.v2.UpdateCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.CmekSettings(),
+        new protos.google.logging.v2.CmekSettings()
       );
       client.innerApiCalls.updateCmekSettings =
         stubSimpleCall(expectedResponse);
@@ -2835,16 +2835,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateCmekSettingsRequest(),
+        new protos.google.logging.v2.UpdateCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.CmekSettings(),
+        new protos.google.logging.v2.CmekSettings()
       );
       client.innerApiCalls.updateCmekSettings =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2853,14 +2853,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ICmekSettings | null,
+            result?: protos.google.logging.v2.ICmekSettings | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -2882,18 +2882,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateCmekSettingsRequest(),
+        new protos.google.logging.v2.UpdateCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateCmekSettings = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateCmekSettings(request), expectedError);
       const actualRequest = (
@@ -2913,11 +2913,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateCmekSettingsRequest(),
+        new protos.google.logging.v2.UpdateCmekSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateCmekSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -2934,16 +2934,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSettingsRequest(),
+        new protos.google.logging.v2.GetSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Settings(),
+        new protos.google.logging.v2.Settings()
       );
       client.innerApiCalls.getSettings = stubSimpleCall(expectedResponse);
       const [response] = await client.getSettings(request);
@@ -2965,16 +2965,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSettingsRequest(),
+        new protos.google.logging.v2.GetSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Settings(),
+        new protos.google.logging.v2.Settings()
       );
       client.innerApiCalls.getSettings =
         stubSimpleCallWithCallback(expectedResponse);
@@ -2983,14 +2983,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ISettings | null,
+            result?: protos.google.logging.v2.ISettings | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -3012,18 +3012,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSettingsRequest(),
+        new protos.google.logging.v2.GetSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.getSettings = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.getSettings(request), expectedError);
       const actualRequest = (
@@ -3043,11 +3043,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetSettingsRequest(),
+        new protos.google.logging.v2.GetSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -3064,16 +3064,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSettingsRequest(),
+        new protos.google.logging.v2.UpdateSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Settings(),
+        new protos.google.logging.v2.Settings()
       );
       client.innerApiCalls.updateSettings = stubSimpleCall(expectedResponse);
       const [response] = await client.updateSettings(request);
@@ -3095,16 +3095,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSettingsRequest(),
+        new protos.google.logging.v2.UpdateSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.Settings(),
+        new protos.google.logging.v2.Settings()
       );
       client.innerApiCalls.updateSettings =
         stubSimpleCallWithCallback(expectedResponse);
@@ -3113,14 +3113,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ISettings | null,
+            result?: protos.google.logging.v2.ISettings | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -3142,18 +3142,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSettingsRequest(),
+        new protos.google.logging.v2.UpdateSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateSettings = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateSettings(request), expectedError);
       const actualRequest = (
@@ -3173,11 +3173,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateSettingsRequest(),
+        new protos.google.logging.v2.UpdateSettingsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateSettingsRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -3194,16 +3194,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.createBucketAsync =
         stubLongRunningCall(expectedResponse);
@@ -3227,16 +3227,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.createBucketAsync =
         stubLongRunningCallWithCallback(expectedResponse);
@@ -3248,14 +3248,14 @@ describe('v2.ConfigServiceV2Client', () => {
             result?: LROperation<
               protos.google.logging.v2.ILogBucket,
               protos.google.logging.v2.IBucketMetadata
-            > | null,
+            > | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const operation = (await promise) as LROperation<
@@ -3281,18 +3281,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createBucketAsync = stubLongRunningCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createBucketAsync(request), expectedError);
       const actualRequest = (
@@ -3312,11 +3312,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateBucketRequest(),
+        new protos.google.logging.v2.CreateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateBucketRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -3324,7 +3324,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.createBucketAsync = stubLongRunningCall(
         undefined,
         undefined,
-        expectedError,
+        expectedError
       );
       const [operation] = await client.createBucketAsync(request);
       await assert.rejects(operation.promise(), expectedError);
@@ -3345,7 +3345,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       expectedResponse.name = 'test';
       expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
@@ -3353,7 +3353,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkCreateBucketAsyncProgress(
-        expectedResponse.name,
+        expectedResponse.name
       );
       assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
       assert(decodedOperation.metadata);
@@ -3370,11 +3370,11 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(
         client.checkCreateBucketAsyncProgress(''),
-        expectedError,
+        expectedError
       );
       assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
@@ -3388,16 +3388,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.updateBucketAsync =
         stubLongRunningCall(expectedResponse);
@@ -3421,16 +3421,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.updateBucketAsync =
         stubLongRunningCallWithCallback(expectedResponse);
@@ -3442,14 +3442,14 @@ describe('v2.ConfigServiceV2Client', () => {
             result?: LROperation<
               protos.google.logging.v2.ILogBucket,
               protos.google.logging.v2.IBucketMetadata
-            > | null,
+            > | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const operation = (await promise) as LROperation<
@@ -3475,18 +3475,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateBucketAsync = stubLongRunningCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateBucketAsync(request), expectedError);
       const actualRequest = (
@@ -3506,11 +3506,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateBucketRequest(),
+        new protos.google.logging.v2.UpdateBucketRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateBucketRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
@@ -3518,7 +3518,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.updateBucketAsync = stubLongRunningCall(
         undefined,
         undefined,
-        expectedError,
+        expectedError
       );
       const [operation] = await client.updateBucketAsync(request);
       await assert.rejects(operation.promise(), expectedError);
@@ -3539,7 +3539,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       expectedResponse.name = 'test';
       expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
@@ -3547,7 +3547,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkUpdateBucketAsyncProgress(
-        expectedResponse.name,
+        expectedResponse.name
       );
       assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
       assert(decodedOperation.metadata);
@@ -3564,11 +3564,11 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(
         client.checkUpdateBucketAsyncProgress(''),
-        expectedError,
+        expectedError
       );
       assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
@@ -3582,16 +3582,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLinkRequest(),
+        new protos.google.logging.v2.CreateLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.createLink = stubLongRunningCall(expectedResponse);
       const [operation] = await client.createLink(request);
@@ -3614,16 +3614,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLinkRequest(),
+        new protos.google.logging.v2.CreateLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.createLink =
         stubLongRunningCallWithCallback(expectedResponse);
@@ -3635,14 +3635,14 @@ describe('v2.ConfigServiceV2Client', () => {
             result?: LROperation<
               protos.google.logging.v2.ILink,
               protos.google.logging.v2.ILinkMetadata
-            > | null,
+            > | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const operation = (await promise) as LROperation<
@@ -3668,18 +3668,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLinkRequest(),
+        new protos.google.logging.v2.CreateLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createLink = stubLongRunningCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createLink(request), expectedError);
       const actualRequest = (
@@ -3699,11 +3699,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLinkRequest(),
+        new protos.google.logging.v2.CreateLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLinkRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -3711,7 +3711,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.createLink = stubLongRunningCall(
         undefined,
         undefined,
-        expectedError,
+        expectedError
       );
       const [operation] = await client.createLink(request);
       await assert.rejects(operation.promise(), expectedError);
@@ -3732,7 +3732,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       expectedResponse.name = 'test';
       expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
@@ -3740,7 +3740,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkCreateLinkProgress(
-        expectedResponse.name,
+        expectedResponse.name
       );
       assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
       assert(decodedOperation.metadata);
@@ -3757,7 +3757,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.checkCreateLinkProgress(''), expectedError);
       assert((client.operationsClient.getOperation as SinonStub).getCall(0));
@@ -3772,16 +3772,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLinkRequest(),
+        new protos.google.logging.v2.DeleteLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.deleteLink = stubLongRunningCall(expectedResponse);
       const [operation] = await client.deleteLink(request);
@@ -3804,16 +3804,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLinkRequest(),
+        new protos.google.logging.v2.DeleteLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.deleteLink =
         stubLongRunningCallWithCallback(expectedResponse);
@@ -3825,14 +3825,14 @@ describe('v2.ConfigServiceV2Client', () => {
             result?: LROperation<
               protos.google.protobuf.IEmpty,
               protos.google.logging.v2.ILinkMetadata
-            > | null,
+            > | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const operation = (await promise) as LROperation<
@@ -3858,18 +3858,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLinkRequest(),
+        new protos.google.logging.v2.DeleteLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteLink = stubLongRunningCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteLink(request), expectedError);
       const actualRequest = (
@@ -3889,11 +3889,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLinkRequest(),
+        new protos.google.logging.v2.DeleteLinkRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLinkRequest',
-        ['name'],
+        ['name']
       );
       request.name = defaultValue1;
       const expectedHeaderRequestParams = `name=${defaultValue1}`;
@@ -3901,7 +3901,7 @@ describe('v2.ConfigServiceV2Client', () => {
       client.innerApiCalls.deleteLink = stubLongRunningCall(
         undefined,
         undefined,
-        expectedError,
+        expectedError
       );
       const [operation] = await client.deleteLink(request);
       await assert.rejects(operation.promise(), expectedError);
@@ -3922,7 +3922,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       expectedResponse.name = 'test';
       expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
@@ -3930,7 +3930,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkDeleteLinkProgress(
-        expectedResponse.name,
+        expectedResponse.name
       );
       assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
       assert(decodedOperation.metadata);
@@ -3947,7 +3947,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.checkDeleteLinkProgress(''), expectedError);
       assert((client.operationsClient.getOperation as SinonStub).getCall(0));
@@ -3962,10 +3962,10 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CopyLogEntriesRequest(),
+        new protos.google.logging.v2.CopyLogEntriesRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.copyLogEntries =
         stubLongRunningCall(expectedResponse);
@@ -3981,10 +3981,10 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CopyLogEntriesRequest(),
+        new protos.google.logging.v2.CopyLogEntriesRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.longrunning.Operation(),
+        new protos.google.longrunning.Operation()
       );
       client.innerApiCalls.copyLogEntries =
         stubLongRunningCallWithCallback(expectedResponse);
@@ -3996,14 +3996,14 @@ describe('v2.ConfigServiceV2Client', () => {
             result?: LROperation<
               protos.google.logging.v2.ICopyLogEntriesResponse,
               protos.google.logging.v2.ICopyLogEntriesMetadata
-            > | null,
+            > | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const operation = (await promise) as LROperation<
@@ -4021,12 +4021,12 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CopyLogEntriesRequest(),
+        new protos.google.logging.v2.CopyLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.copyLogEntries = stubLongRunningCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.copyLogEntries(request), expectedError);
     });
@@ -4038,13 +4038,13 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CopyLogEntriesRequest(),
+        new protos.google.logging.v2.CopyLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.copyLogEntries = stubLongRunningCall(
         undefined,
         undefined,
-        expectedError,
+        expectedError
       );
       const [operation] = await client.copyLogEntries(request);
       await assert.rejects(operation.promise(), expectedError);
@@ -4057,7 +4057,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       expectedResponse.name = 'test';
       expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
@@ -4065,7 +4065,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const decodedOperation = await client.checkCopyLogEntriesProgress(
-        expectedResponse.name,
+        expectedResponse.name
       );
       assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
       assert(decodedOperation.metadata);
@@ -4082,11 +4082,11 @@ describe('v2.ConfigServiceV2Client', () => {
 
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(
         client.checkCopyLogEntriesProgress(''),
-        expectedError,
+        expectedError
       );
       assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
@@ -4100,11 +4100,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4133,11 +4133,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4153,14 +4153,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogBucket[] | null,
+            result?: protos.google.logging.v2.ILogBucket[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -4182,18 +4182,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.listBuckets = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.listBuckets(request), expectedError);
       const actualRequest = (
@@ -4213,11 +4213,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4246,14 +4246,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listBuckets.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listBuckets, request),
+          .calledWith(client.innerApiCalls.listBuckets, request)
       );
       assert(
         (client.descriptors.page.listBuckets.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4264,18 +4264,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listBuckets.createStream = stubPageStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.listBucketsStream(request);
       const promise = new Promise((resolve, reject) => {
@@ -4294,14 +4294,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listBuckets.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listBuckets, request),
+          .calledWith(client.innerApiCalls.listBuckets, request)
       );
       assert(
         (client.descriptors.page.listBuckets.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4312,11 +4312,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4335,16 +4335,16 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(responses, expectedResponse);
       assert.deepStrictEqual(
         (client.descriptors.page.listBuckets.asyncIterate as SinonStub).getCall(
-          0,
+          0
         ).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4355,18 +4355,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListBucketsRequest(),
+        new protos.google.logging.v2.ListBucketsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListBucketsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listBuckets.asyncIterate = stubAsyncIterationCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const iterable = client.listBucketsAsync(request);
       await assert.rejects(async () => {
@@ -4377,16 +4377,16 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       assert.deepStrictEqual(
         (client.descriptors.page.listBuckets.asyncIterate as SinonStub).getCall(
-          0,
+          0
         ).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -4399,11 +4399,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4432,11 +4432,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4452,14 +4452,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogView[] | null,
+            result?: protos.google.logging.v2.ILogView[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -4481,11 +4481,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4509,11 +4509,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4542,14 +4542,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listViews.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listViews, request),
+          .calledWith(client.innerApiCalls.listViews, request)
       );
       assert(
         (client.descriptors.page.listViews.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4560,18 +4560,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listViews.createStream = stubPageStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.listViewsStream(request);
       const promise = new Promise((resolve, reject) => {
@@ -4590,14 +4590,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listViews.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listViews, request),
+          .calledWith(client.innerApiCalls.listViews, request)
       );
       assert(
         (client.descriptors.page.listViews.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4608,11 +4608,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4632,14 +4632,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listViews.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listViews.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4650,18 +4650,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListViewsRequest(),
+        new protos.google.logging.v2.ListViewsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListViewsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listViews.asyncIterate = stubAsyncIterationCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const iterable = client.listViewsAsync(request);
       await assert.rejects(async () => {
@@ -4673,14 +4673,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listViews.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listViews.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -4693,11 +4693,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4726,11 +4726,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4746,14 +4746,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogSink[] | null,
+            result?: protos.google.logging.v2.ILogSink[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -4775,11 +4775,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4803,11 +4803,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4836,14 +4836,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listSinks.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listSinks, request),
+          .calledWith(client.innerApiCalls.listSinks, request)
       );
       assert(
         (client.descriptors.page.listSinks.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4854,18 +4854,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listSinks.createStream = stubPageStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.listSinksStream(request);
       const promise = new Promise((resolve, reject) => {
@@ -4884,14 +4884,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listSinks.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listSinks, request),
+          .calledWith(client.innerApiCalls.listSinks, request)
       );
       assert(
         (client.descriptors.page.listSinks.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4902,11 +4902,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -4926,14 +4926,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listSinks.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listSinks.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -4944,18 +4944,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListSinksRequest(),
+        new protos.google.logging.v2.ListSinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListSinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listSinks.asyncIterate = stubAsyncIterationCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const iterable = client.listSinksAsync(request);
       await assert.rejects(async () => {
@@ -4967,14 +4967,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listSinks.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listSinks.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -4987,11 +4987,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5020,11 +5020,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5040,14 +5040,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILink[] | null,
+            result?: protos.google.logging.v2.ILink[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -5069,11 +5069,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5097,11 +5097,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5130,14 +5130,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLinks.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLinks, request),
+          .calledWith(client.innerApiCalls.listLinks, request)
       );
       assert(
         (client.descriptors.page.listLinks.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5148,18 +5148,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listLinks.createStream = stubPageStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.listLinksStream(request);
       const promise = new Promise((resolve, reject) => {
@@ -5178,14 +5178,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLinks.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLinks, request),
+          .calledWith(client.innerApiCalls.listLinks, request)
       );
       assert(
         (client.descriptors.page.listLinks.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5196,11 +5196,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5220,14 +5220,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listLinks.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLinks.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5238,18 +5238,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLinksRequest(),
+        new protos.google.logging.v2.ListLinksRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLinksRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listLinks.asyncIterate = stubAsyncIterationCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const iterable = client.listLinksAsync(request);
       await assert.rejects(async () => {
@@ -5261,14 +5261,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listLinks.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLinks.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -5281,11 +5281,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5314,11 +5314,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5334,14 +5334,14 @@ describe('v2.ConfigServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogExclusion[] | null,
+            result?: protos.google.logging.v2.ILogExclusion[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -5363,18 +5363,18 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.listExclusions = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.listExclusions(request), expectedError);
       const actualRequest = (
@@ -5394,11 +5394,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5427,14 +5427,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listExclusions.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listExclusions, request),
+          .calledWith(client.innerApiCalls.listExclusions, request)
       );
       assert(
         (client.descriptors.page.listExclusions.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5445,11 +5445,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5473,14 +5473,14 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.descriptors.page.listExclusions.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listExclusions, request),
+          .calledWith(client.innerApiCalls.listExclusions, request)
       );
       assert(
         (client.descriptors.page.listExclusions.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5491,11 +5491,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5516,14 +5516,14 @@ describe('v2.ConfigServiceV2Client', () => {
         (
           client.descriptors.page.listExclusions.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -5534,11 +5534,11 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListExclusionsRequest(),
+        new protos.google.logging.v2.ListExclusionsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListExclusionsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -5556,14 +5556,14 @@ describe('v2.ConfigServiceV2Client', () => {
         (
           client.descriptors.page.listExclusions.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -5575,10 +5575,10 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.GetOperationRequest(),
+        new operationsProtos.google.longrunning.GetOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
       const response = await client.getOperation(request);
@@ -5586,7 +5586,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.getOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
     it('invokes getOperation without error using callback', async () => {
@@ -5595,10 +5595,10 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.GetOperationRequest(),
+        new operationsProtos.google.longrunning.GetOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new operationsProtos.google.longrunning.Operation(),
+        new operationsProtos.google.longrunning.Operation()
       );
       client.operationsClient.getOperation = sinon
         .stub()
@@ -5609,14 +5609,14 @@ describe('v2.ConfigServiceV2Client', () => {
           undefined,
           (
             err?: Error | null,
-            result?: operationsProtos.google.longrunning.Operation | null,
+            result?: operationsProtos.google.longrunning.Operation | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -5629,12 +5629,12 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.GetOperationRequest(),
+        new operationsProtos.google.longrunning.GetOperationRequest()
       );
       const expectedError = new Error('expected');
       client.operationsClient.getOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(async () => {
         await client.getOperation(request);
@@ -5642,7 +5642,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.getOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
   });
@@ -5654,10 +5654,10 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.CancelOperationRequest(),
+        new operationsProtos.google.longrunning.CancelOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.operationsClient.cancelOperation =
         stubSimpleCall(expectedResponse);
@@ -5666,7 +5666,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.cancelOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
     it('invokes cancelOperation without error using callback', async () => {
@@ -5675,10 +5675,10 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.CancelOperationRequest(),
+        new operationsProtos.google.longrunning.CancelOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.operationsClient.cancelOperation = sinon
         .stub()
@@ -5689,14 +5689,14 @@ describe('v2.ConfigServiceV2Client', () => {
           undefined,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.Empty | null,
+            result?: protos.google.protobuf.Empty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -5709,12 +5709,12 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.CancelOperationRequest(),
+        new operationsProtos.google.longrunning.CancelOperationRequest()
       );
       const expectedError = new Error('expected');
       client.operationsClient.cancelOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(async () => {
         await client.cancelOperation(request);
@@ -5722,7 +5722,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.cancelOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
   });
@@ -5734,10 +5734,10 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.DeleteOperationRequest(),
+        new operationsProtos.google.longrunning.DeleteOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.operationsClient.deleteOperation =
         stubSimpleCall(expectedResponse);
@@ -5746,7 +5746,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.deleteOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
     it('invokes deleteOperation without error using callback', async () => {
@@ -5755,10 +5755,10 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.DeleteOperationRequest(),
+        new operationsProtos.google.longrunning.DeleteOperationRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.operationsClient.deleteOperation = sinon
         .stub()
@@ -5769,14 +5769,14 @@ describe('v2.ConfigServiceV2Client', () => {
           undefined,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.Empty | null,
+            result?: protos.google.protobuf.Empty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -5789,12 +5789,12 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.DeleteOperationRequest(),
+        new operationsProtos.google.longrunning.DeleteOperationRequest()
       );
       const expectedError = new Error('expected');
       client.operationsClient.deleteOperation = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(async () => {
         await client.deleteOperation(request);
@@ -5802,7 +5802,7 @@ describe('v2.ConfigServiceV2Client', () => {
       assert(
         (client.operationsClient.deleteOperation as SinonStub)
           .getCall(0)
-          .calledWith(request),
+          .calledWith(request)
       );
     });
   });
@@ -5813,17 +5813,17 @@ describe('v2.ConfigServiceV2Client', () => {
         projectId: 'bogus',
       });
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.ListOperationsRequest(),
+        new operationsProtos.google.longrunning.ListOperationsRequest()
       );
       const expectedResponse = [
         generateSampleMessage(
-          new operationsProtos.google.longrunning.ListOperationsResponse(),
+          new operationsProtos.google.longrunning.ListOperationsResponse()
         ),
         generateSampleMessage(
-          new operationsProtos.google.longrunning.ListOperationsResponse(),
+          new operationsProtos.google.longrunning.ListOperationsResponse()
         ),
         generateSampleMessage(
-          new operationsProtos.google.longrunning.ListOperationsResponse(),
+          new operationsProtos.google.longrunning.ListOperationsResponse()
         ),
       ];
       client.operationsClient.descriptor.listOperations.asyncIterate =
@@ -5840,7 +5840,7 @@ describe('v2.ConfigServiceV2Client', () => {
           client.operationsClient.descriptor.listOperations
             .asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
     it('uses async iteration with listOperations with error', async () => {
@@ -5850,7 +5850,7 @@ describe('v2.ConfigServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new operationsProtos.google.longrunning.ListOperationsRequest(),
+        new operationsProtos.google.longrunning.ListOperationsRequest()
       );
       const expectedError = new Error('expected');
       client.operationsClient.descriptor.listOperations.asyncIterate =
@@ -5868,7 +5868,7 @@ describe('v2.ConfigServiceV2Client', () => {
           client.operationsClient.descriptor.listOperations
             .asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
   });
@@ -5893,7 +5893,7 @@ describe('v2.ConfigServiceV2Client', () => {
 
       it('billingAccountCmekSettingsPath', () => {
         const result = client.billingAccountCmekSettingsPath(
-          'billingAccountValue',
+          'billingAccountValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -5902,14 +5902,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountCmekSettingsName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountCmekSettingsName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -5918,7 +5918,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -5944,7 +5944,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('billingAccountExclusionPath', () => {
         const result = client.billingAccountExclusionPath(
           'billingAccountValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -5953,7 +5953,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -5967,7 +5967,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -5981,7 +5981,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6007,7 +6007,7 @@ describe('v2.ConfigServiceV2Client', () => {
         const result = client.billingAccountLocationBucketPath(
           'billingAccountValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6016,14 +6016,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -6032,7 +6032,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6046,7 +6046,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6060,7 +6060,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6088,7 +6088,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6097,14 +6097,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -6113,14 +6113,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -6129,7 +6129,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6143,7 +6143,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6157,7 +6157,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6185,7 +6185,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6194,14 +6194,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -6210,14 +6210,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -6226,7 +6226,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6240,7 +6240,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6254,7 +6254,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6280,7 +6280,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('billingAccountLogPath', () => {
         const result = client.billingAccountLogPath(
           'billingAccountValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6289,7 +6289,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6303,7 +6303,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6316,7 +6316,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6347,7 +6347,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6361,7 +6361,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6387,7 +6387,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('billingAccountSinkPath', () => {
         const result = client.billingAccountSinkPath(
           'billingAccountValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6396,7 +6396,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6410,7 +6410,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6423,7 +6423,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6454,7 +6454,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6467,7 +6467,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6493,13 +6493,13 @@ describe('v2.ConfigServiceV2Client', () => {
       it('folderExclusionPath', () => {
         const result = client.folderExclusionPath(
           'folderValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6509,7 +6509,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6519,7 +6519,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6547,7 +6547,7 @@ describe('v2.ConfigServiceV2Client', () => {
         const result = client.folderLocationBucketPath(
           'folderValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6556,7 +6556,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6569,7 +6569,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6583,7 +6583,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6596,7 +6596,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6626,7 +6626,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6635,7 +6635,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6649,7 +6649,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6663,7 +6663,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6677,7 +6677,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6691,7 +6691,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6721,7 +6721,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -6730,7 +6730,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6744,7 +6744,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6758,7 +6758,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6772,7 +6772,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6786,7 +6786,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6815,7 +6815,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6825,7 +6825,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6835,7 +6835,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6863,7 +6863,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6873,7 +6873,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6902,7 +6902,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6912,7 +6912,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6922,7 +6922,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -6951,7 +6951,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.locationPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -6961,7 +6961,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.locationPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -6971,7 +6971,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.locationPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7000,7 +7000,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7010,7 +7010,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7020,7 +7020,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7051,7 +7051,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7065,7 +7065,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7091,7 +7091,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('organizationExclusionPath', () => {
         const result = client.organizationExclusionPath(
           'organizationValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7100,7 +7100,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7114,7 +7114,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7128,7 +7128,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7156,7 +7156,7 @@ describe('v2.ConfigServiceV2Client', () => {
         const result = client.organizationLocationBucketPath(
           'organizationValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7165,7 +7165,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7179,7 +7179,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7193,7 +7193,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7207,7 +7207,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7235,7 +7235,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7244,14 +7244,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketLinkName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -7260,7 +7260,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7274,7 +7274,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7288,7 +7288,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7302,7 +7302,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7330,7 +7330,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7339,14 +7339,14 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -7355,7 +7355,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7369,7 +7369,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7383,7 +7383,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7397,7 +7397,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7423,13 +7423,13 @@ describe('v2.ConfigServiceV2Client', () => {
       it('organizationLogPath', () => {
         const result = client.organizationLogPath(
           'organizationValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.organizationLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7440,7 +7440,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7450,7 +7450,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7481,7 +7481,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7495,7 +7495,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7521,7 +7521,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('organizationSinkPath', () => {
         const result = client.organizationSinkPath(
           'organizationValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7530,7 +7530,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7541,7 +7541,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7551,7 +7551,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7579,7 +7579,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7589,7 +7589,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7620,7 +7620,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7633,7 +7633,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7659,7 +7659,7 @@ describe('v2.ConfigServiceV2Client', () => {
       it('projectExclusionPath', () => {
         const result = client.projectExclusionPath(
           'projectValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7668,7 +7668,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7678,7 +7678,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7688,7 +7688,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7716,7 +7716,7 @@ describe('v2.ConfigServiceV2Client', () => {
         const result = client.projectLocationBucketPath(
           'projectValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7725,7 +7725,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7739,7 +7739,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7753,7 +7753,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7767,7 +7767,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7797,7 +7797,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7806,7 +7806,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7820,7 +7820,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7834,7 +7834,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7848,7 +7848,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7862,7 +7862,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7892,7 +7892,7 @@ describe('v2.ConfigServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -7901,7 +7901,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7915,7 +7915,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7929,7 +7929,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7943,7 +7943,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -7957,7 +7957,7 @@ describe('v2.ConfigServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -7986,7 +7986,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -7996,7 +7996,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -8006,7 +8006,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -8034,7 +8034,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -8044,7 +8044,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -8073,7 +8073,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -8083,7 +8083,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -8093,7 +8093,7 @@ describe('v2.ConfigServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });

--- a/handwritten/logging/test/gapic_logging_service_v2_v2.ts
+++ b/handwritten/logging/test/gapic_logging_service_v2_v2.ts
@@ -30,7 +30,7 @@ import {protobuf} from 'google-gax';
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(
-  require('../protos/protos.json'),
+  require('../protos/protos.json')
 ).resolveAll();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -47,7 +47,7 @@ function generateSampleMessage<T extends object>(instance: T) {
     instance.constructor as typeof protobuf.Message
   ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
-    filledObject,
+    filledObject
   ) as T;
 }
 
@@ -59,7 +59,7 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
 
 function stubSimpleCallWithCallback<ResponseType>(
   response?: ResponseType,
-  error?: Error,
+  error?: Error
 ) {
   return error
     ? sinon.stub().callsArgWith(2, error)
@@ -68,7 +68,7 @@ function stubSimpleCallWithCallback<ResponseType>(
 
 function stubBidiStreamingCall<ResponseType>(
   response?: ResponseType,
-  error?: Error,
+  error?: Error
 ) {
   const transformStub = error
     ? sinon.stub().callsArgWith(2, error)
@@ -82,7 +82,7 @@ function stubBidiStreamingCall<ResponseType>(
 
 function stubPageStreamingCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   const pagingStub = sinon.stub();
   if (responses) {
@@ -120,7 +120,7 @@ function stubPageStreamingCall<ResponseType>(
 
 function stubAsyncIterationCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   let counter = 0;
   const asyncIterable = {
@@ -327,16 +327,16 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogRequest(),
+        new protos.google.logging.v2.DeleteLogRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogRequest',
-        ['logName'],
+        ['logName']
       );
       request.logName = defaultValue1;
       const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteLog = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteLog(request);
@@ -358,16 +358,16 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogRequest(),
+        new protos.google.logging.v2.DeleteLogRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogRequest',
-        ['logName'],
+        ['logName']
       );
       request.logName = defaultValue1;
       const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteLog =
         stubSimpleCallWithCallback(expectedResponse);
@@ -376,14 +376,14 @@ describe('v2.LoggingServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -405,11 +405,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogRequest(),
+        new protos.google.logging.v2.DeleteLogRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogRequest',
-        ['logName'],
+        ['logName']
       );
       request.logName = defaultValue1;
       const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
@@ -433,11 +433,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogRequest(),
+        new protos.google.logging.v2.DeleteLogRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogRequest',
-        ['logName'],
+        ['logName']
       );
       request.logName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -454,10 +454,10 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesRequest(),
+        new protos.google.logging.v2.WriteLogEntriesRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesResponse(),
+        new protos.google.logging.v2.WriteLogEntriesResponse()
       );
       client.innerApiCalls.writeLogEntries = stubSimpleCall(expectedResponse);
       const [response] = await client.writeLogEntries(request);
@@ -471,10 +471,10 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesRequest(),
+        new protos.google.logging.v2.WriteLogEntriesRequest()
       );
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesResponse(),
+        new protos.google.logging.v2.WriteLogEntriesResponse()
       );
       client.innerApiCalls.writeLogEntries =
         stubSimpleCallWithCallback(expectedResponse);
@@ -483,14 +483,14 @@ describe('v2.LoggingServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.IWriteLogEntriesResponse | null,
+            result?: protos.google.logging.v2.IWriteLogEntriesResponse | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -504,12 +504,12 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesRequest(),
+        new protos.google.logging.v2.WriteLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.writeLogEntries = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.writeLogEntries(request), expectedError);
     });
@@ -521,7 +521,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.WriteLogEntriesRequest(),
+        new protos.google.logging.v2.WriteLogEntriesRequest()
       );
       const expectedError = new Error('The client has already been closed.');
       client.close();
@@ -537,11 +537,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.TailLogEntriesRequest(),
+        new protos.google.logging.v2.TailLogEntriesRequest()
       );
 
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.TailLogEntriesResponse(),
+        new protos.google.logging.v2.TailLogEntriesResponse()
       );
       client.innerApiCalls.tailLogEntries =
         stubBidiStreamingCall(expectedResponse);
@@ -551,7 +551,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'data',
           (response: protos.google.logging.v2.TailLogEntriesResponse) => {
             resolve(response);
-          },
+          }
         );
         stream.on('error', (err: Error) => {
           reject(err);
@@ -564,12 +564,12 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.innerApiCalls.tailLogEntries as SinonStub)
           .getCall(0)
-          .calledWith(null),
+          .calledWith(null)
       );
       assert.deepStrictEqual(
         ((stream as unknown as PassThrough)._transform as SinonStub).getCall(0)
           .args[0],
-        request,
+        request
       );
     });
 
@@ -580,12 +580,12 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.TailLogEntriesRequest(),
+        new protos.google.logging.v2.TailLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.tailLogEntries = stubBidiStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.tailLogEntries();
       const promise = new Promise((resolve, reject) => {
@@ -593,7 +593,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'data',
           (response: protos.google.logging.v2.TailLogEntriesResponse) => {
             resolve(response);
-          },
+          }
         );
         stream.on('error', (err: Error) => {
           reject(err);
@@ -605,12 +605,12 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.innerApiCalls.tailLogEntries as SinonStub)
           .getCall(0)
-          .calledWith(null),
+          .calledWith(null)
       );
       assert.deepStrictEqual(
         ((stream as unknown as PassThrough)._transform as SinonStub).getCall(0)
           .args[0],
-        request,
+        request
       );
     });
   });
@@ -623,7 +623,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedResponse = [
         generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -642,7 +642,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedResponse = [
         generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -656,14 +656,14 @@ describe('v2.LoggingServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogEntry[] | null,
+            result?: protos.google.logging.v2.ILogEntry[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -677,12 +677,12 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.listLogEntries = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.listLogEntries(request), expectedError);
     });
@@ -694,7 +694,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedResponse = [
         generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -721,7 +721,7 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogEntries.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogEntries, request),
+          .calledWith(client.innerApiCalls.listLogEntries, request)
       );
     });
 
@@ -732,7 +732,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.descriptors.page.listLogEntries.createStream =
@@ -754,7 +754,7 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogEntries.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogEntries, request),
+          .calledWith(client.innerApiCalls.listLogEntries, request)
       );
     });
 
@@ -765,7 +765,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedResponse = [
         generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -784,7 +784,7 @@ describe('v2.LoggingServiceV2Client', () => {
         (
           client.descriptors.page.listLogEntries.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
 
@@ -795,7 +795,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogEntriesRequest(),
+        new protos.google.logging.v2.ListLogEntriesRequest()
       );
       const expectedError = new Error('expected');
       client.descriptors.page.listLogEntries.asyncIterate =
@@ -811,7 +811,7 @@ describe('v2.LoggingServiceV2Client', () => {
         (
           client.descriptors.page.listLogEntries.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
   });
@@ -824,17 +824,17 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedResponse = [
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
       ];
       client.innerApiCalls.listMonitoredResourceDescriptors =
@@ -850,17 +850,17 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedResponse = [
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
       ];
       client.innerApiCalls.listMonitoredResourceDescriptors =
@@ -870,14 +870,14 @@ describe('v2.LoggingServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.api.IMonitoredResourceDescriptor[] | null,
+            result?: protos.google.api.IMonitoredResourceDescriptor[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -891,16 +891,16 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedError = new Error('expected');
       client.innerApiCalls.listMonitoredResourceDescriptors = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(
         client.listMonitoredResourceDescriptors(request),
-        expectedError,
+        expectedError
       );
     });
 
@@ -911,17 +911,17 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedResponse = [
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
       ];
       client.descriptors.page.listMonitoredResourceDescriptors.createStream =
@@ -933,7 +933,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'data',
           (response: protos.google.api.MonitoredResourceDescriptor) => {
             responses.push(response);
-          },
+          }
         );
         stream.on('end', () => {
           resolve(responses);
@@ -952,8 +952,8 @@ describe('v2.LoggingServiceV2Client', () => {
           .getCall(0)
           .calledWith(
             client.innerApiCalls.listMonitoredResourceDescriptors,
-            request,
-          ),
+            request
+          )
       );
     });
 
@@ -964,7 +964,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedError = new Error('expected');
       client.descriptors.page.listMonitoredResourceDescriptors.createStream =
@@ -976,7 +976,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'data',
           (response: protos.google.api.MonitoredResourceDescriptor) => {
             responses.push(response);
-          },
+          }
         );
         stream.on('end', () => {
           resolve(responses);
@@ -994,8 +994,8 @@ describe('v2.LoggingServiceV2Client', () => {
           .getCall(0)
           .calledWith(
             client.innerApiCalls.listMonitoredResourceDescriptors,
-            request,
-          ),
+            request
+          )
       );
     });
 
@@ -1006,17 +1006,17 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedResponse = [
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
         generateSampleMessage(
-          new protos.google.api.MonitoredResourceDescriptor(),
+          new protos.google.api.MonitoredResourceDescriptor()
         ),
       ];
       client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate =
@@ -1032,7 +1032,7 @@ describe('v2.LoggingServiceV2Client', () => {
           client.descriptors.page.listMonitoredResourceDescriptors
             .asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
 
@@ -1043,7 +1043,7 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest(),
+        new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
       );
       const expectedError = new Error('expected');
       client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate =
@@ -1060,7 +1060,7 @@ describe('v2.LoggingServiceV2Client', () => {
           client.descriptors.page.listMonitoredResourceDescriptors
             .asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
     });
   });
@@ -1073,11 +1073,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1102,11 +1102,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1122,7 +1122,7 @@ describe('v2.LoggingServiceV2Client', () => {
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -1144,11 +1144,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1172,11 +1172,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1201,14 +1201,14 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogs.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogs, request),
+          .calledWith(client.innerApiCalls.listLogs, request)
       );
       assert(
         (client.descriptors.page.listLogs.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -1219,18 +1219,18 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listLogs.createStream = stubPageStreamingCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const stream = client.listLogsStream(request);
       const promise = new Promise((resolve, reject) => {
@@ -1249,14 +1249,14 @@ describe('v2.LoggingServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogs.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogs, request),
+          .calledWith(client.innerApiCalls.listLogs, request)
       );
       assert(
         (client.descriptors.page.listLogs.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -1267,11 +1267,11 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1287,14 +1287,14 @@ describe('v2.LoggingServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listLogs.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLogs.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -1305,18 +1305,18 @@ describe('v2.LoggingServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogsRequest(),
+        new protos.google.logging.v2.ListLogsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.descriptors.page.listLogs.asyncIterate = stubAsyncIterationCall(
         undefined,
-        expectedError,
+        expectedError
       );
       const iterable = client.listLogsAsync(request);
       await assert.rejects(async () => {
@@ -1328,14 +1328,14 @@ describe('v2.LoggingServiceV2Client', () => {
       assert.deepStrictEqual(
         (client.descriptors.page.listLogs.asyncIterate as SinonStub).getCall(0)
           .args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLogs.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -1360,7 +1360,7 @@ describe('v2.LoggingServiceV2Client', () => {
 
       it('billingAccountCmekSettingsPath', () => {
         const result = client.billingAccountCmekSettingsPath(
-          'billingAccountValue',
+          'billingAccountValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1369,14 +1369,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountCmekSettingsName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountCmekSettingsName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1385,7 +1385,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1411,7 +1411,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('billingAccountExclusionPath', () => {
         const result = client.billingAccountExclusionPath(
           'billingAccountValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1420,7 +1420,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1434,7 +1434,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1448,7 +1448,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1474,7 +1474,7 @@ describe('v2.LoggingServiceV2Client', () => {
         const result = client.billingAccountLocationBucketPath(
           'billingAccountValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1483,14 +1483,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1499,7 +1499,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1513,7 +1513,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1527,7 +1527,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1555,7 +1555,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1564,14 +1564,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1580,14 +1580,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -1596,7 +1596,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1610,7 +1610,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1624,7 +1624,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1652,7 +1652,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1661,14 +1661,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1677,14 +1677,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -1693,7 +1693,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1707,7 +1707,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1721,7 +1721,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1747,7 +1747,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('billingAccountLogPath', () => {
         const result = client.billingAccountLogPath(
           'billingAccountValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1756,7 +1756,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1770,7 +1770,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1783,7 +1783,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1814,7 +1814,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1828,7 +1828,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1854,7 +1854,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('billingAccountSinkPath', () => {
         const result = client.billingAccountSinkPath(
           'billingAccountValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1863,7 +1863,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1877,7 +1877,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1890,7 +1890,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1921,7 +1921,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1934,7 +1934,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1960,13 +1960,13 @@ describe('v2.LoggingServiceV2Client', () => {
       it('folderExclusionPath', () => {
         const result = client.folderExclusionPath(
           'folderValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1976,7 +1976,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1986,7 +1986,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2014,7 +2014,7 @@ describe('v2.LoggingServiceV2Client', () => {
         const result = client.folderLocationBucketPath(
           'folderValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2023,7 +2023,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2036,7 +2036,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2050,7 +2050,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2063,7 +2063,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2093,7 +2093,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2102,7 +2102,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2116,7 +2116,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2130,7 +2130,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2144,7 +2144,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2158,7 +2158,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2188,7 +2188,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2197,7 +2197,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2211,7 +2211,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2225,7 +2225,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2239,7 +2239,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2253,7 +2253,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2282,7 +2282,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2292,7 +2292,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2302,7 +2302,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2330,7 +2330,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2340,7 +2340,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2369,7 +2369,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2379,7 +2379,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2389,7 +2389,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2418,7 +2418,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2428,7 +2428,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2438,7 +2438,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2469,7 +2469,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2483,7 +2483,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2509,7 +2509,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('organizationExclusionPath', () => {
         const result = client.organizationExclusionPath(
           'organizationValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2518,7 +2518,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2532,7 +2532,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2546,7 +2546,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2574,7 +2574,7 @@ describe('v2.LoggingServiceV2Client', () => {
         const result = client.organizationLocationBucketPath(
           'organizationValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2583,7 +2583,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2597,7 +2597,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2611,7 +2611,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2625,7 +2625,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2653,7 +2653,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2662,14 +2662,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketLinkName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -2678,7 +2678,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2692,7 +2692,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2706,7 +2706,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2720,7 +2720,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2748,7 +2748,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2757,14 +2757,14 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -2773,7 +2773,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2787,7 +2787,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2801,7 +2801,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2815,7 +2815,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2841,13 +2841,13 @@ describe('v2.LoggingServiceV2Client', () => {
       it('organizationLogPath', () => {
         const result = client.organizationLogPath(
           'organizationValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.organizationLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2858,7 +2858,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2868,7 +2868,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2899,7 +2899,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2913,7 +2913,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2939,7 +2939,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('organizationSinkPath', () => {
         const result = client.organizationSinkPath(
           'organizationValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2948,7 +2948,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2959,7 +2959,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2969,7 +2969,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2997,7 +2997,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3007,7 +3007,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3038,7 +3038,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3051,7 +3051,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3077,7 +3077,7 @@ describe('v2.LoggingServiceV2Client', () => {
       it('projectExclusionPath', () => {
         const result = client.projectExclusionPath(
           'projectValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3086,7 +3086,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3096,7 +3096,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3106,7 +3106,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3134,7 +3134,7 @@ describe('v2.LoggingServiceV2Client', () => {
         const result = client.projectLocationBucketPath(
           'projectValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3143,7 +3143,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3157,7 +3157,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3171,7 +3171,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3185,7 +3185,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3215,7 +3215,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3224,7 +3224,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3238,7 +3238,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3252,7 +3252,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3266,7 +3266,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3280,7 +3280,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3310,7 +3310,7 @@ describe('v2.LoggingServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3319,7 +3319,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3333,7 +3333,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3347,7 +3347,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3361,7 +3361,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3375,7 +3375,7 @@ describe('v2.LoggingServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3404,7 +3404,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3414,7 +3414,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3424,7 +3424,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3452,7 +3452,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3462,7 +3462,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3491,7 +3491,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3501,7 +3501,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3511,7 +3511,7 @@ describe('v2.LoggingServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });

--- a/handwritten/logging/test/gapic_metrics_service_v2_v2.ts
+++ b/handwritten/logging/test/gapic_metrics_service_v2_v2.ts
@@ -30,7 +30,7 @@ import {protobuf} from 'google-gax';
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(
-  require('../protos/protos.json'),
+  require('../protos/protos.json')
 ).resolveAll();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -47,7 +47,7 @@ function generateSampleMessage<T extends object>(instance: T) {
     instance.constructor as typeof protobuf.Message
   ).toObject(instance as protobuf.Message<T>, {defaults: true});
   return (instance.constructor as typeof protobuf.Message).fromObject(
-    filledObject,
+    filledObject
   ) as T;
 }
 
@@ -59,7 +59,7 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
 
 function stubSimpleCallWithCallback<ResponseType>(
   response?: ResponseType,
-  error?: Error,
+  error?: Error
 ) {
   return error
     ? sinon.stub().callsArgWith(2, error)
@@ -68,7 +68,7 @@ function stubSimpleCallWithCallback<ResponseType>(
 
 function stubPageStreamingCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   const pagingStub = sinon.stub();
   if (responses) {
@@ -106,7 +106,7 @@ function stubPageStreamingCall<ResponseType>(
 
 function stubAsyncIterationCall<ResponseType>(
   responses?: ResponseType[],
-  error?: Error,
+  error?: Error
 ) {
   let counter = 0;
   const asyncIterable = {
@@ -313,16 +313,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLogMetricRequest(),
+        new protos.google.logging.v2.GetLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.getLogMetric = stubSimpleCall(expectedResponse);
       const [response] = await client.getLogMetric(request);
@@ -344,16 +344,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLogMetricRequest(),
+        new protos.google.logging.v2.GetLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.getLogMetric =
         stubSimpleCallWithCallback(expectedResponse);
@@ -362,14 +362,14 @@ describe('v2.MetricsServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogMetric | null,
+            result?: protos.google.logging.v2.ILogMetric | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -391,18 +391,18 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLogMetricRequest(),
+        new protos.google.logging.v2.GetLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.getLogMetric = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.getLogMetric(request), expectedError);
       const actualRequest = (
@@ -422,11 +422,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.GetLogMetricRequest(),
+        new protos.google.logging.v2.GetLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.GetLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -443,16 +443,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLogMetricRequest(),
+        new protos.google.logging.v2.CreateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLogMetricRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.createLogMetric = stubSimpleCall(expectedResponse);
       const [response] = await client.createLogMetric(request);
@@ -474,16 +474,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLogMetricRequest(),
+        new protos.google.logging.v2.CreateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLogMetricRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.createLogMetric =
         stubSimpleCallWithCallback(expectedResponse);
@@ -492,14 +492,14 @@ describe('v2.MetricsServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogMetric | null,
+            result?: protos.google.logging.v2.ILogMetric | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -521,18 +521,18 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLogMetricRequest(),
+        new protos.google.logging.v2.CreateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLogMetricRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.createLogMetric = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.createLogMetric(request), expectedError);
       const actualRequest = (
@@ -552,11 +552,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.CreateLogMetricRequest(),
+        new protos.google.logging.v2.CreateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.CreateLogMetricRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -573,16 +573,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateLogMetricRequest(),
+        new protos.google.logging.v2.UpdateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.updateLogMetric = stubSimpleCall(expectedResponse);
       const [response] = await client.updateLogMetric(request);
@@ -604,16 +604,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateLogMetricRequest(),
+        new protos.google.logging.v2.UpdateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.logging.v2.LogMetric(),
+        new protos.google.logging.v2.LogMetric()
       );
       client.innerApiCalls.updateLogMetric =
         stubSimpleCallWithCallback(expectedResponse);
@@ -622,14 +622,14 @@ describe('v2.MetricsServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogMetric | null,
+            result?: protos.google.logging.v2.ILogMetric | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -651,18 +651,18 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateLogMetricRequest(),
+        new protos.google.logging.v2.UpdateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.updateLogMetric = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.updateLogMetric(request), expectedError);
       const actualRequest = (
@@ -682,11 +682,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.UpdateLogMetricRequest(),
+        new protos.google.logging.v2.UpdateLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.UpdateLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -703,16 +703,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogMetricRequest(),
+        new protos.google.logging.v2.DeleteLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteLogMetric = stubSimpleCall(expectedResponse);
       const [response] = await client.deleteLogMetric(request);
@@ -734,16 +734,16 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogMetricRequest(),
+        new protos.google.logging.v2.DeleteLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedResponse = generateSampleMessage(
-        new protos.google.protobuf.Empty(),
+        new protos.google.protobuf.Empty()
       );
       client.innerApiCalls.deleteLogMetric =
         stubSimpleCallWithCallback(expectedResponse);
@@ -752,14 +752,14 @@ describe('v2.MetricsServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.protobuf.IEmpty | null,
+            result?: protos.google.protobuf.IEmpty | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -781,18 +781,18 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogMetricRequest(),
+        new protos.google.logging.v2.DeleteLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.deleteLogMetric = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.deleteLogMetric(request), expectedError);
       const actualRequest = (
@@ -812,11 +812,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.DeleteLogMetricRequest(),
+        new protos.google.logging.v2.DeleteLogMetricRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.DeleteLogMetricRequest',
-        ['metricName'],
+        ['metricName']
       );
       request.metricName = defaultValue1;
       const expectedError = new Error('The client has already been closed.');
@@ -833,11 +833,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -866,11 +866,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -886,14 +886,14 @@ describe('v2.MetricsServiceV2Client', () => {
           request,
           (
             err?: Error | null,
-            result?: protos.google.logging.v2.ILogMetric[] | null,
+            result?: protos.google.logging.v2.ILogMetric[] | null
           ) => {
             if (err) {
               reject(err);
             } else {
               resolve(result);
             }
-          },
+          }
         );
       });
       const response = await promise;
@@ -915,18 +915,18 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
       const expectedError = new Error('expected');
       client.innerApiCalls.listLogMetrics = stubSimpleCall(
         undefined,
-        expectedError,
+        expectedError
       );
       await assert.rejects(client.listLogMetrics(request), expectedError);
       const actualRequest = (
@@ -946,11 +946,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -979,14 +979,14 @@ describe('v2.MetricsServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogMetrics.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogMetrics, request),
+          .calledWith(client.innerApiCalls.listLogMetrics, request)
       );
       assert(
         (client.descriptors.page.listLogMetrics.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -997,11 +997,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1025,14 +1025,14 @@ describe('v2.MetricsServiceV2Client', () => {
       assert(
         (client.descriptors.page.listLogMetrics.createStream as SinonStub)
           .getCall(0)
-          .calledWith(client.innerApiCalls.listLogMetrics, request),
+          .calledWith(client.innerApiCalls.listLogMetrics, request)
       );
       assert(
         (client.descriptors.page.listLogMetrics.createStream as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -1043,11 +1043,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1068,14 +1068,14 @@ describe('v2.MetricsServiceV2Client', () => {
         (
           client.descriptors.page.listLogMetrics.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
 
@@ -1086,11 +1086,11 @@ describe('v2.MetricsServiceV2Client', () => {
       });
       client.initialize();
       const request = generateSampleMessage(
-        new protos.google.logging.v2.ListLogMetricsRequest(),
+        new protos.google.logging.v2.ListLogMetricsRequest()
       );
       const defaultValue1 = getTypeDefaultValue(
         '.google.logging.v2.ListLogMetricsRequest',
-        ['parent'],
+        ['parent']
       );
       request.parent = defaultValue1;
       const expectedHeaderRequestParams = `parent=${defaultValue1}`;
@@ -1108,14 +1108,14 @@ describe('v2.MetricsServiceV2Client', () => {
         (
           client.descriptors.page.listLogMetrics.asyncIterate as SinonStub
         ).getCall(0).args[1],
-        request,
+        request
       );
       assert(
         (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
           .getCall(0)
           .args[2].otherArgs.headers[
             'x-goog-request-params'
-          ].includes(expectedHeaderRequestParams),
+          ].includes(expectedHeaderRequestParams)
       );
     });
   });
@@ -1140,7 +1140,7 @@ describe('v2.MetricsServiceV2Client', () => {
 
       it('billingAccountCmekSettingsPath', () => {
         const result = client.billingAccountCmekSettingsPath(
-          'billingAccountValue',
+          'billingAccountValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1149,14 +1149,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountCmekSettingsName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountCmekSettingsName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1165,7 +1165,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1191,7 +1191,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('billingAccountExclusionPath', () => {
         const result = client.billingAccountExclusionPath(
           'billingAccountValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1200,7 +1200,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1214,7 +1214,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1228,7 +1228,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1254,7 +1254,7 @@ describe('v2.MetricsServiceV2Client', () => {
         const result = client.billingAccountLocationBucketPath(
           'billingAccountValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1263,14 +1263,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1279,7 +1279,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1293,7 +1293,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1307,7 +1307,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1335,7 +1335,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1344,14 +1344,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1360,14 +1360,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketLinkName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -1376,7 +1376,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1390,7 +1390,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1404,7 +1404,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1432,7 +1432,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'billingAccountValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1441,14 +1441,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchBillingAccountFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'billingAccountValue');
         assert(
@@ -1457,14 +1457,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
       it('matchLocationFromBillingAccountLocationBucketViewName', () => {
         const result =
           client.matchLocationFromBillingAccountLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'locationValue');
         assert(
@@ -1473,7 +1473,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1487,7 +1487,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1501,7 +1501,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1527,7 +1527,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('billingAccountLogPath', () => {
         const result = client.billingAccountLogPath(
           'billingAccountValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1536,7 +1536,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1550,7 +1550,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1563,7 +1563,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1594,7 +1594,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1608,7 +1608,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1634,7 +1634,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('billingAccountSinkPath', () => {
         const result = client.billingAccountSinkPath(
           'billingAccountValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1643,7 +1643,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1657,7 +1657,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1670,7 +1670,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1701,7 +1701,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1714,7 +1714,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1740,13 +1740,13 @@ describe('v2.MetricsServiceV2Client', () => {
       it('folderExclusionPath', () => {
         const result = client.folderExclusionPath(
           'folderValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1756,7 +1756,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1766,7 +1766,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1794,7 +1794,7 @@ describe('v2.MetricsServiceV2Client', () => {
         const result = client.folderLocationBucketPath(
           'folderValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1803,7 +1803,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1816,7 +1816,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1830,7 +1830,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1843,7 +1843,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1873,7 +1873,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1882,7 +1882,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1896,7 +1896,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1910,7 +1910,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1924,7 +1924,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -1938,7 +1938,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -1968,7 +1968,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'folderValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -1977,7 +1977,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -1991,7 +1991,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2005,7 +2005,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2019,7 +2019,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2033,7 +2033,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2062,7 +2062,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2072,7 +2072,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2082,7 +2082,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2110,7 +2110,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2120,7 +2120,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2149,7 +2149,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2159,7 +2159,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2169,7 +2169,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.folderSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2198,7 +2198,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2208,7 +2208,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2218,7 +2218,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.logMetricPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2249,7 +2249,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2263,7 +2263,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2289,7 +2289,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('organizationExclusionPath', () => {
         const result = client.organizationExclusionPath(
           'organizationValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2298,7 +2298,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2312,7 +2312,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2326,7 +2326,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2354,7 +2354,7 @@ describe('v2.MetricsServiceV2Client', () => {
         const result = client.organizationLocationBucketPath(
           'organizationValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2363,7 +2363,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2377,7 +2377,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2391,7 +2391,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2405,7 +2405,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2433,7 +2433,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2442,14 +2442,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketLinkName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketLinkName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -2458,7 +2458,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2472,7 +2472,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2486,7 +2486,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2500,7 +2500,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2528,7 +2528,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'organizationValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2537,14 +2537,14 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
       it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
         const result =
           client.matchOrganizationFromOrganizationLocationBucketViewName(
-            fakePath,
+            fakePath
           );
         assert.strictEqual(result, 'organizationValue');
         assert(
@@ -2553,7 +2553,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2567,7 +2567,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2581,7 +2581,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2595,7 +2595,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2621,13 +2621,13 @@ describe('v2.MetricsServiceV2Client', () => {
       it('organizationLogPath', () => {
         const result = client.organizationLogPath(
           'organizationValue',
-          'logValue',
+          'logValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
           (client.pathTemplates.organizationLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2638,7 +2638,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2648,7 +2648,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2679,7 +2679,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2693,7 +2693,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2719,7 +2719,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('organizationSinkPath', () => {
         const result = client.organizationSinkPath(
           'organizationValue',
-          'sinkValue',
+          'sinkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2728,7 +2728,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2739,7 +2739,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2749,7 +2749,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.organizationSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2777,7 +2777,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2787,7 +2787,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2818,7 +2818,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2831,7 +2831,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2857,7 +2857,7 @@ describe('v2.MetricsServiceV2Client', () => {
       it('projectExclusionPath', () => {
         const result = client.projectExclusionPath(
           'projectValue',
-          'exclusionValue',
+          'exclusionValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2866,7 +2866,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2876,7 +2876,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2886,7 +2886,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectExclusionPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2914,7 +2914,7 @@ describe('v2.MetricsServiceV2Client', () => {
         const result = client.projectLocationBucketPath(
           'projectValue',
           'locationValue',
-          'bucketValue',
+          'bucketValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -2923,7 +2923,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -2937,7 +2937,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2951,7 +2951,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -2965,7 +2965,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -2995,7 +2995,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'linkValue',
+          'linkValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3004,7 +3004,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3018,7 +3018,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3032,7 +3032,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3046,7 +3046,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3060,7 +3060,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3090,7 +3090,7 @@ describe('v2.MetricsServiceV2Client', () => {
           'projectValue',
           'locationValue',
           'bucketValue',
-          'viewValue',
+          'viewValue'
         );
         assert.strictEqual(result, fakePath);
         assert(
@@ -3099,7 +3099,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .render as SinonStub
           )
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3113,7 +3113,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3127,7 +3127,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3141,7 +3141,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3155,7 +3155,7 @@ describe('v2.MetricsServiceV2Client', () => {
               .match as SinonStub
           )
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3184,7 +3184,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3194,7 +3194,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3204,7 +3204,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectLogPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3232,7 +3232,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3242,7 +3242,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });
@@ -3271,7 +3271,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.render as SinonStub)
             .getCall(-1)
-            .calledWith(expectedParameters),
+            .calledWith(expectedParameters)
         );
       });
 
@@ -3281,7 +3281,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
 
@@ -3291,7 +3291,7 @@ describe('v2.MetricsServiceV2Client', () => {
         assert(
           (client.pathTemplates.projectSinkPathTemplate.match as SinonStub)
             .getCall(-1)
-            .calledWith(fakePath),
+            .calledWith(fakePath)
         );
       });
     });

--- a/handwritten/logging/test/index.ts
+++ b/handwritten/logging/test/index.ts
@@ -215,8 +215,8 @@ describe('Logging', () => {
               libVersion: version,
               scopes: EXPECTED_SCOPES,
             },
-            options,
-          ),
+            options
+          )
         );
         return fakeGoogleAuthInstance;
       };
@@ -245,8 +245,8 @@ describe('Logging', () => {
             libVersion: version,
             scopes: EXPECTED_SCOPES,
           },
-          options,
-        ),
+          options
+        )
       );
     });
 
@@ -354,7 +354,7 @@ describe('Logging', () => {
         logging.configService.createSink = async (
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           reqOpts: any,
-          gaxOpts: {},
+          gaxOpts: {}
         ) => {
           const expectedParent = 'projects/' + logging.projectId;
           assert.strictEqual(reqOpts.parent, expectedParent);
@@ -376,11 +376,11 @@ describe('Logging', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           reqOpts: any,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          gaxOpts: {},
+          gaxOpts: {}
         ) => {
           assert.strictEqual(
             reqOpts.uniqueWriterIdentity,
-            config.uniqueWriterIdentity,
+            config.uniqueWriterIdentity
           );
           assert.strictEqual(reqOpts.sink.uniqueWriterIdentity, undefined);
           return [{}];
@@ -399,7 +399,7 @@ describe('Logging', () => {
         logging.configService.createSink = async (
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           reqOpts: any,
-          gaxOpts: {},
+          gaxOpts: {}
         ) => {
           assert.strictEqual(reqOpts.sink.gaxOptions, undefined);
           assert.strictEqual(gaxOpts, config.gaxOptions);
@@ -455,7 +455,7 @@ describe('Logging', () => {
 
           const [sink_, apiResponse_] = await logging.createSink(
             SINK_NAME,
-            {} as CreateSinkRequest,
+            {} as CreateSinkRequest
           );
           assert.strictEqual(sink_, sink);
           assert.strictEqual(sink_.metadata, apiResponse);
@@ -487,7 +487,7 @@ describe('Logging', () => {
       logging.loggingService.listLogEntries = async (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         reqOpts: any,
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           filter: reqOpts?.filter,
@@ -512,7 +512,7 @@ describe('Logging', () => {
 
       logging.loggingService.listLogEntries = async (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        reqOpts: any,
+        reqOpts: any
       ) => {
         assert.deepStrictEqual(reqOpts.resourceNames, resourceNames);
         return [[]];
@@ -526,7 +526,7 @@ describe('Logging', () => {
 
       logging.loggingService.listLogEntries = async (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(
           reqOpts,
@@ -534,7 +534,7 @@ describe('Logging', () => {
             filter: 'timestamp > "2020-11-11T15:01:23.045123456Z"',
             orderBy: 'timestamp desc',
             resourceNames: ['projects/' + logging.projectId],
-          }),
+          })
         );
 
         assert.deepStrictEqual(gaxOpts, {
@@ -552,7 +552,7 @@ describe('Logging', () => {
       logging.loggingService.listLogEntries = async (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         reqOpts: any,
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(
           reqOpts,
@@ -560,7 +560,7 @@ describe('Logging', () => {
             filter: reqOpts?.filter,
             orderBy: 'timestamp desc',
             resourceNames: ['projects/' + logging.projectId],
-          }),
+          })
         );
         assert.deepStrictEqual(gaxOpts, {
           autoPaginate: undefined,
@@ -614,7 +614,7 @@ describe('Logging', () => {
       logging.loggingService.listLogEntries = async (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         reqOpts: any,
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           a: 'b',
@@ -692,7 +692,7 @@ describe('Logging', () => {
     it('should make request once reading', done => {
       logging.loggingService.listLogEntriesStream = (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           resourceNames: ['projects/' + logging.projectId],
@@ -721,7 +721,7 @@ describe('Logging', () => {
       logging = new LOGGING({projectId: PROJECT_ID});
       logging.loggingService.listLogEntriesStream = (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           resourceNames: ['projects/' + logging.projectId],
@@ -758,12 +758,12 @@ describe('Logging', () => {
         {
           filter: 'custom filter',
         },
-        OPTIONS,
+        OPTIONS
       );
       logging = new LOGGING({projectId: PROJECT_ID});
       logging.loggingService.listLogEntriesStream = (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           resourceNames: ['projects/' + logging.projectId],

--- a/handwritten/logging/test/instrumentation.ts
+++ b/handwritten/logging/test/instrumentation.ts
@@ -37,19 +37,19 @@ describe('instrumentation_info', () => {
   it('should generate library info properly by default', () => {
     const entry = instrumentation.createDiagnosticEntry(
       undefined,
-      undefined,
+      undefined
     ) as Entry;
     assert.equal(
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      instrumentation.getNodejsLibraryVersion(),
+      instrumentation.getNodejsLibraryVersion()
     );
   });
 
@@ -58,19 +58,19 @@ describe('instrumentation_info', () => {
     const entry = instrumentation.createDiagnosticEntry(
       undefined,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      data as any,
+      data as any
     ) as Entry;
     assert.equal(
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      instrumentation.NODEJS_DEFAULT_LIBRARY_VERSION,
+      instrumentation.NODEJS_DEFAULT_LIBRARY_VERSION
     );
   });
 
@@ -84,7 +84,7 @@ describe('instrumentation_info', () => {
       entries[0][1].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
   });
 
@@ -97,25 +97,25 @@ describe('instrumentation_info', () => {
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.length,
-      2,
+      2
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      NODEJS_TEST,
+      NODEJS_TEST
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      VERSION_TEST,
+      VERSION_TEST
     );
   });
 
@@ -128,19 +128,19 @@ describe('instrumentation_info', () => {
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.length,
-      1,
+      1
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
   });
 
   it('should truncate instrumentation info in log entry', () => {
     const entries = instrumentation.populateInstrumentationInfo(
-      createEntry(LONG_NODEJS_TEST, LONG_VERSION_TEST),
+      createEntry(LONG_NODEJS_TEST, LONG_VERSION_TEST)
     );
     assert.equal(entries[0].length, 1);
     assert.equal(true, entries[1]);
@@ -148,13 +148,13 @@ describe('instrumentation_info', () => {
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      NODEJS_TEST + '-oo*',
+      NODEJS_TEST + '-oo*'
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      VERSION_TEST + '.0.0.0.0.*',
+      VERSION_TEST + '.0.0.0.0.*'
     );
   });
 
@@ -168,7 +168,7 @@ describe('instrumentation_info', () => {
       entries[0][1].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries[0].length, 1);
@@ -180,7 +180,7 @@ describe('instrumentation_info', () => {
     // library version is always added as a third one
     const dummy = createEntry(
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-one',
-      'v1',
+      'v1'
     );
     dummy.data?.[instrumentation.DIAGNOSTIC_INFO_KEY][
       instrumentation.INSTRUMENTATION_SOURCE_KEY
@@ -206,26 +206,26 @@ describe('instrumentation_info', () => {
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.length,
-      3,
+      3
     );
     assert.equal(true, entries[1]);
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-one',
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-one'
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-two',
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-two'
     );
     assert.equal(
       entries[0][0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[2]?.[NAME],
-      instrumentation.NODEJS_LIBRARY_NAME_PREFIX,
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
   });
 });
@@ -235,7 +235,7 @@ function createEntry(name: string | undefined, version: string | undefined) {
     {
       severity: google.logging.type.LogSeverity.DEBUG,
     },
-    undefined,
+    undefined
   );
   if (name || version) {
     entry.data = {

--- a/handwritten/logging/test/log-sync.ts
+++ b/handwritten/logging/test/log-sync.ts
@@ -61,7 +61,7 @@ describe('LogSync', () => {
       const log = new LogSync(LOGGING, LOG_NAME);
       assert.strictEqual(
         log.formattedName_,
-        logCommon.formatLogName('{{project-id}}', LOG_NAME),
+        logCommon.formatLogName('{{project-id}}', LOG_NAME)
       );
     });
 
@@ -122,7 +122,7 @@ describe('LogSync', () => {
         const result = JSON.parse(fs.readFileSync(TEST_FILE, 'utf8'));
         assert.strictEqual(
           result.logName,
-          'projects/{{project-id}}/logs/escaping%2Frequired%2Ffor%2Fthis%2Flog-name',
+          'projects/{{project-id}}/logs/escaping%2Frequired%2Ffor%2Fthis%2Flog-name'
         );
         done();
       });

--- a/handwritten/logging/test/log.ts
+++ b/handwritten/logging/test/log.ts
@@ -123,8 +123,8 @@ describe('Log', () => {
       assert(
         callbackifyFake.callbackifyAll.calledWithExactly(
           Log,
-          sinon.match({exclude: ['entry', 'getEntriesStream']}),
-        ),
+          sinon.match({exclude: ['entry', 'getEntriesStream']})
+        )
       );
     });
 
@@ -140,7 +140,7 @@ describe('Log', () => {
       const log = new Log(LOGGING, LOG_NAME);
       assert.strictEqual(
         log.formattedName_,
-        logCommon.formatLogName('{{project-id}}', LOG_NAME),
+        logCommon.formatLogName('{{project-id}}', LOG_NAME)
       );
     });
 
@@ -172,8 +172,8 @@ describe('Log', () => {
             logName: log.formattedName_,
           },
           undefined,
-          undefined,
-        ),
+          undefined
+        )
       );
     });
 
@@ -186,8 +186,8 @@ describe('Log', () => {
             logName: log.formattedName_,
           },
           undefined,
-          log.defaultWriteDeleteCallback,
-        ),
+          log.defaultWriteDeleteCallback
+        )
       );
       log.defaultWriteDeleteCallback = undefined;
     });
@@ -195,7 +195,7 @@ describe('Log', () => {
     it('should accept gaxOptions', async () => {
       await log.delete({});
       assert(
-        log.logging.loggingService.deleteLog.calledWith(sinon.match.any, {}),
+        log.logging.loggingService.deleteLog.calledWith(sinon.match.any, {})
       );
     });
   });
@@ -235,7 +235,7 @@ describe('Log', () => {
       assert(
         log.logging.getEntries.calledWithExactly({
           filter: `logName="${LOG_NAME_FORMATTED}"`,
-        }),
+        })
       );
     });
 
@@ -273,7 +273,7 @@ describe('Log', () => {
       assert(
         log.logging.getEntriesStream.calledWithExactly({
           log: LOG_NAME_ENCODED,
-        }),
+        })
       );
     });
 
@@ -292,9 +292,9 @@ describe('Log', () => {
             {
               log: LOG_NAME_ENCODED,
             },
-            options,
-          ),
-        ),
+            options
+          )
+        )
       );
     });
   });
@@ -312,7 +312,7 @@ describe('Log', () => {
       assert(
         log.logging.tailEntries.calledWithExactly({
           log: LOG_NAME_ENCODED,
-        }),
+        })
       );
     });
 
@@ -331,9 +331,9 @@ describe('Log', () => {
             {
               log: LOG_NAME_ENCODED,
             },
-            options,
-          ),
-        ),
+            options
+          )
+        )
       );
     });
   });
@@ -388,8 +388,8 @@ describe('Log', () => {
             },
           },
           undefined,
-          undefined,
-        ),
+          undefined
+        )
       );
     });
 
@@ -424,8 +424,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             resource: reusableDetectedResource,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -454,8 +454,8 @@ describe('Log', () => {
             resource: EXPECTED_RESOURCE,
           },
           undefined,
-          undefined,
-        ),
+          undefined
+        )
       );
     });
 
@@ -470,8 +470,8 @@ describe('Log', () => {
             resource: FAKE_RESOURCE,
           },
           undefined,
-          undefined,
-        ),
+          undefined
+        )
       );
     });
 
@@ -487,8 +487,8 @@ describe('Log', () => {
             resource: FAKE_RESOURCE,
           },
           undefined,
-          log.defaultWriteDeleteCallback,
-        ),
+          log.defaultWriteDeleteCallback
+        )
       );
       log.defaultWriteDeleteCallback = undefined;
     });
@@ -503,8 +503,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: 'decorated entries',
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -517,8 +517,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: arrifiedEntries,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -530,8 +530,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: ENTRIES,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -541,8 +541,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             partialSuccess: true,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -553,8 +553,8 @@ describe('Log', () => {
           sinon.match({
             dryRun: true,
             partialSuccess: false,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -567,8 +567,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             partialSuccess: true,
-          }),
-        ),
+          })
+        )
       );
       instrumentation.setInstrumentationStatus(true);
     });
@@ -582,8 +582,8 @@ describe('Log', () => {
         log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             partialSuccess: true,
-          }),
-        ),
+          })
+        )
       );
     });
 
@@ -597,8 +597,8 @@ describe('Log', () => {
           {
             maxRetries: 1,
           },
-          sinon.match.any,
-        ),
+          sinon.match.any
+        )
       );
       log.logging.loggingService.writeLogEntries.reset();
       await log.write(ENTRIES, {gaxOptions: {maxRetries: 10}});
@@ -608,8 +608,8 @@ describe('Log', () => {
           {
             maxRetries: 10,
           },
-          sinon.match.any,
-        ),
+          sinon.match.any
+        )
       );
     });
   });
@@ -656,7 +656,7 @@ describe('Log', () => {
         .returns({} as EntryJson);
       log.decorateEntries([entry]);
       assert(
-        localJSONStub.calledWithExactly({removeCircular: true}, PROJECT_ID),
+        localJSONStub.calledWithExactly({removeCircular: true}, PROJECT_ID)
       );
     });
 
@@ -749,11 +749,11 @@ describe('Log', () => {
       assert.ok(log.jsonFieldsToTruncate.length > 1);
       assert.ok(log.jsonFieldsToTruncate[0] === TRUNCATE_FIELD);
       const notExists = log.jsonFieldsToTruncate.filter(
-        (str: string) => str === INVALID_TRUNCATE_FIELD,
+        (str: string) => str === INVALID_TRUNCATE_FIELD
       );
       assert.strictEqual(notExists.length, 0);
       const existOnce = log.jsonFieldsToTruncate.filter(
-        (str: string) => str === TRUNCATE_FIELD,
+        (str: string) => str === TRUNCATE_FIELD
       );
       assert.strictEqual(existOnce.length, 1);
     });

--- a/handwritten/logging/test/middleware/express/test-make-middleware.ts
+++ b/handwritten/logging/test/middleware/express/test-make-middleware.ts
@@ -45,7 +45,7 @@ describe('middleware/express/make-middleware', () => {
       '../../../src/middleware/express/make-middleware',
       {
         '../../../src/utils/context': FAKE_CONTEXT,
-      },
+      }
     );
 
     it('should return a function accepting 3 arguments', () => {
@@ -133,7 +133,7 @@ describe('middleware/express/make-middleware', () => {
         const middleware = makeMiddleware(
           FAKE_PROJECT_ID,
           () => {},
-          emitRequestLog,
+          emitRequestLog
         );
         middleware(fakeRequest, fakeResponse, () => {});
 

--- a/handwritten/logging/test/sink.ts
+++ b/handwritten/logging/test/sink.ts
@@ -75,7 +75,7 @@ describe('Sink', () => {
     it('should localize the formatted name', () => {
       assert.strictEqual(
         sink.formattedName_,
-        'projects/' + LOGGING.projectId + '/sinks/' + SINK_NAME,
+        'projects/' + LOGGING.projectId + '/sinks/' + SINK_NAME
       );
     });
   });
@@ -98,7 +98,7 @@ describe('Sink', () => {
       sink.logging.auth.getProjectId = async () => PROJECT_ID;
       sink.logging.configService.deleteSink = async (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           sinkName: sink.formattedName_,
@@ -113,7 +113,7 @@ describe('Sink', () => {
       const gaxOptions = {};
       sink.logging.configService.deleteSink = async (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(gaxOpts, gaxOptions);
       };
@@ -203,7 +203,7 @@ describe('Sink', () => {
       };
       sink.setMetadata(METADATA).then(
         () => {},
-        err => assert.strictEqual(err, error),
+        err => assert.strictEqual(err, error)
       );
     });
 
@@ -213,7 +213,7 @@ describe('Sink', () => {
       sink.getMetadata = async () => [currentMetadata] as any;
       sink.logging.configService.updateSink = async (
         reqOpts: {},
-        gaxOpts: {},
+        gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
           sinkName: sink.formattedName_,

--- a/handwritten/logging/test/utils/common.ts
+++ b/handwritten/logging/test/utils/common.ts
@@ -142,7 +142,7 @@ describe('ObjectToStructConverter', () => {
 
       assert.strictEqual(
         objectToStructConverter.encodeValue_(buffer).blobValue.toString(),
-        'Value',
+        'Value'
       );
     });
 
@@ -210,7 +210,7 @@ describe('ObjectToStructConverter', () => {
           it('should replace circular reference with [Circular]', () => {
             assert.deepStrictEqual(
               objectToStructConverter.encodeValue_(VALUE),
-              {stringValue: '[Circular]'},
+              {stringValue: '[Circular]'}
             );
           });
         });

--- a/handwritten/logging/test/utils/context.ts
+++ b/handwritten/logging/test/utils/context.ts
@@ -134,7 +134,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -154,7 +154,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -179,7 +179,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -201,7 +201,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -221,7 +221,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -300,17 +300,17 @@ describe('context', () => {
             assert.strictEqual(
               context.trace,
               test.expected.trace,
-              `From ${test.header}; Expected trace: ${test.expected.trace}; Got: ${context.trace}`,
+              `From ${test.header}; Expected trace: ${test.expected.trace}; Got: ${context.trace}`
             );
             assert.strictEqual(
               context.spanId,
               test.expected.spanId,
-              `From ${test.header}; Expected spanId: ${test.expected.spanId}; Got: ${context.spanId}`,
+              `From ${test.header}; Expected spanId: ${test.expected.spanId}; Got: ${context.spanId}`
             );
             assert.strictEqual(
               context.traceSampled,
               test.expected.traceSampled,
-              `From ${test.header}; Expected traceSampled: ${test.expected.traceSampled}; Got: ${context.traceSampled}`,
+              `From ${test.header}; Expected traceSampled: ${test.expected.traceSampled}; Got: ${context.traceSampled}`
             );
           } else {
             assert.fail();
@@ -349,7 +349,7 @@ describe('context', () => {
               (parentSpan.spanContext().traceFlags & 1) !== 0;
             assert.strictEqual(
               context.trace,
-              `projects/${projectId}/traces/${traceId}`,
+              `projects/${projectId}/traces/${traceId}`
             );
             assert.strictEqual(context.spanId, spanId);
             assert.strictEqual(context.traceSampled, traceSampled);
@@ -401,17 +401,17 @@ describe('context', () => {
             assert.strictEqual(
               context.trace,
               test.expected.trace,
-              `From ${test.header}; Expected trace: ${test.expected.trace}; Got: ${context.trace}`,
+              `From ${test.header}; Expected trace: ${test.expected.trace}; Got: ${context.trace}`
             );
             assert.strictEqual(
               context.spanId,
               test.expected.spanId,
-              `From ${test.header}; Expected spanId: ${test.expected.spanId}; Got: ${context.spanId}`,
+              `From ${test.header}; Expected spanId: ${test.expected.spanId}; Got: ${context.spanId}`
             );
             assert.strictEqual(
               context.traceSampled,
               test.expected.traceSampled,
-              `From ${test.header}; Expected traceSampled: ${test.expected.traceSampled}; Got: ${context.traceSampled}`,
+              `From ${test.header}; Expected traceSampled: ${test.expected.traceSampled}; Got: ${context.traceSampled}`
             );
           } else {
             // This is the header: '' test case;

--- a/handwritten/logging/test/utils/http-request.ts
+++ b/handwritten/logging/test/utils/http-request.ts
@@ -105,14 +105,14 @@ describe('http-request', () => {
       const h1 = makeHttpRequestData(
         fakeRequest as ServerRequest,
         fakeResponse as ServerResponse,
-        1003,
+        1003
       );
       assert.deepStrictEqual(h1.latency, {seconds: 1, nanos: 3e6});
 
       const h2 = makeHttpRequestData(
         fakeRequest as ServerRequest,
         fakeResponse as ServerResponse,
-        9003.1,
+        9003.1
       );
       assert.deepStrictEqual(h2.latency, {seconds: 9, nanos: 3.1e6});
 
@@ -120,7 +120,7 @@ describe('http-request', () => {
       const h3 = makeHttpRequestData(
         fakeRequest as ServerRequest,
         fakeResponse as ServerResponse,
-        1.0000000001,
+        1.0000000001
       );
       assert.deepStrictEqual(h3.latency, {seconds: 0, nanos: 1e6});
     });
@@ -135,7 +135,7 @@ describe('http-request', () => {
 
     it('should be false on invalid objects', () => {
       assert(
-        !isRawHttpRequest({requestMethod: 'POST'} as CloudLoggingHttpRequest),
+        !isRawHttpRequest({requestMethod: 'POST'} as CloudLoggingHttpRequest)
       );
       assert(!isRawHttpRequest({}));
       assert(!isRawHttpRequest(null));

--- a/handwritten/logging/test/utils/log-common.ts
+++ b/handwritten/logging/test/utils/log-common.ts
@@ -40,7 +40,7 @@ describe('Log Common', () => {
         assignSeverityToEntries(ENTRIES[0], SEVERITY)
           .map(x => x.metadata)
           .map(x => x.severity),
-        [SEVERITY],
+        [SEVERITY]
       );
     });
 
@@ -49,7 +49,7 @@ describe('Log Common', () => {
         assignSeverityToEntries(ENTRIES, SEVERITY)
           .map(x => x.metadata)
           .map(x => x.severity),
-        [SEVERITY, SEVERITY, SEVERITY],
+        [SEVERITY, SEVERITY, SEVERITY]
       );
     });
 

--- a/handwritten/logging/test/utils/metadata.ts
+++ b/handwritten/logging/test/utils/metadata.ts
@@ -298,7 +298,7 @@ describe('metadata', () => {
       };
       await assert.rejects(
         metadata.getGKEDescriptor(),
-        (err: Error) => err === FAKE_ERROR,
+        (err: Error) => err === FAKE_ERROR
       );
     });
 
@@ -306,7 +306,7 @@ describe('metadata', () => {
       readFileShouldError = true;
 
       await assert.doesNotReject(metadata.getGKEDescriptor(), (err: Error) =>
-        err.message.includes(FAKE_READFILE_ERROR_MESSAGE),
+        err.message.includes(FAKE_READFILE_ERROR_MESSAGE)
       );
     });
   });

--- a/handwritten/pubsub/src/lease-manager.ts
+++ b/handwritten/pubsub/src/lease-manager.ts
@@ -28,10 +28,16 @@ import {logs as baseLogs, LoggingFunction} from './logs';
  * @private
  */
 export const logs = {
-  callbackDelivery: baseLogs.pubsub.sublog('callback-delivery') as LoggingFunction,
-  callbackExceptions: baseLogs.pubsub.sublog('callback-exceptions') as LoggingFunction,
+  callbackDelivery: baseLogs.pubsub.sublog(
+    'callback-delivery',
+  ) as LoggingFunction,
+  callbackExceptions: baseLogs.pubsub.sublog(
+    'callback-exceptions',
+  ) as LoggingFunction,
   expiry: baseLogs.pubsub.sublog('expiry') as LoggingFunction,
-  subscriberFlowControl: baseLogs.pubsub.sublog('subscriber-flow-control') as LoggingFunction,
+  subscriberFlowControl: baseLogs.pubsub.sublog(
+    'subscriber-flow-control',
+  ) as LoggingFunction,
 };
 
 export interface FlowControlOptions {

--- a/handwritten/pubsub/src/message-stream.ts
+++ b/handwritten/pubsub/src/message-stream.ts
@@ -34,7 +34,9 @@ import {logs as baseLogs, LoggingFunction} from './logs';
  * @private
  */
 export const logs = {
-  subscriberStreams: baseLogs.pubsub.sublog('subscriber-streams') as LoggingFunction,
+  subscriberStreams: baseLogs.pubsub.sublog(
+    'subscriber-streams',
+  ) as LoggingFunction,
 };
 
 /*!

--- a/handwritten/pubsub/system-test/pubsub.ts
+++ b/handwritten/pubsub/system-test/pubsub.ts
@@ -61,7 +61,11 @@ describe('pubsub', () => {
     return {name, topic, fullName};
   }
 
-  async function generateSub(test: string, topicName: string, opts: SubscriptionOptions = {}): Promise<UsedSub> {
+  async function generateSub(
+    test: string,
+    topicName: string,
+    opts: SubscriptionOptions = {},
+  ): Promise<UsedSub> {
     const name = resources.generateName(test);
     const sub = pubsub.topic(topicName).subscription(name, opts);
     await sub.create();
@@ -97,22 +101,18 @@ describe('pubsub', () => {
       schemas.push(pubsub.schema(s.name!));
     }
     await Promise.all(
-      resources.filterForCleanup(schemas).map(x => x.delete?.())
+      resources.filterForCleanup(schemas).map(x => x.delete?.()),
     );
 
     // Snapshots.
-    await Promise.all(
-      resources.filterForCleanup(snaps).map(x => x.delete?.())
-    )
+    await Promise.all(resources.filterForCleanup(snaps).map(x => x.delete?.()));
 
     // Subscriptions next.
-    await Promise.all(
-      resources.filterForCleanup(subs).map(x => x.delete?.())
-    );
+    await Promise.all(resources.filterForCleanup(subs).map(x => x.delete?.()));
 
     // Finally topics.
     await Promise.all(
-      resources.filterForCleanup(topics).map(x => x.delete?.())
+      resources.filterForCleanup(topics).map(x => x.delete?.()),
     );
   }
 
@@ -212,7 +212,7 @@ describe('pubsub', () => {
           assert.ifError(err);
           assert.strictEqual(exists, false);
           done();
-        }
+        },
       );
     });
 
@@ -283,7 +283,7 @@ describe('pubsub', () => {
           generateSubName('ordered'),
           {
             enableMessageOrdering: true,
-          }
+          },
         );
         const {
           input,
@@ -313,9 +313,9 @@ describe('pubsub', () => {
                   `Unknown key "${key}" for test data: ${JSON.stringify(
                     pending,
                     null,
-                    4
-                  )}`
-                )
+                    4,
+                  )}`,
+                ),
               );
               subscription.close();
               return;
@@ -326,8 +326,8 @@ describe('pubsub', () => {
             if (key && data !== expected) {
               deferred.reject(
                 new Error(
-                  `Expected "${expected}" but received "${data}" for key "${key}"`
-                )
+                  `Expected "${expected}" but received "${data}" for key "${key}"`,
+                ),
               );
               subscription.close();
               return;
@@ -367,10 +367,12 @@ describe('pubsub', () => {
 
       const testSubProms: Promise<UsedSub>[] = [];
       for (let i = 0; i < count; i++) {
-        testSubProms.push(generateSub(testName, testTopic.name, {
-          minAckDeadline: Duration.from({seconds: 60}),
-          maxAckDeadline: Duration.from({seconds: 60}),
-        }));
+        testSubProms.push(
+          generateSub(testName, testTopic.name, {
+            minAckDeadline: Duration.from({seconds: 60}),
+            maxAckDeadline: Duration.from({seconds: 60}),
+          }),
+        );
       }
       const testSubs = await Promise.all(testSubProms);
       const subs = testSubs.map(t => t.sub);
@@ -504,21 +506,23 @@ describe('pubsub', () => {
       };
 
       const testTopic = await generateTopic('msg-ret');
-      const [sub] = await testTopic.topic.createSubscription(subName, callOptions);
+      const [sub] = await testTopic.topic.createSubscription(
+        subName,
+        callOptions,
+      );
       const [metadata] = await sub.getMetadata();
       assert.strictEqual(
         Number(metadata!.messageRetentionDuration!.seconds),
-        threeDaysInSeconds
+        threeDaysInSeconds,
       );
-      assert.strictEqual(
-        Number(metadata!.messageRetentionDuration!.nanos),
-        0
-      );
+      assert.strictEqual(Number(metadata!.messageRetentionDuration!.nanos), 0);
     });
 
     it('should set metadata for a subscription', async () => {
       const testTopic = await generateTopic('met-sub');
-      const subscription = testTopic.topic.subscription(generateSubName('met-sub'));
+      const subscription = testTopic.topic.subscription(
+        generateSubName('met-sub'),
+      );
       const threeDaysInSeconds = 3 * 24 * 60 * 60;
 
       await subscription.create();
@@ -534,7 +538,9 @@ describe('pubsub', () => {
 
     it('should error when using a non-existent subscription', async () => {
       const testTopic = await generateTopic('dne-sub');
-      const subscription = testTopic.topic.subscription(generateSubName('dne-sub'));
+      const subscription = testTopic.topic.subscription(
+        generateSubName('dne-sub'),
+      );
 
       await new Promise((res, rej) => {
         subscription.on('error', (err: {code: number}) => {
@@ -771,7 +777,7 @@ describe('pubsub', () => {
 
       const [newPolicy] = await topic.iam.setPolicy(policy);
       const expectedBindings = policy.bindings.map(binding =>
-        Object.assign({condition: null}, binding)
+        Object.assign({condition: null}, binding),
       );
       assert.deepStrictEqual(newPolicy!.bindings, expectedBindings);
     });
@@ -792,7 +798,8 @@ describe('pubsub', () => {
   describe('Snapshot', () => {
     async function snapshotPop(test: string) {
       const topic: Topic = (await generateTopic('snap')).topic;
-      const subscription: Subscription = (await generateSub('snap', topic.name)).sub;
+      const subscription: Subscription = (await generateSub('snap', topic.name))
+        .sub;
       const snapshotId: string = generateSnapshotName('snap');
       const snapshot: Snapshot = subscription.snapshot(snapshotId);
 
@@ -805,7 +812,6 @@ describe('pubsub', () => {
         snapshot,
       };
     }
-
 
     function getSnapshotName({name}: {name: string}) {
       return name.split('/').pop();
@@ -848,7 +854,7 @@ describe('pubsub', () => {
       async function seekPop(test: string) {
         const pop = await snapshotPop(test);
         const errorPromise = new Promise((_, reject) =>
-          pop.subscription.on('error', reject)
+          pop.subscription.on('error', reject),
         );
 
         return {
@@ -860,7 +866,10 @@ describe('pubsub', () => {
       // This creates a Promise that hooks the 'message' callback of the
       // subscription above, and resolves when that callback calls `resolve`.
       type WorkCallback = (arg: Message, resolve: Function) => void;
-      function makeMessagePromise(subscription: Subscription, workCallback: WorkCallback): Promise<void> {
+      function makeMessagePromise(
+        subscription: Subscription,
+        workCallback: WorkCallback,
+      ): Promise<void> {
         return new Promise(resolve => {
           subscription.on('message', (arg: Message) => {
             workCallback(arg, resolve);
@@ -895,7 +904,7 @@ describe('pubsub', () => {
             await pop.subscription.close();
 
             resolve();
-          }
+          },
         );
 
         messageId = await publishTestMessage(pop.topic);
@@ -923,7 +932,7 @@ describe('pubsub', () => {
                 message.publishTime,
                 (err: ServiceError | null) => {
                   assert.ifError(err);
-                }
+                },
               );
               return;
             }
@@ -932,7 +941,7 @@ describe('pubsub', () => {
             await pop.subscription.close();
 
             resolve();
-          }
+          },
         );
 
         messageId = await publishTestMessage(pop.topic);
@@ -964,7 +973,7 @@ describe('pubsub', () => {
             await pop.subscription.close();
 
             resolve();
-          }
+          },
         );
 
         await Promise.race([pop.errorPromise, messagePromise]);
@@ -976,7 +985,7 @@ describe('pubsub', () => {
     // This should really be handled by a standard method of Array(), imo, but it's not.
     async function aiToArray(
       iterator: AsyncIterable<ISchema>,
-      nameFilter?: string
+      nameFilter?: string,
     ): Promise<ISchema[]> {
       const result = [] as ISchema[];
       for await (const i of iterator) {
@@ -1028,14 +1037,14 @@ describe('pubsub', () => {
 
       const basicList = await aiToArray(
         pubsub.listSchemas(SchemaViews.Basic),
-        schemaId
+        schemaId,
       );
       assert.strictEqual(basicList.length, 1);
       assert.strictEqual(basicList[0].definition, '');
 
       const fullList = await aiToArray(
         pubsub.listSchemas(SchemaViews.Full),
-        schemaId
+        schemaId,
       );
       assert.strictEqual(fullList.length, 1);
       assert.ok(fullList[0].definition);

--- a/handwritten/storage/conformance-test/conformanceCommon.ts
+++ b/handwritten/storage/conformance-test/conformanceCommon.ts
@@ -50,7 +50,7 @@ interface ConformanceTestResult {
 
 type LibraryMethodsModuleType = typeof import('./libraryMethods');
 const methodMap: Map<String, String[]> = new Map(
-  Object.entries(jsonToNodeApiMapping)
+  Object.entries(jsonToNodeApiMapping),
 );
 
 const DURATION_SECONDS = 600; // 10 mins.
@@ -94,36 +94,36 @@ export function executeScenario(testCase: RetryTestCase) {
             });
             creationResult = await createTestBenchRetryTest(
               instructionSet.instructions,
-              jsonMethod?.name.toString()
+              jsonMethod?.name.toString(),
             );
             if (storageMethodString.includes('InstancePrecondition')) {
               bucket = await createBucketForTest(
                 storage,
                 testCase.preconditionProvided,
-                storageMethodString
+                storageMethodString,
               );
               file = await createFileForTest(
                 testCase.preconditionProvided,
                 storageMethodString,
-                bucket
+                bucket,
               );
             } else {
               bucket = await createBucketForTest(
                 storage,
                 false,
-                storageMethodString
+                storageMethodString,
               );
               file = await createFileForTest(
                 false,
                 storageMethodString,
-                bucket
+                bucket,
               );
             }
             notification = bucket.notification(`${TESTS_PREFIX}`);
             await notification.create();
 
             [hmacKey] = await storage.createHmacKey(
-              `${TESTS_PREFIX}@email.com`
+              `${TESTS_PREFIX}@email.com`,
             );
 
             storage.interceptors.push({
@@ -154,7 +154,7 @@ export function executeScenario(testCase: RetryTestCase) {
               await assert.rejects(storageMethodObject(methodParameters));
             }
             const testBenchResult = await getTestBenchRetryTest(
-              creationResult.id
+              creationResult.id,
             );
             assert.strictEqual(testBenchResult.completed, true);
           }).timeout(TIMEOUT_FOR_INDIVIDUAL_TEST);
@@ -167,7 +167,7 @@ export function executeScenario(testCase: RetryTestCase) {
 async function createBucketForTest(
   storage: Storage,
   preconditionShouldBeOnInstance: boolean,
-  storageMethodString: String
+  storageMethodString: String,
 ) {
   const name = generateName(storageMethodString, 'bucket');
   const bucket = storage.bucket(name);
@@ -187,7 +187,7 @@ async function createBucketForTest(
 async function createFileForTest(
   preconditionShouldBeOnInstance: boolean,
   storageMethodString: String,
-  bucket: Bucket
+  bucket: Bucket,
 ) {
   const name = generateName(storageMethodString, 'file');
   const file = bucket.file(name);
@@ -209,7 +209,7 @@ function generateName(storageMethodString: String, bucketOrFile: string) {
 
 async function createTestBenchRetryTest(
   instructions: String[],
-  methodName: string
+  methodName: string,
 ): Promise<ConformanceTestCreationResult> {
   const requestBody = {instructions: {[methodName]: instructions}};
   const response = await fetch(`${TESTBENCH_HOST}retry_test`, {
@@ -221,7 +221,7 @@ async function createTestBenchRetryTest(
 }
 
 async function getTestBenchRetryTest(
-  testId: string
+  testId: string,
 ): Promise<ConformanceTestResult> {
   const response = await fetch(`${TESTBENCH_HOST}retry_test/${testId}`, {
     method: 'GET',

--- a/handwritten/storage/conformance-test/globalHooks.ts
+++ b/handwritten/storage/conformance-test/globalHooks.ts
@@ -29,7 +29,7 @@ export async function mochaGlobalSetup(this: any) {
   await getTestBenchDockerImage();
   await runTestBenchDockerImage();
   await new Promise(resolve =>
-    setTimeout(resolve, TIME_TO_WAIT_FOR_CONTAINER_READY)
+    setTimeout(resolve, TIME_TO_WAIT_FOR_CONTAINER_READY),
   );
 }
 

--- a/handwritten/storage/conformance-test/libraryMethods.ts
+++ b/handwritten/storage/conformance-test/libraryMethods.ts
@@ -40,7 +40,7 @@ export interface ConformanceTestOptions {
 /////////////////////////////////////////////////
 
 export async function addLifecycleRuleInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.addLifecycleRule({
     action: {
@@ -65,7 +65,7 @@ export async function addLifecycleRule(options: ConformanceTestOptions) {
       },
       {
         ifMetagenerationMatch: 2,
-      }
+      },
     );
   } else {
     await options.bucket!.addLifecycleRule({
@@ -80,7 +80,7 @@ export async function addLifecycleRule(options: ConformanceTestOptions) {
 }
 
 export async function combineInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const file1 = options.bucket!.file('file1.txt');
   const file2 = options.bucket!.file('file2.txt');
@@ -142,7 +142,7 @@ export async function deleteBucket(options: ConformanceTestOptions) {
 // Preconditions cannot be implemented with current setup.
 
 export async function deleteLabelsInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.deleteLabels();
 }
@@ -158,7 +158,7 @@ export async function deleteLabels(options: ConformanceTestOptions) {
 }
 
 export async function disableRequesterPaysInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.disableRequesterPays();
 }
@@ -174,7 +174,7 @@ export async function disableRequesterPays(options: ConformanceTestOptions) {
 }
 
 export async function enableLoggingInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const config = {
     prefix: 'log',
@@ -198,7 +198,7 @@ export async function enableLogging(options: ConformanceTestOptions) {
 }
 
 export async function enableRequesterPaysInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.enableRequesterPays();
 }
@@ -249,7 +249,7 @@ export async function lock(options: ConformanceTestOptions) {
 }
 
 export async function bucketMakePrivateInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.makePrivate();
 }
@@ -269,7 +269,7 @@ export async function bucketMakePublic(options: ConformanceTestOptions) {
 }
 
 export async function removeRetentionPeriodInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.removeRetentionPeriod();
 }
@@ -285,7 +285,7 @@ export async function removeRetentionPeriod(options: ConformanceTestOptions) {
 }
 
 export async function setCorsConfigurationInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const corsConfiguration = [{maxAgeSeconds: 3600}]; // 1 hour
   await options.bucket!.setCorsConfiguration(corsConfiguration);
@@ -303,7 +303,7 @@ export async function setCorsConfiguration(options: ConformanceTestOptions) {
 }
 
 export async function setLabelsInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const labels = {
     labelone: 'labelonevalue',
@@ -327,7 +327,7 @@ export async function setLabels(options: ConformanceTestOptions) {
 }
 
 export async function bucketSetMetadataInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const metadata = {
     website: {
@@ -355,7 +355,7 @@ export async function bucketSetMetadata(options: ConformanceTestOptions) {
 }
 
 export async function setRetentionPeriodInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const DURATION_SECONDS = 15780000; // 6 months.
   await options.bucket!.setRetentionPeriod(DURATION_SECONDS);
@@ -373,7 +373,7 @@ export async function setRetentionPeriod(options: ConformanceTestOptions) {
 }
 
 export async function bucketSetStorageClassInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.bucket!.setStorageClass('nearline');
 }
@@ -389,11 +389,11 @@ export async function bucketSetStorageClass(options: ConformanceTestOptions) {
 }
 
 export async function bucketUploadResumableInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const filePath = path.join(
     getDirName(),
-    `../conformance-test/test-data/tmp-${crypto.randomUUID()}.txt`
+    `../conformance-test/test-data/tmp-${crypto.randomUUID()}.txt`,
   );
   createTestFileFromBuffer(FILE_SIZE_BYTES, filePath);
   if (options.bucket!.instancePreconditionOpts) {
@@ -411,7 +411,7 @@ export async function bucketUploadResumableInstancePrecondition(
 export async function bucketUploadResumable(options: ConformanceTestOptions) {
   const filePath = path.join(
     getDirName(),
-    `../conformance-test/test-data/tmp-${crypto.randomUUID()}.txt`
+    `../conformance-test/test-data/tmp-${crypto.randomUUID()}.txt`,
   );
   createTestFileFromBuffer(FILE_SIZE_BYTES, filePath);
   if (options.preconditionRequired) {
@@ -432,7 +432,7 @@ export async function bucketUploadResumable(options: ConformanceTestOptions) {
 }
 
 export async function bucketUploadMultipartInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   if (options.bucket!.instancePreconditionOpts) {
     delete options.bucket!.instancePreconditionOpts.ifMetagenerationMatch;
@@ -441,9 +441,9 @@ export async function bucketUploadMultipartInstancePrecondition(
   await options.bucket!.upload(
     path.join(
       getDirName(),
-      '../../../conformance-test/test-data/retryStrategyTestData.json'
+      '../../../conformance-test/test-data/retryStrategyTestData.json',
     ),
-    {resumable: false}
+    {resumable: false},
   );
 }
 
@@ -456,17 +456,17 @@ export async function bucketUploadMultipart(options: ConformanceTestOptions) {
     await options.bucket!.upload(
       path.join(
         getDirName(),
-        '../../../conformance-test/test-data/retryStrategyTestData.json'
+        '../../../conformance-test/test-data/retryStrategyTestData.json',
       ),
-      {resumable: false, preconditionOpts: {ifGenerationMatch: 0}}
+      {resumable: false, preconditionOpts: {ifGenerationMatch: 0}},
     );
   } else {
     await options.bucket!.upload(
       path.join(
         getDirName(),
-        '../../../conformance-test/test-data/retryStrategyTestData.json'
+        '../../../conformance-test/test-data/retryStrategyTestData.json',
       ),
-      {resumable: false}
+      {resumable: false},
     );
   }
 }
@@ -501,7 +501,7 @@ export async function createReadStream(options: ConformanceTestOptions) {
 }
 
 export async function createResumableUploadInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.file!.createResumableUpload();
 }
@@ -517,7 +517,7 @@ export async function createResumableUpload(options: ConformanceTestOptions) {
 }
 
 export async function fileDeleteInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.file!.delete();
 }
@@ -557,7 +557,7 @@ export async function isPublic(options: ConformanceTestOptions) {
 }
 
 export async function fileMakePrivateInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.file!.makePrivate();
 }
@@ -615,7 +615,7 @@ export async function rotateEncryptionKey(options: ConformanceTestOptions) {
 }
 
 export async function saveResumableInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const buf = createTestBuffer(FILE_SIZE_BYTES);
   await options.file!.save(buf, {
@@ -647,7 +647,7 @@ export async function saveResumable(options: ConformanceTestOptions) {
 }
 
 export async function saveMultipartInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   await options.file!.save('testdata', {resumable: false});
 }
@@ -668,7 +668,7 @@ export async function saveMultipart(options: ConformanceTestOptions) {
 }
 
 export async function setMetadataInstancePrecondition(
-  options: ConformanceTestOptions
+  options: ConformanceTestOptions,
 ) {
   const metadata = {
     contentType: 'application/x-font-ttf',

--- a/handwritten/storage/conformance-test/scenarios/scenarioFive.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioFive.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 5;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioFour.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioFour.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 4;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioOne.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioOne.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 1;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioSeven.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioSeven.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 7;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioSix.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioSix.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 6;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioThree.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioThree.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 3;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/scenarios/scenarioTwo.ts
+++ b/handwritten/storage/conformance-test/scenarios/scenarioTwo.ts
@@ -19,7 +19,7 @@ import assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 2;
 const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
-  test => test.id === SCENARIO_NUMBER_TO_TEST
+  test => test.id === SCENARIO_NUMBER_TO_TEST,
 );
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {

--- a/handwritten/storage/conformance-test/v4SignedUrl.ts
+++ b/handwritten/storage/conformance-test/v4SignedUrl.ts
@@ -93,9 +93,9 @@ interface BucketAction {
 const testFile = fs.readFileSync(
   path.join(
     getDirName(),
-    '../../../conformance-test/test-data/v4SignedUrl.json'
+    '../../../conformance-test/test-data/v4SignedUrl.json',
   ),
-  'utf-8'
+  'utf-8',
 );
 
 const testCases = JSON.parse(testFile);
@@ -105,7 +105,7 @@ const v4SignedPolicyCases: V4SignedPolicyTestCase[] =
 
 const SERVICE_ACCOUNT = path.join(
   getDirName(),
-  '../../../conformance-test/fixtures/signing-service-account.json'
+  '../../../conformance-test/fixtures/signing-service-account.json',
 );
 
 let storage: Storage;
@@ -143,7 +143,7 @@ describe('v4 conformance test', () => {
         const host = testCase.hostname
           ? new URL(
               (testCase.scheme ? testCase.scheme + '://' : '') +
-                testCase.hostname
+                testCase.hostname,
             )
           : undefined;
         const origin = testCase.bucketBoundHostname
@@ -151,7 +151,7 @@ describe('v4 conformance test', () => {
           : undefined;
         const {bucketBoundHostname, virtualHostedStyle} = parseUrlStyle(
           testCase.urlStyle,
-          origin
+          origin,
         );
         const extensionHeaders = testCase.headers;
         const queryParams = testCase.queryParameters;
@@ -204,7 +204,7 @@ describe('v4 conformance test', () => {
         // Order-insensitive comparison of query params
         assert.deepStrictEqual(
           querystring.parse(actual.search),
-          querystring.parse(expected.search)
+          querystring.parse(expected.search),
         );
       });
     });
@@ -247,7 +247,7 @@ describe('v4 conformance test', () => {
           : undefined;
         const {bucketBoundHostname, virtualHostedStyle} = parseUrlStyle(
           input.urlStyle,
-          origin
+          origin,
         );
         options.virtualHostedStyle = virtualHostedStyle;
         options.bucketBoundHostname = bucketBoundHostname;
@@ -260,11 +260,11 @@ describe('v4 conformance test', () => {
         assert.strictEqual(policy.url, testCase.policyOutput.url);
         const outputFields = testCase.policyOutput.fields;
         const decodedPolicy = JSON.parse(
-          Buffer.from(policy.fields.policy, 'base64').toString()
+          Buffer.from(policy.fields.policy, 'base64').toString(),
         );
         assert.deepStrictEqual(
           decodedPolicy,
-          JSON.parse(testCase.policyOutput.expectedDecodedPolicy)
+          JSON.parse(testCase.policyOutput.expectedDecodedPolicy),
         );
 
         assert.deepStrictEqual(policy.fields, outputFields);
@@ -275,7 +275,7 @@ describe('v4 conformance test', () => {
 
 function parseUrlStyle(
   style?: keyof typeof UrlStyle,
-  origin?: string
+  origin?: string,
 ): {bucketBoundHostname?: string; virtualHostedStyle?: boolean} {
   if (style === UrlStyle.BUCKET_BOUND_HOSTNAME) {
     return {bucketBoundHostname: origin};

--- a/handwritten/storage/src/bucket.ts
+++ b/handwritten/storage/src/bucket.ts
@@ -208,7 +208,7 @@ export class ComposeCleanupError extends Error {
     message: string,
     errors: Error[],
     newFile: File,
-    apiResponse: unknown
+    apiResponse: unknown,
   ) {
     super(message);
     this.name = 'ComposeCleanupError';
@@ -1599,9 +1599,9 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
    * metadata's `kms_key_name` value, if any.
    * @property {string} [userProject] The ID of the project which will be
    *     billed for the request.
-    * @property {boolean} [deleteSourceObjects] If true, the source objects
-    *     will be permanently deleted after a successful compose operation.
-    */
+   * @property {boolean} [deleteSourceObjects] If true, the source objects
+   *     will be permanently deleted after a successful compose operation.
+   */
   /**
    * @callback CombineCallback
    * @param {?Error} err Request error, if any.
@@ -1741,7 +1741,7 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
       Object.assign(
         requestQueryObject,
         destinationFile.instancePreconditionOpts,
-        requestQueryObject
+        requestQueryObject,
       );
     }
 
@@ -1799,7 +1799,7 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
 
           Promise.all(deletePromises).then(results => {
             const errors = results.filter(
-              (res): res is Error => res instanceof Error
+              (res): res is Error => res instanceof Error,
             );
 
             if (errors.length > 0) {
@@ -1807,7 +1807,7 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
                 `Compose operation succeeded, but cleaning up source objects failed. Failed to delete ${errors.length} source object(s).`,
                 errors,
                 destinationFile,
-                resp
+                resp,
               );
               callback!(cleanupErr, destinationFile, resp);
               return;
@@ -1818,7 +1818,7 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
         } else {
           callback!(null, destinationFile, resp);
         }
-      }
+      },
     );
   }
 

--- a/handwritten/storage/src/file.ts
+++ b/handwritten/storage/src/file.ts
@@ -2203,7 +2203,9 @@ class File extends ServiceObject<File, FileMetadata> {
           if (!callbackCalled) {
             callbackCalled = true;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const err = (fileWriteStream as any).errored || new Error('Write stream destroyed');
+            const err =
+              (fileWriteStream as any).errored ||
+              new Error('Write stream destroyed');
             pipelineCallback(err);
           }
         });

--- a/handwritten/storage/src/nodejs-common/util.ts
+++ b/handwritten/storage/src/nodejs-common/util.ts
@@ -982,11 +982,11 @@ export class Util {
         reqOpts.headers = headers;
       } else {
         const hasContentType = Object.keys(headers).some(
-          key => key.toLowerCase() === 'content-type'
+          key => key.toLowerCase() === 'content-type',
         );
         reqOpts.headers = hasContentType
           ? headers
-          : { ...headers, 'Content-Type': 'application/json' };
+          : {...headers, 'Content-Type': 'application/json'};
       }
     }
 

--- a/handwritten/storage/test/acl.ts
+++ b/handwritten/storage/test/acl.ts
@@ -149,7 +149,7 @@ describe('storage/acl', () => {
         (err: Error, acls: {}, apiResponse: unknown) => {
           assert.deepStrictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
   });
@@ -443,7 +443,7 @@ describe('storage/acl', () => {
         (err: Error, acls: Array<{}>, apiResponse: unknown) => {
           assert.deepStrictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
   });
@@ -594,7 +594,7 @@ describe('storage/AclRoleAccessorMethods', () => {
           entity: 'user-' + fakeUser,
           role: fakeRole,
         },
-        fakeOptions
+        fakeOptions,
       );
 
       aclEntity.add = (options: {}) => {

--- a/handwritten/storage/test/bucket.ts
+++ b/handwritten/storage/test/bucket.ts
@@ -366,7 +366,7 @@ describe('Bucket', () => {
       });
       assert.deepStrictEqual(
         bucket.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -386,7 +386,7 @@ describe('Bucket', () => {
       });
       assert.deepStrictEqual(
         bucket.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -406,7 +406,7 @@ describe('Bucket', () => {
       });
       assert.deepStrictEqual(
         bucket.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -426,7 +426,7 @@ describe('Bucket', () => {
       });
       assert.deepStrictEqual(
         bucket.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -709,7 +709,7 @@ describe('Bucket', () => {
       destination.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
-          mime.getType(destination.name)
+          mime.getType(destination.name),
         );
 
         done();
@@ -725,7 +725,7 @@ describe('Bucket', () => {
       destination.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
-          destination.metadata.contentType
+          destination.metadata.contentType,
         );
 
         done();
@@ -740,7 +740,7 @@ describe('Bucket', () => {
       destination.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
-          mime.getType(destination.name)
+          mime.getType(destination.name),
         );
 
         done();
@@ -831,19 +831,19 @@ describe('Bucket', () => {
       destination.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.ifGenerationMatch,
-          options.ifGenerationMatch
+          options.ifGenerationMatch,
         );
         assert.strictEqual(
           reqOpts.qs.ifGenerationNotMatch,
-          options.ifGenerationNotMatch
+          options.ifGenerationNotMatch,
         );
         assert.strictEqual(
           reqOpts.qs.ifMetagenerationMatch,
-          options.ifMetagenerationMatch
+          options.ifMetagenerationMatch,
         );
         assert.strictEqual(
           reqOpts.qs.ifMetagenerationNotMatch,
-          options.ifMetagenerationNotMatch
+          options.ifMetagenerationNotMatch,
         );
         done();
       };
@@ -857,7 +857,7 @@ describe('Bucket', () => {
 
       destination.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback();
       };
@@ -873,7 +873,7 @@ describe('Bucket', () => {
 
       destination.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error);
       };
@@ -891,7 +891,7 @@ describe('Bucket', () => {
 
       destination.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, resp);
       };
@@ -902,7 +902,7 @@ describe('Bucket', () => {
         (err: Error, obj: {}, apiResponse: {}) => {
           assert.strictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -912,7 +912,7 @@ describe('Bucket', () => {
 
       destination.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.maxRetries, 0);
         callback();
@@ -944,7 +944,10 @@ describe('Bucket', () => {
         return [{}];
       };
 
-      destination.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
+      destination.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function,
+      ) => {
         assert.strictEqual(reqOpts.qs.deleteSourceObjects, undefined);
         assert.strictEqual(reqOpts.json.deleteSourceObjects, undefined);
         assert.strictEqual(reqOpts.json.sourceObjects[0].generation, 12345);
@@ -959,7 +962,7 @@ describe('Bucket', () => {
           assert.ifError(err);
           assert.strictEqual(deletedCount, 2);
           done();
-        }
+        },
       );
     });
 
@@ -975,7 +978,10 @@ describe('Bucket', () => {
         };
       });
 
-      destination.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
+      destination.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function,
+      ) => {
         assert.strictEqual(reqOpts.json.deleteSourceObjects, undefined);
         callback(null, {});
       };
@@ -1000,16 +1006,24 @@ describe('Bucket', () => {
         };
       });
 
-      destination.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
+      destination.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function,
+      ) => {
         assert.strictEqual(reqOpts.json.deleteSourceObjects, undefined);
         callback(composeError);
       };
 
-      bucket.combine(sources, destination, {deleteSourceObjects: true}, (err: any) => {
-        assert.strictEqual(err, composeError);
-        assert.strictEqual(deletedCount, 0);
-        done();
-      });
+      bucket.combine(
+        sources,
+        destination,
+        {deleteSourceObjects: true},
+        (err: any) => {
+          assert.strictEqual(err, composeError);
+          assert.strictEqual(deletedCount, 0);
+          done();
+        },
+      );
     });
 
     it('should return ComposeCleanupError if deleting source objects fails', done => {
@@ -1028,7 +1042,10 @@ describe('Bucket', () => {
         return [{}];
       };
 
-      destination.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
+      destination.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function,
+      ) => {
         assert.strictEqual(reqOpts.json.deleteSourceObjects, undefined);
         callback(null, {success: true});
       };
@@ -1052,7 +1069,7 @@ describe('Bucket', () => {
           } catch (assertErr) {
             done(assertErr);
           }
-        }
+        },
       );
     });
   });
@@ -1113,7 +1130,7 @@ describe('Bucket', () => {
       beforeEach(() => {
         bucket.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(error, apiResponse);
         };
@@ -1129,7 +1146,7 @@ describe('Bucket', () => {
             assert.strictEqual(apiResponse_, apiResponse);
 
             done();
-          }
+          },
         );
       });
     });
@@ -1142,7 +1159,7 @@ describe('Bucket', () => {
       beforeEach(() => {
         bucket.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, apiResponse);
         };
@@ -1166,7 +1183,7 @@ describe('Bucket', () => {
             assert.strictEqual(channel_.metadata, apiResponse);
             assert.strictEqual(apiResponse_, apiResponse);
             done();
-          }
+          },
         );
       });
     });
@@ -1202,7 +1219,7 @@ describe('Bucket', () => {
       const expectedTopic = PUBSUB_SERVICE_PATH + topic;
       const expectedJson = Object.assign(
         {topic: expectedTopic},
-        convertObjKeysToSnakeCase(options)
+        convertObjKeysToSnakeCase(options),
       );
 
       bucket.request = (reqOpts: DecorateRequestOptions) => {
@@ -1285,7 +1302,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, response);
       };
@@ -1297,7 +1314,7 @@ describe('Bucket', () => {
           assert.strictEqual(notification, null);
           assert.strictEqual(resp, response);
           done();
-        }
+        },
       );
     });
 
@@ -1308,7 +1325,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, response);
       };
@@ -1326,7 +1343,7 @@ describe('Bucket', () => {
           assert.strictEqual(notification.metadata, response);
           assert.strictEqual(resp, response);
           done();
-        }
+        },
       );
     });
   });
@@ -1626,7 +1643,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         _optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {
           billing: {
@@ -1643,7 +1660,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(callback, undefined);
         done();
@@ -1694,7 +1711,7 @@ describe('Bucket', () => {
           {
             bucket: 'bucket-name',
           },
-          assert.ifError
+          assert.ifError,
         ),
           BucketExceptionMessages.CONFIGURATION_OBJECT_PREFIX_REQUIRED;
       });
@@ -1776,7 +1793,7 @@ describe('Bucket', () => {
           prefix: PREFIX,
           bucket: bucketName,
         },
-        assert.ifError
+        assert.ifError,
       );
     });
 
@@ -1786,7 +1803,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (metadata: BucketMetadata) => {
         assert.deepStrictEqual(
           metadata!.logging!.logBucket,
-          bucketForLogging.id
+          bucketForLogging.id,
         );
         setImmediate(done);
         return Promise.resolve([]);
@@ -1797,7 +1814,7 @@ describe('Bucket', () => {
           prefix: PREFIX,
           bucket: bucketForLogging,
         },
-        assert.ifError
+        assert.ifError,
       );
     });
 
@@ -1807,10 +1824,10 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         Promise.resolve([setMetadataResponse]).then(resp =>
-          callback(null, ...resp)
+          callback(null, ...resp),
         );
       };
 
@@ -1820,7 +1837,7 @@ describe('Bucket', () => {
           assert.ifError(err);
           assert.strictEqual(response, setMetadataResponse);
           done();
-        }
+        },
       );
     });
 
@@ -1843,7 +1860,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {
           billing: {
@@ -1860,7 +1877,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.equal(callback, undefined);
         done();
@@ -1933,7 +1950,7 @@ describe('Bucket', () => {
           delimiter: '/',
           autoPaginate: false,
         },
-        util.noop
+        util.noop,
       );
     });
 
@@ -1941,7 +1958,7 @@ describe('Bucket', () => {
       const token = 'next-page-token';
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {nextPageToken: token, items: []});
       };
@@ -1950,14 +1967,14 @@ describe('Bucket', () => {
         (err: Error, results: {}, nextQuery: GetFilesOptions) => {
           assert.strictEqual(nextQuery.pageToken, token);
           assert.strictEqual(nextQuery.maxResults, 5);
-        }
+        },
       );
     });
 
     it('should return null nextQuery if there are no more results', () => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: []});
       };
@@ -1965,14 +1982,14 @@ describe('Bucket', () => {
         {maxResults: 5},
         (err: Error, results: {}, nextQuery: {}) => {
           assert.strictEqual(nextQuery, null);
-        }
+        },
       );
     });
 
     it('should return File objects', done => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {
           items: [{name: 'fake-file-name', generation: 1}],
@@ -1983,7 +2000,7 @@ describe('Bucket', () => {
         assert(files[0] instanceof FakeFile);
         assert.strictEqual(
           typeof files[0].calledWith_[2].generation,
-          'undefined'
+          'undefined',
         );
         done();
       });
@@ -1992,7 +2009,7 @@ describe('Bucket', () => {
     it('should return versioned Files if queried for versions', done => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {
           items: [{name: 'fake-file-name', generation: 1}],
@@ -2010,7 +2027,7 @@ describe('Bucket', () => {
     it('should return Files with specified values if queried for fields', done => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {
           items: [{name: 'fake-file-name'}],
@@ -2023,14 +2040,14 @@ describe('Bucket', () => {
           assert.ifError(err);
           assert.strictEqual(files[0].name, 'fake-file-name');
           done();
-        }
+        },
       );
     });
 
     it('should add nextPageToken to fields for autoPaginate', done => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.qs.fields, 'items(name),nextPageToken');
         callback(null, {
@@ -2046,7 +2063,7 @@ describe('Bucket', () => {
           assert.strictEqual(files[0].name, 'fake-file-name');
           assert.strictEqual(nextQuery.pageToken, 'fake-page-token');
           done();
-        }
+        },
       );
     });
 
@@ -2054,7 +2071,7 @@ describe('Bucket', () => {
       const softDeletedTime = new Date('1/1/2024').toISOString();
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {
           items: [{name: 'fake-file-name', generation: 1, softDeletedTime}],
@@ -2074,7 +2091,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {
           items: [{name: 'fake-file-name', kmsKeyName}],
@@ -2092,7 +2109,7 @@ describe('Bucket', () => {
       const resp = {items: [{name: 'fake-file-name'}]};
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, resp);
       };
@@ -2100,7 +2117,7 @@ describe('Bucket', () => {
         (err: Error, files: Array<{}>, nextQuery: {}, apiResponse: {}) => {
           assert.deepStrictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -2110,7 +2127,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, apiResponse);
       };
@@ -2123,7 +2140,7 @@ describe('Bucket', () => {
           assert.strictEqual(apiResponse_, apiResponse);
 
           done();
-        }
+        },
       );
     });
 
@@ -2137,7 +2154,7 @@ describe('Bucket', () => {
       };
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: [fileMetadata]});
       };
@@ -2199,7 +2216,7 @@ describe('Bucket', () => {
       };
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: [fileMetadata]});
       };
@@ -2208,7 +2225,7 @@ describe('Bucket', () => {
         assert.ifError(err);
         assert.deepStrictEqual(
           files[0].metadata.contexts,
-          fileMetadata.contexts
+          fileMetadata.contexts,
         );
         done();
       });
@@ -2309,7 +2326,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, response);
       };
@@ -2320,7 +2337,7 @@ describe('Bucket', () => {
           assert.strictEqual(notifications, null);
           assert.strictEqual(resp, response);
           done();
-        }
+        },
       );
     });
 
@@ -2330,7 +2347,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, response);
       };
@@ -2353,7 +2370,7 @@ describe('Bucket', () => {
           });
           assert.strictEqual(resp, response);
           done();
-        }
+        },
       );
     });
   });
@@ -2379,7 +2396,7 @@ describe('Bucket', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       urlSignerStub = (sandbox.stub as any)(fakeSigner, 'URLSigner').returns(
-        signer
+        signer,
       );
 
       SIGNED_URL_CONFIG = {
@@ -2418,7 +2435,7 @@ describe('Bucket', () => {
             signingEndpoint: undefined,
           });
           done();
-        }
+        },
       );
     });
   });
@@ -2436,7 +2453,7 @@ describe('Bucket', () => {
 
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(reqOpts, {
           method: 'POST',
@@ -2472,7 +2489,7 @@ describe('Bucket', () => {
 
       bucket.makeAllFilesPublicPrivate_ = (
         opts: MakeAllFilesPublicPrivateOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(opts.private, true);
         assert.strictEqual(opts.force, true);
@@ -2518,7 +2535,7 @@ describe('Bucket', () => {
     it('should not make files private by default', done => {
       bucket.parent.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback();
       };
@@ -2535,7 +2552,7 @@ describe('Bucket', () => {
 
       bucket.parent.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error);
       };
@@ -2551,7 +2568,7 @@ describe('Bucket', () => {
     beforeEach(() => {
       bucket.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback();
       };
@@ -2578,7 +2595,7 @@ describe('Bucket', () => {
 
       bucket.makeAllFilesPublicPrivate_ = (
         opts: MakeAllFilesPublicPrivateOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(opts.public, true);
         assert.strictEqual(opts.force, true);
@@ -2597,7 +2614,7 @@ describe('Bucket', () => {
           assert(didSetDefaultAcl);
           assert(didMakeFilesPublic);
           done();
-        }
+        },
       );
     });
 
@@ -2642,7 +2659,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         _optionsOrCallback: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {
           retentionPolicy: null,
@@ -2659,7 +2676,7 @@ describe('Bucket', () => {
     it('should pass options to underlying request call', async () => {
       bucket.request = function (
         reqOpts: DecorateRequestOptions,
-        callback_: Function
+        callback_: Function,
       ) {
         assert.strictEqual(this, bucket);
         assert.deepStrictEqual(reqOpts, {
@@ -2684,7 +2701,7 @@ describe('Bucket', () => {
 
     it('should set the userProject if qs is undefined', done => {
       FakeServiceObject.prototype.request = ((
-        reqOpts: DecorateRequestOptions
+        reqOpts: DecorateRequestOptions,
       ) => {
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         done();
@@ -2702,7 +2719,7 @@ describe('Bucket', () => {
       };
 
       FakeServiceObject.prototype.request = ((
-        reqOpts: DecorateRequestOptions
+        reqOpts: DecorateRequestOptions,
       ) => {
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         assert.strictEqual(reqOpts.qs, options.qs);
@@ -2722,7 +2739,7 @@ describe('Bucket', () => {
       };
 
       FakeServiceObject.prototype.request = ((
-        reqOpts: DecorateRequestOptions
+        reqOpts: DecorateRequestOptions,
       ) => {
         assert.strictEqual(reqOpts.qs.userProject, fakeUserProject);
         done();
@@ -2753,7 +2770,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: BucketMetadata,
         _callbackOrOptions: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(metadata.labels, labels);
         Promise.resolve([]).then(resp => callback(null, ...resp));
@@ -2779,7 +2796,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         _callbackOrOptions: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {
           retentionPolicy: {
@@ -2801,7 +2818,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: {},
         _callbackOrOptions: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {
           cors: corsConfiguration,
@@ -2841,7 +2858,7 @@ describe('Bucket', () => {
       bucket.setMetadata = (
         metadata: BucketMetadata,
         options: {},
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(metadata, {storageClass: STORAGE_CLASS});
         assert.strictEqual(options, OPTIONS);
@@ -2872,14 +2889,14 @@ describe('Bucket', () => {
       methods.forEach(method => {
         assert.strictEqual(
           bucket.methods[method].reqOpts.qs.userProject,
-          undefined
+          undefined,
         );
       });
       bucket.setUserProject(USER_PROJECT);
       methods.forEach(method => {
         assert.strictEqual(
           bucket.methods[method].reqOpts.qs.userProject,
-          USER_PROJECT
+          USER_PROJECT,
         );
       });
     });
@@ -2889,12 +2906,12 @@ describe('Bucket', () => {
     const basename = 'testfile.json';
     const filepath = path.join(
       getDirName(),
-      '../../../test/testdata/' + basename
+      '../../../test/testdata/' + basename,
     );
     const nonExistentFilePath = path.join(
       getDirName(),
       '../../../test/testdata/',
-      'non-existent-file'
+      'non-existent-file',
     );
     const metadata = {
       metadata: {
@@ -3055,7 +3072,7 @@ describe('Bucket', () => {
             _transform(
               chunk: string | Buffer,
               _encoding: string,
-              done: Function
+              done: Function,
             ) {
               this.push(chunk);
               setTimeout(() => {
@@ -3136,7 +3153,7 @@ describe('Bucket', () => {
             _transform(
               chunk: string | Buffer,
               _encoding: string,
-              done: Function
+              done: Function,
             ) {
               this.push(chunk);
               setTimeout(() => {
@@ -3183,7 +3200,7 @@ describe('Bucket', () => {
             _transform(
               chunk: string | Buffer,
               _encoding: string,
-              done: Function
+              done: Function,
             ) {
               this.push(chunk);
               setTimeout(() => {
@@ -3241,7 +3258,7 @@ describe('Bucket', () => {
         setImmediate(() => {
           assert.strictEqual(
             options!.metadata!.contentType,
-            metadata.contentType
+            metadata.contentType,
           );
           done();
         });
@@ -3309,7 +3326,7 @@ describe('Bucket', () => {
           assert.strictEqual(file, fakeFile);
           assert.strictEqual(apiResponse, metadata);
           done();
-        }
+        },
       );
     });
 
@@ -3419,7 +3436,7 @@ describe('Bucket', () => {
         (errs: Error[]) => {
           assert.deepStrictEqual(errs, [error, error]);
           done();
-        }
+        },
       );
     });
 
@@ -3448,7 +3465,7 @@ describe('Bucket', () => {
           assert.deepStrictEqual(errs, [error, error]);
           assert.deepStrictEqual(files, successFiles);
           done();
-        }
+        },
       );
     });
   });
@@ -3462,7 +3479,7 @@ describe('Bucket', () => {
     it('should set autoRetry to false when ifMetagenerationMatch is undefined (setMetadata)', done => {
       bucket.disableAutoRetryConditionallyIdempotent_(
         bucket.methods.setMetadata,
-        AvailableServiceObjectMethods.setMetadata
+        AvailableServiceObjectMethods.setMetadata,
       );
       assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
       done();
@@ -3471,7 +3488,7 @@ describe('Bucket', () => {
     it('should set autoRetry to false when ifMetagenerationMatch is undefined (delete)', done => {
       bucket.disableAutoRetryConditionallyIdempotent_(
         bucket.methods.delete,
-        AvailableServiceObjectMethods.delete
+        AvailableServiceObjectMethods.delete,
       );
       assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
       done();
@@ -3486,7 +3503,7 @@ describe('Bucket', () => {
       });
       bucket.disableAutoRetryConditionallyIdempotent_(
         bucket.methods.delete,
-        AvailableServiceObjectMethods.delete
+        AvailableServiceObjectMethods.delete,
       );
       assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
       done();
@@ -3500,7 +3517,7 @@ describe('Bucket', () => {
       });
       bucket.disableAutoRetryConditionallyIdempotent_(
         bucket.methods.delete,
-        AvailableServiceObjectMethods.delete
+        AvailableServiceObjectMethods.delete,
       );
       assert.strictEqual(bucket.storage.retryOptions.autoRetry, true);
       done();
@@ -3532,22 +3549,22 @@ describe('Bucket', () => {
         bucket.setMetadata = (metadata: BucketMetadata) => {
           assert.strictEqual(
             metadata.encryption?.defaultKmsKeyName,
-            encryptionMetadata.encryption.defaultKmsKeyName
+            encryptionMetadata.encryption.defaultKmsKeyName,
           );
 
           assert.deepStrictEqual(
             metadata.encryption?.googleManagedEncryptionEnforcementConfig,
-            {restrictionMode: 'FullyRestricted', effectiveTime: effectiveTime}
+            {restrictionMode: 'FullyRestricted', effectiveTime: effectiveTime},
           );
 
           assert.deepStrictEqual(
             metadata.encryption?.customerManagedEncryptionEnforcementConfig,
-            {restrictionMode: 'NotRestricted', effectiveTime: effectiveTime}
+            {restrictionMode: 'NotRestricted', effectiveTime: effectiveTime},
           );
 
           assert.deepStrictEqual(
             metadata.encryption?.customerSuppliedEncryptionEnforcementConfig,
-            {restrictionMode: 'FullyRestricted', effectiveTime: effectiveTime}
+            {restrictionMode: 'FullyRestricted', effectiveTime: effectiveTime},
           );
         };
         bucket.setMetadata(encryptionMetadata, assert.ifError);
@@ -3575,7 +3592,7 @@ describe('Bucket', () => {
           assert.strictEqual(
             metadata.encryption?.customerSuppliedEncryptionEnforcementConfig
               ?.restrictionMode,
-            'FullyRestricted'
+            'FullyRestricted',
           );
           done();
         };
@@ -3596,7 +3613,7 @@ describe('Bucket', () => {
           assert.strictEqual(
             metadata.encryption?.googleManagedEncryptionEnforcementConfig
               ?.restrictionMode,
-            'fully_restricted'
+            'fully_restricted',
           );
           done();
         };
@@ -3617,15 +3634,15 @@ describe('Bucket', () => {
         bucket.setMetadata = (metadata: BucketMetadata) => {
           assert.ok(metadata.encryption?.defaultKmsKeyName);
           assert.ok(
-            metadata.encryption?.googleManagedEncryptionEnforcementConfig
+            metadata.encryption?.googleManagedEncryptionEnforcementConfig,
           );
           assert.strictEqual(
             metadata.encryption?.customerManagedEncryptionEnforcementConfig,
-            undefined
+            undefined,
           );
           assert.strictEqual(
             metadata.encryption?.customerSuppliedEncryptionEnforcementConfig,
-            undefined
+            undefined,
           );
           done();
         };

--- a/handwritten/storage/test/channel.ts
+++ b/handwritten/storage/test/channel.ts
@@ -112,7 +112,7 @@ describe('Channel', () => {
 
       channel.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, apiResponse);
       };
@@ -127,7 +127,7 @@ describe('Channel', () => {
     it('should not require a callback', done => {
       channel.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.doesNotThrow(() => callback());
         done();

--- a/handwritten/storage/test/crc32c.ts
+++ b/handwritten/storage/test/crc32c.ts
@@ -67,7 +67,7 @@ describe('CRC32C', () => {
           assert.equal(
             result,
             expected,
-            `Expected '${input}' to produce \`${expected}\` - not \`${result}\``
+            `Expected '${input}' to produce \`${expected}\` - not \`${result}\``,
           );
         }
       });
@@ -87,7 +87,7 @@ describe('CRC32C', () => {
           assert.equal(
             result,
             expected,
-            `Expected '${input}' to produce \`${expected}\` - not \`${result}\``
+            `Expected '${input}' to produce \`${expected}\` - not \`${result}\``,
           );
         }
       });
@@ -324,7 +324,7 @@ describe('CRC32C', () => {
 
             assert.throws(
               () => CRC32C.from(arrayBufferView.buffer),
-              expectedError
+              expectedError,
             );
           }
         });

--- a/handwritten/storage/test/file.ts
+++ b/handwritten/storage/test/file.ts
@@ -90,7 +90,7 @@ const fakeUtil = Object.assign({}, util, {
   makeRequest(
     reqOpts: DecorateRequestOptions,
     config: object,
-    callback: BodyResponseCallback
+    callback: BodyResponseCallback,
   ) {
     callback(null);
   },
@@ -210,7 +210,7 @@ describe('File', () => {
   // crc32c hash of `zlib.gzipSync(Buffer.from(DATA), {level: 9})`
   const GZIPPED_DATA = Buffer.from(
     'H4sIAAAAAAACEytJLS5RSEksSQQAsq4I0wkAAAA=',
-    'base64'
+    'base64',
   );
   //crc32c hash of `GZIPPED_DATA`
   const CRC32C_HASH_GZIP = '64jygg==';
@@ -300,7 +300,7 @@ describe('File', () => {
     it('should set instanceRetryValue to the storage instance retryOptions.autoRetry value', () => {
       assert.strictEqual(
         file.instanceRetryValue,
-        STORAGE.retryOptions.autoRetry
+        STORAGE.retryOptions.autoRetry,
       );
     });
 
@@ -384,7 +384,7 @@ describe('File', () => {
       });
       assert.deepStrictEqual(
         file.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -403,7 +403,7 @@ describe('File', () => {
       });
       assert.deepStrictEqual(
         file.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -422,7 +422,7 @@ describe('File', () => {
       });
       assert.deepStrictEqual(
         file.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -441,7 +441,7 @@ describe('File', () => {
       });
       assert.deepStrictEqual(
         file.instancePreconditionOpts,
-        options.preconditionOpts
+        options.preconditionOpts,
       );
     });
 
@@ -633,7 +633,7 @@ describe('File', () => {
       file.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
-          newFile.kmsKeyName
+          newFile.kmsKeyName,
         );
         assert.strictEqual(file.kmsKeyName, newFile.kmsKeyName);
         done();
@@ -649,7 +649,7 @@ describe('File', () => {
       file.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
-          destinationKmsKeyName
+          destinationKmsKeyName,
         );
         assert.strictEqual(file.kmsKeyName, destinationKmsKeyName);
         done();
@@ -666,7 +666,7 @@ describe('File', () => {
       file.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.destinationPredefinedAcl,
-          options.predefinedAcl
+          options.predefinedAcl,
         );
         assert.strictEqual(reqOpts.json.destinationPredefinedAcl, undefined);
         done();
@@ -683,7 +683,7 @@ describe('File', () => {
       file.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
-          destinationKmsKeyName
+          destinationKmsKeyName,
         );
         assert.strictEqual(file.kmsKeyName, destinationKmsKeyName);
         done();
@@ -713,7 +713,7 @@ describe('File', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         file: any,
         expectedPath: string,
-        callback: Function
+        callback: Function,
       ) {
         file.request = (reqOpts: DecorateRequestOptions) => {
           assert.strictEqual(reqOpts.uri, expectedPath);
@@ -775,7 +775,7 @@ describe('File', () => {
       beforeEach(() => {
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, apiResponse);
         };
@@ -786,7 +786,7 @@ describe('File', () => {
 
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           file.copy = (newFile_: {}, options: {}, callback: Function) => {
             assert.strictEqual(newFile_, newFile);
@@ -808,7 +808,7 @@ describe('File', () => {
 
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           file.copy = (newFile_: {}, options: any) => {
@@ -831,13 +831,13 @@ describe('File', () => {
 
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           file.copy = (newFile_: {}, options: any) => {
             assert.strictEqual(
               options.destinationKmsKeyName,
-              fakeOptions.destinationKmsKeyName
+              fakeOptions.destinationKmsKeyName,
             );
             done();
           };
@@ -865,7 +865,7 @@ describe('File', () => {
         const resp = {success: true};
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, resp);
         };
@@ -989,7 +989,7 @@ describe('File', () => {
         err: Error,
         res: {},
         body: {},
-        callback: Function
+        callback: Function,
       ) => {
         const rawResponseStream = new PassThrough();
         Object.assign(rawResponseStream, {
@@ -1199,7 +1199,7 @@ describe('File', () => {
             err: Error,
             res: {},
             body: {},
-            callback: Function
+            callback: Function,
           ) => {
             callback(ERROR, null, res);
             setImmediate(() => {
@@ -1237,7 +1237,7 @@ describe('File', () => {
             err: Error,
             res: {},
             body: {},
-            callback: Function
+            callback: Function,
           ) => {
             callback(null, null, rawResponseStream);
             setImmediate(() => {
@@ -1274,7 +1274,7 @@ describe('File', () => {
             err: Error,
             res: {},
             body: {},
-            callback: Function
+            callback: Function,
           ) => {
             callback(null, null, rawResponseStream);
             setImmediate(() => {
@@ -1310,7 +1310,7 @@ describe('File', () => {
           err: Error,
           res: {},
           body: {},
-          callback: Function
+          callback: Function,
         ) => {
           const rawResponseStream = new PassThrough();
           Object.assign(rawResponseStream, {
@@ -1349,7 +1349,7 @@ describe('File', () => {
 
         assert.equal(
           Buffer.compare(Buffer.concat(collection), GZIPPED_DATA),
-          0
+          0,
         );
       });
 
@@ -1408,7 +1408,7 @@ describe('File', () => {
           err: Error,
           res: {},
           body: {},
-          callback: Function
+          callback: Function,
         ) => {
           const rawResponseStream = new PassThrough();
           Object.assign(rawResponseStream, {
@@ -1451,7 +1451,7 @@ describe('File', () => {
             err: Error,
             res: {},
             body: {},
-            callback: Function
+            callback: Function,
           ) => {
             const rawResponseStream = new PassThrough();
             Object.assign(rawResponseStream, {
@@ -1484,7 +1484,7 @@ describe('File', () => {
           err: Error,
           res: {},
           body: {},
-          callback: Function
+          callback: Function,
         ) => {
           const rawResponseStream = new PassThrough();
           Object.assign(rawResponseStream, {
@@ -1629,7 +1629,7 @@ describe('File', () => {
           err: Error,
           res: {},
           body: {},
-          callback: Function
+          callback: Function,
         ) => {
           const rawResponseStream = new PassThrough();
           Object.assign(rawResponseStream, {
@@ -1672,7 +1672,7 @@ describe('File', () => {
             err: Error,
             res: {},
             body: {},
-            callback: Function
+            callback: Function,
           ) => {
             const rawResponseStream = new PassThrough();
             Object.assign(rawResponseStream, {
@@ -1709,7 +1709,7 @@ describe('File', () => {
           setImmediate(() => {
             assert.strictEqual(
               opts.headers!.Range,
-              'bytes=' + startOffset + '-'
+              'bytes=' + startOffset + '-',
             );
             done();
           });
@@ -1864,23 +1864,23 @@ describe('File', () => {
           assert.strictEqual(opts.userProject, options.userProject);
           assert.strictEqual(
             opts.retryOptions.autoRetry,
-            options.retryOptions.autoRetry
+            options.retryOptions.autoRetry,
           );
           assert.strictEqual(
             opts.retryOptions.maxRetries,
-            options.retryOptions.maxRetries
+            options.retryOptions.maxRetries,
           );
           assert.strictEqual(
             opts.retryOptions.maxRetryDelay,
-            options.retryOptions.maxRetryDelay
+            options.retryOptions.maxRetryDelay,
           );
           assert.strictEqual(
             opts.retryOptions.retryDelayMultiplier,
-            options.retryOptions.retryDelayMultiplier
+            options.retryOptions.retryDelayMultiplier,
           );
           assert.strictEqual(
             opts.retryOptions.totalTimeout,
-            options.retryOptions.totalTimeout
+            options.retryOptions.totalTimeout,
           );
           assert.strictEqual(opts.params, options.preconditionOpts);
 
@@ -1943,23 +1943,23 @@ describe('File', () => {
           assert.strictEqual(opts.userProject, options.userProject);
           assert.strictEqual(
             opts.retryOptions.autoRetry,
-            options.retryOptions.autoRetry
+            options.retryOptions.autoRetry,
           );
           assert.strictEqual(
             opts.retryOptions.maxRetries,
-            options.retryOptions.maxRetries
+            options.retryOptions.maxRetries,
           );
           assert.strictEqual(
             opts.retryOptions.maxRetryDelay,
-            options.retryOptions.maxRetryDelay
+            options.retryOptions.maxRetryDelay,
           );
           assert.strictEqual(
             opts.retryOptions.retryDelayMultiplier,
-            options.retryOptions.retryDelayMultiplier
+            options.retryOptions.retryDelayMultiplier,
           );
           assert.strictEqual(
             opts.retryOptions.totalTimeout,
-            options.retryOptions.totalTimeout
+            options.retryOptions.totalTimeout,
           );
           assert.strictEqual(opts.params, file.instancePreconditionOpts);
 
@@ -2008,7 +2008,7 @@ describe('File', () => {
 
     it('should emit RangeError', done => {
       const error = new RangeError(
-        'Cannot provide an `offset` without providing a `uri`'
+        'Cannot provide an `offset` without providing a `uri`',
       );
 
       const options = {
@@ -2218,7 +2218,7 @@ describe('File', () => {
       file.startResumableUpload_ = (stream: {}, options: any) => {
         assert.strictEqual(
           options.preconditionOpts.ifMetagenerationNotMatch,
-          100
+          100,
         );
         done();
       };
@@ -2337,7 +2337,7 @@ describe('File', () => {
           assert.strictEqual(e, error);
           assert.strictEqual(closed, true);
           done();
-        }
+        },
       );
     });
 
@@ -2353,7 +2353,7 @@ describe('File', () => {
         (e: Error | null) => {
           assert.strictEqual(e, error);
           done();
-        }
+        },
       );
     });
 
@@ -2647,7 +2647,7 @@ describe('File', () => {
         assert.ifError(err);
         // Verify that setEncryptionKey was called with the correct key
         assert.ok(
-          (file.setEncryptionKey as sinon.SinonStub).calledWith(encryptionKey)
+          (file.setEncryptionKey as sinon.SinonStub).calledWith(encryptionKey),
         );
         done();
       });
@@ -2769,7 +2769,7 @@ describe('File', () => {
               assert.ifError(err);
               assert.strictEqual(
                 fileContents + fileContents,
-                tmpFileContents.toString()
+                tmpFileContents.toString(),
               );
               done();
             });
@@ -2893,7 +2893,7 @@ describe('File', () => {
           assert.strictEqual(expirationDate, null);
           assert.strictEqual(apiResponse_, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -2908,12 +2908,12 @@ describe('File', () => {
         (err: Error, expirationDate: {}, apiResponse_: {}) => {
           assert.strictEqual(
             err.message,
-            FileExceptionMessages.EXPIRATION_TIME_NA
+            FileExceptionMessages.EXPIRATION_TIME_NA,
           );
           assert.strictEqual(expirationDate, null);
           assert.strictEqual(apiResponse_, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -2934,7 +2934,7 @@ describe('File', () => {
           assert.deepStrictEqual(expirationDate, expirationTime);
           assert.strictEqual(apiResponse_, apiResponse);
           done();
-        }
+        },
       );
     });
   });
@@ -2970,7 +2970,7 @@ describe('File', () => {
           assert.strictEqual(typeof signedPolicy.base64, 'string');
           assert.strictEqual(typeof signedPolicy.signature, 'string');
           done();
-        }
+        },
       );
     });
 
@@ -3006,7 +3006,7 @@ describe('File', () => {
           assert.ifError(err);
           assert(signedPolicy.string.indexOf(conditionString) > -1);
           done();
-        }
+        },
       );
     });
 
@@ -3021,7 +3021,7 @@ describe('File', () => {
           assert.ifError(err);
           assert(signedPolicy.string.indexOf(conditionString) > -1);
           done();
-        }
+        },
       );
     });
 
@@ -3042,11 +3042,11 @@ describe('File', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             policy.conditions.some((condition: any) => {
               return condition.success_action_redirect === redirectUrl;
-            })
+            }),
           );
 
           done();
-        }
+        },
       );
     });
 
@@ -3067,11 +3067,11 @@ describe('File', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             policy.conditions.some((condition: any) => {
               return condition.success_action_status === successStatus;
-            })
+            }),
           );
 
           done();
-        }
+        },
       );
     });
 
@@ -3088,7 +3088,7 @@ describe('File', () => {
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, expires.toISOString());
             done();
-          }
+          },
         );
       });
 
@@ -3104,7 +3104,7 @@ describe('File', () => {
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, new Date(expires).toISOString());
             done();
-          }
+          },
         );
       });
 
@@ -3120,7 +3120,7 @@ describe('File', () => {
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, new Date(expires).toISOString());
             done();
-          }
+          },
         );
       });
 
@@ -3132,7 +3132,7 @@ describe('File', () => {
             {
               expires,
             },
-            () => {}
+            () => {},
           ),
             ExceptionMessages.EXPIRATION_DATE_INVALID;
         });
@@ -3146,7 +3146,7 @@ describe('File', () => {
             {
               expires,
             },
-            () => {}
+            () => {},
           ),
             ExceptionMessages.EXPIRATION_DATE_PAST;
         });
@@ -3165,7 +3165,7 @@ describe('File', () => {
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
             done();
-          }
+          },
         );
       });
 
@@ -3180,7 +3180,7 @@ describe('File', () => {
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
             done();
-          }
+          },
         );
       });
 
@@ -3191,7 +3191,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               equals: [{}],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.EQUALS_CONDITION_TWO_ELEMENTS;
         });
@@ -3204,7 +3204,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               equals: [['1', '2', '3']],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.EQUALS_CONDITION_TWO_ELEMENTS;
         });
@@ -3223,7 +3223,7 @@ describe('File', () => {
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
             done();
-          }
+          },
         );
       });
 
@@ -3238,7 +3238,7 @@ describe('File', () => {
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
             done();
-          }
+          },
         );
       });
 
@@ -3249,7 +3249,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               startsWith: [{}],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.STARTS_WITH_TWO_ELEMENTS;
         });
@@ -3262,7 +3262,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               startsWith: [['1', '2', '3']],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.STARTS_WITH_TWO_ELEMENTS;
         });
@@ -3281,7 +3281,7 @@ describe('File', () => {
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
             done();
-          }
+          },
         );
       });
 
@@ -3292,7 +3292,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               contentLengthRange: [{max: 1}],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.CONTENT_LENGTH_RANGE_MIN_MAX;
         });
@@ -3305,7 +3305,7 @@ describe('File', () => {
               expires: Date.now() + 2000,
               contentLengthRange: [{min: 0}],
             },
-            () => {}
+            () => {},
           ),
             FileExceptionMessages.CONTENT_LENGTH_RANGE_MIN_MAX;
         });
@@ -3368,7 +3368,7 @@ describe('File', () => {
       const policyString = JSON.stringify(policy);
       const EXPECTED_POLICY = Buffer.from(policyString).toString('base64');
       const EXPECTED_SIGNATURE = Buffer.from(SIGNATURE, 'base64').toString(
-        'hex'
+        'hex',
       );
       const EXPECTED_FIELDS = {
         ...CONFIG.fields,
@@ -3389,11 +3389,11 @@ describe('File', () => {
           const signStub = BUCKET.storage.authClient.sign;
           assert.deepStrictEqual(
             Buffer.from(signStub.getCall(0).args[0], 'base64').toString(),
-            policyString
+            policyString,
           );
 
           done();
-        }
+        },
       );
     });
 
@@ -3430,10 +3430,10 @@ describe('File', () => {
           assert(
             Buffer.from(res.fields.policy, 'base64')
               .toString('utf-8')
-              .includes(EXPECTED_POLICY_ELEMENT)
+              .includes(EXPECTED_POLICY_ELEMENT),
           );
           done();
-        }
+        },
       );
     });
 
@@ -3454,11 +3454,11 @@ describe('File', () => {
           assert.strictEqual(res.fields['x-goog-meta-foo'], 'bar');
           const decodedPolicy = Buffer.from(
             res.fields.policy,
-            'base64'
+            'base64',
           ).toString('utf-8');
           assert(decodedPolicy.includes(expectedConditionString));
           done();
-        }
+        },
       );
     });
 
@@ -3478,11 +3478,11 @@ describe('File', () => {
           assert.strictEqual(res.fields['x-goog-meta-foo'], 'bår');
           const decodedPolicy = Buffer.from(
             res.fields.policy,
-            'base64'
+            'base64',
           ).toString('utf-8');
           assert(decodedPolicy.includes('"x-goog-meta-foo":"b\\u00e5r"'));
           done();
-        }
+        },
       );
     });
 
@@ -3503,14 +3503,14 @@ describe('File', () => {
           assert.strictEqual(res.fields['x-ignore-foo'], 'bar');
           const decodedPolicy = Buffer.from(
             res.fields.policy,
-            'base64'
+            'base64',
           ).toString('utf-8');
           assert(!decodedPolicy.includes(expectedConditionString));
 
           const signStub = BUCKET.storage.authClient.sign;
           assert(!signStub.getCall(0).args[0].includes('x-ignore-foo'));
           done();
-        }
+        },
       );
     });
 
@@ -3528,16 +3528,16 @@ describe('File', () => {
           const expectedConditionString = JSON.stringify(CONFIG.conditions);
           const decodedPolicy = Buffer.from(
             res.fields.policy,
-            'base64'
+            'base64',
           ).toString('utf-8');
           assert(decodedPolicy.includes(expectedConditionString));
 
           const signStub = BUCKET.storage.authClient.sign;
           assert(
-            !signStub.getCall(0).args[0].includes(expectedConditionString)
+            !signStub.getCall(0).args[0].includes(expectedConditionString),
           );
           done();
-        }
+        },
       );
     });
 
@@ -3550,7 +3550,7 @@ describe('File', () => {
           assert.ifError(err);
           assert(res.url, CONFIG.bucketBoundHostname);
           done();
-        }
+        },
       );
     });
 
@@ -3563,7 +3563,7 @@ describe('File', () => {
           assert.ifError(err);
           assert(res.url, `https://${BUCKET.name}.storage.googleapis.com/`);
           done();
-        }
+        },
       );
     });
 
@@ -3582,7 +3582,7 @@ describe('File', () => {
           assert.ifError(err);
           assert(res.url, `https://${BUCKET.name}.storage.googleapis.com/`);
           done();
-        }
+        },
       );
     });
 
@@ -3610,7 +3610,7 @@ describe('File', () => {
           assert.ifError(err);
           assert.strictEqual(res.url, `${emulatorHost}/${BUCKET.name}`);
           done();
-        }
+        },
       );
     });
 
@@ -3625,14 +3625,14 @@ describe('File', () => {
           (err: Error, response: SignedPostPolicyV4Output) => {
             assert.ifError(err);
             const policy = JSON.parse(
-              Buffer.from(response.fields.policy, 'base64').toString()
+              Buffer.from(response.fields.policy, 'base64').toString(),
             );
             assert.strictEqual(
               policy.expiration,
-              formatAsUTCISO(expires, true, '-', ':')
+              formatAsUTCISO(expires, true, '-', ':'),
             );
             done();
-          }
+          },
         );
       });
 
@@ -3646,14 +3646,14 @@ describe('File', () => {
           (err: Error, response: SignedPostPolicyV4Output) => {
             assert.ifError(err);
             const policy = JSON.parse(
-              Buffer.from(response.fields.policy, 'base64').toString()
+              Buffer.from(response.fields.policy, 'base64').toString(),
             );
             assert.strictEqual(
               policy.expiration,
-              formatAsUTCISO(new Date(expires), true, '-', ':')
+              formatAsUTCISO(new Date(expires), true, '-', ':'),
             );
             done();
-          }
+          },
         );
       });
 
@@ -3661,7 +3661,7 @@ describe('File', () => {
         const expires = formatAsUTCISO(
           new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
           false,
-          '-'
+          '-',
         );
 
         file.generateSignedPostPolicyV4(
@@ -3671,14 +3671,14 @@ describe('File', () => {
           (err: Error, response: SignedPostPolicyV4Output) => {
             assert.ifError(err);
             const policy = JSON.parse(
-              Buffer.from(response.fields.policy, 'base64').toString()
+              Buffer.from(response.fields.policy, 'base64').toString(),
             );
             assert.strictEqual(
               policy.expiration,
-              formatAsUTCISO(new Date(expires), true, '-', ':')
+              formatAsUTCISO(new Date(expires), true, '-', ':'),
             );
             done();
-          }
+          },
         );
       });
 
@@ -3690,7 +3690,7 @@ describe('File', () => {
             {
               expires,
             },
-            () => {}
+            () => {},
           ),
             ExceptionMessages.EXPIRATION_DATE_INVALID;
         });
@@ -3704,7 +3704,7 @@ describe('File', () => {
             {
               expires,
             },
-            () => {}
+            () => {},
           ),
             ExceptionMessages.EXPIRATION_DATE_PAST;
         });
@@ -3718,7 +3718,7 @@ describe('File', () => {
             {
               expires,
             },
-            () => {}
+            () => {},
           ),
             {message: 'Max allowed expiration is seven days (604800 seconds).'};
         });
@@ -3747,7 +3747,7 @@ describe('File', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       urlSignerStub = (sandbox.stub as any)(fakeSigner, 'URLSigner').returns(
-        signer
+        signer,
       );
 
       SIGNED_URL_CONFIG = {
@@ -3893,7 +3893,7 @@ describe('File', () => {
       file.setMetadata = (
         metadata: FileMetadata,
         optionsOrCallback: SetMetadataOptions | MetadataCallback<FileMetadata>,
-        cb: MetadataCallback<FileMetadata>
+        cb: MetadataCallback<FileMetadata>,
       ) => {
         Promise.resolve([apiResponse]).then(resp => cb(null, ...resp));
       };
@@ -3980,7 +3980,7 @@ describe('File', () => {
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),
-        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`
+        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`,
       );
       done();
     });
@@ -3990,7 +3990,7 @@ describe('File', () => {
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),
-        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`
+        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`,
       );
       done();
     });
@@ -4000,7 +4000,7 @@ describe('File', () => {
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),
-        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`
+        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`,
       );
       done();
     });
@@ -4010,7 +4010,7 @@ describe('File', () => {
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),
-        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`
+        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`,
       );
       done();
     });
@@ -4020,7 +4020,7 @@ describe('File', () => {
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),
-        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`
+        `https://storage.googleapis.com/bucket-name/${encodeURIComponent(NAME)}`,
       );
       done();
     });
@@ -4043,7 +4043,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         const error = new ApiError('Permission Denied.');
         error.code = 403;
@@ -4062,7 +4062,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         callback(error);
       };
@@ -4076,7 +4076,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         assert.strictEqual(reqOpts.method, 'GET');
         callback(null);
@@ -4096,7 +4096,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         assert.strictEqual(reqOpts.uri, expectedURL);
         callback(null);
@@ -4111,7 +4111,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         assert.deepStrictEqual(reqOpts.headers, {});
         callback(null);
@@ -4136,7 +4136,7 @@ describe('File', () => {
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) {
         assert.deepStrictEqual(reqOpts.headers, expectedHeader);
         callback(null);
@@ -4153,7 +4153,7 @@ describe('File', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       file: any,
       expectedDestination: string,
-      callback: Function
+      callback: Function,
     ) {
       file.moveFileAtomic = (destination: string) => {
         assert.strictEqual(destination, expectedDestination);
@@ -4250,7 +4250,7 @@ describe('File', () => {
       file.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.qs.ifGenerationMatch,
-          options.preconditionOpts.ifGenerationMatch
+          options.preconditionOpts.ifGenerationMatch,
         );
         assert.strictEqual(reqOpts.json.userProject, undefined);
         assert.deepStrictEqual(options, originalOptions);
@@ -4265,7 +4265,7 @@ describe('File', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         file: any,
         expectedPath: string,
-        callback: Function
+        callback: Function,
       ) {
         file.request = (reqOpts: DecorateRequestOptions) => {
           assert.strictEqual(reqOpts.uri, expectedPath);
@@ -4315,7 +4315,7 @@ describe('File', () => {
         const resp = {success: true};
         file.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, resp);
         };
@@ -4348,7 +4348,7 @@ describe('File', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         file: any,
         expectedDestination: string,
-        callback: Function
+        callback: Function,
       ) {
         file.copy = (destination: string) => {
           assert.strictEqual(destination, expectedDestination);
@@ -4395,7 +4395,7 @@ describe('File', () => {
           assert.strictEqual(err, error);
           assert.strictEqual(
             err.message,
-            `file#copy failed with an error - ${originalErrorMessage}`
+            `file#copy failed with an error - ${originalErrorMessage}`,
           );
           done();
         });
@@ -4420,7 +4420,7 @@ describe('File', () => {
             assert.strictEqual(destinationFile, newFile);
             assert.strictEqual(apiResponse, copyApiResponse);
             done();
-          }
+          },
         );
       });
 
@@ -4504,7 +4504,7 @@ describe('File', () => {
           assert.strictEqual(err, error);
           assert.strictEqual(
             err.message,
-            `file#delete failed with an error - ${originalErrorMessage}`
+            `file#delete failed with an error - ${originalErrorMessage}`,
           );
           done();
         });
@@ -4550,7 +4550,7 @@ describe('File', () => {
     it('should pass options to underlying request call', async () => {
       file.parent.request = function (
         reqOpts: DecorateRequestOptions,
-        callback_: Function
+        callback_: Function,
       ) {
         assert.strictEqual(this, file);
         assert.deepStrictEqual(reqOpts, {
@@ -4574,7 +4574,7 @@ describe('File', () => {
 
       file.parent.request = function (
         reqOpts: DecorateRequestOptions,
-        callback_: Function
+        callback_: Function,
       ) {
         assert.strictEqual(this, file);
         assert.strictEqual(reqOpts, options);
@@ -4632,7 +4632,7 @@ describe('File', () => {
       file.copy = (
         destination: string,
         options: object,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(destination, newFile);
         assert.deepStrictEqual(options, {});
@@ -4647,7 +4647,7 @@ describe('File', () => {
     const DATA = 'Data!';
     const BUFFER_DATA = Buffer.from(DATA, 'utf8');
     const UINT8_ARRAY_DATA = Uint8Array.from(
-      Array.from(DATA).map(l => l.charCodeAt(0))
+      Array.from(DATA).map(l => l.charCodeAt(0)),
     );
 
     class DelayedStreamNoError extends Transform {
@@ -4724,7 +4724,7 @@ describe('File', () => {
             _transform(
               chunk: string | Buffer,
               _encoding: string,
-              done: Function
+              done: Function,
             ) {
               this.push(chunk);
               setTimeout(() => {
@@ -4854,7 +4854,7 @@ describe('File', () => {
             transform(
               chunk: string | Buffer,
               _encoding: string,
-              done: Function
+              done: Function,
             ) {
               this.push(chunk);
               setTimeout(() => {
@@ -5074,7 +5074,7 @@ describe('File', () => {
       newFile.setMetadata(
         {retention: null},
         {overrideUnlockedRetention: true},
-        assert.ifError
+        assert.ifError,
       );
     });
   });
@@ -5121,7 +5121,7 @@ describe('File', () => {
 
         assert.strictEqual(
           contexts!.custom!['🚀-launcher'].value,
-          '✨-sparkle'
+          '✨-sparkle',
         );
       });
 
@@ -5161,11 +5161,11 @@ describe('File', () => {
         assert.ok(sentMetadata.contexts!.custom);
         assert.strictEqual(
           sentMetadata.contexts!.custom!['only-key'].value,
-          'only-val'
+          'only-val',
         );
         assert.strictEqual(
           sentMetadata.contexts!.custom!['new-key'],
-          undefined
+          undefined,
         );
       });
 
@@ -5188,7 +5188,7 @@ describe('File', () => {
         assert.ok(sentMetadata.contexts!.custom);
         assert.strictEqual(
           sentMetadata.contexts!.custom!['new-key'].value,
-          'added'
+          'added',
         );
       });
 
@@ -5261,7 +5261,7 @@ describe('File', () => {
         const callOptions = stub.getCall(0).args[2];
         assert.deepStrictEqual(
           callOptions.metadata.contexts,
-          metadata.contexts
+          metadata.contexts,
         );
       });
     });
@@ -5280,7 +5280,6 @@ describe('File', () => {
       assert.strictEqual(sentMetadata.contexts.custom['empty-key'].value, '');
     });
   });
-
 
   describe('setStorageClass', () => {
     const STORAGE_CLASS = 'new_storage_class';
@@ -5431,11 +5430,11 @@ describe('File', () => {
 
       assert.deepStrictEqual(
         file.interceptors[0].request({}),
-        expectedInterceptor
+        expectedInterceptor,
       );
       assert.deepStrictEqual(
         file.encryptionKeyInterceptor.request({}),
-        expectedInterceptor
+        expectedInterceptor,
       );
 
       done();
@@ -5733,7 +5732,7 @@ describe('File', () => {
       makeWritableStreamOverride = (stream: {}, options_: any) => {
         assert.strictEqual(
           options_.request.qs.userProject,
-          options.userProject
+          options.userProject,
         );
         done();
       };
@@ -5748,7 +5747,7 @@ describe('File', () => {
         beforeEach(() => {
           file.request = (
             reqOpts: DecorateRequestOptions,
-            callback: Function
+            callback: Function,
           ) => {
             callback(error);
           };
@@ -5775,7 +5774,7 @@ describe('File', () => {
         beforeEach(() => {
           file.request = (
             reqOpts: DecorateRequestOptions,
-            callback: Function
+            callback: Function,
           ) => {
             callback(null, body, resp);
           };

--- a/handwritten/storage/test/headers.ts
+++ b/handwritten/storage/test/headers.ts
@@ -67,8 +67,8 @@ describe('headers', () => {
     }
     assert.ok(
       /^gl-node\/(?<nodeVersion>[^W]+) gccl\/(?<gccl>[^W]+) gccl-invocation-id\/(?<gcclInvocationId>[^W]+)$/.test(
-        requests[0].headers['x-goog-api-client']
-      )
+        requests[0].headers['x-goog-api-client'],
+      ),
     );
   });
 
@@ -89,8 +89,8 @@ describe('headers', () => {
     }
     assert.ok(
       /^gl-deno\/0.00.0 gccl\/(?<gccl>[^W]+) gccl-invocation-id\/(?<gcclInvocationId>[^W]+)$/.test(
-        requests[1].headers['x-goog-api-client']
-      )
+        requests[1].headers['x-goog-api-client'],
+      ),
     );
   });
 });

--- a/handwritten/storage/test/iam.ts
+++ b/handwritten/storage/test/iam.ts
@@ -140,7 +140,7 @@ describe('storage/iam', () => {
             {
               resourceId: iam.resourceId_,
             },
-            policy
+            policy,
           ),
           qs: {},
         });
@@ -211,7 +211,7 @@ describe('storage/iam', () => {
           assert.strictEqual(permissions, null);
           assert.strictEqual(apiResp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -236,7 +236,7 @@ describe('storage/iam', () => {
           assert.strictEqual(apiResp, apiResponse);
 
           done();
-        }
+        },
       );
     });
 
@@ -258,7 +258,7 @@ describe('storage/iam', () => {
           assert.strictEqual(apiResp, apiResponse);
 
           done();
-        }
+        },
       );
     });
 
@@ -272,7 +272,7 @@ describe('storage/iam', () => {
         {
           permissions,
         },
-        options
+        options,
       );
 
       iam.request_ = (reqOpts: DecorateRequestOptions) => {

--- a/handwritten/storage/test/index.ts
+++ b/handwritten/storage/test/index.ts
@@ -145,7 +145,7 @@ describe('Storage', () => {
       assert.deepStrictEqual(
         calledWith.packageJson,
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        getPackageJSON()
+        getPackageJSON(),
       );
     });
 
@@ -231,7 +231,7 @@ describe('Storage', () => {
       const calledWith = storage.calledWith_[0];
       assert.strictEqual(
         calledWith.retryOptions.retryDelayMultiplier,
-        retryDelayMultiplier
+        retryDelayMultiplier,
       );
     });
 
@@ -269,15 +269,15 @@ describe('Storage', () => {
       assert.strictEqual(calledWith.retryOptions.maxRetries, maxRetryDefault);
       assert.strictEqual(
         calledWith.retryOptions.retryDelayMultiplier,
-        retryDelayMultiplierDefault
+        retryDelayMultiplierDefault,
       );
       assert.strictEqual(
         calledWith.retryOptions.totalTimeout,
-        totalTimeoutDefault
+        totalTimeoutDefault,
       );
       assert.strictEqual(
         calledWith.retryOptions.maxRetryDelay,
-        maxRetryDelayDefault
+        maxRetryDelayDefault,
       );
     });
 
@@ -317,7 +317,7 @@ describe('Storage', () => {
       const error = undefined;
       assert.strictEqual(
         calledWith.retryOptions.retryableErrorFn(error),
-        false
+        false,
       );
     });
 
@@ -376,7 +376,7 @@ describe('Storage', () => {
       error.code = 0;
       assert.strictEqual(
         calledWith.retryOptions.retryableErrorFn(error),
-        false
+        false,
       );
     });
 
@@ -393,7 +393,7 @@ describe('Storage', () => {
       ];
       assert.strictEqual(
         calledWith.retryOptions.retryableErrorFn(error),
-        false
+        false,
       );
     });
 
@@ -435,11 +435,11 @@ describe('Storage', () => {
       const calledWith = storage.calledWith_[0];
       assert.strictEqual(
         calledWith.baseUrl,
-        `https://${protocollessApiEndpoint}/storage/v1`
+        `https://${protocollessApiEndpoint}/storage/v1`,
       );
       assert.strictEqual(
         calledWith.apiEndpoint,
-        `https://${protocollessApiEndpoint}`
+        `https://${protocollessApiEndpoint}`,
       );
     });
 
@@ -464,7 +464,7 @@ describe('Storage', () => {
     it('should use `CRC32C_DEFAULT_VALIDATOR_GENERATOR` by default', () => {
       assert.strictEqual(
         storage.crc32cGenerator,
-        CRC32C_DEFAULT_VALIDATOR_GENERATOR
+        CRC32C_DEFAULT_VALIDATOR_GENERATOR,
       );
     });
 
@@ -496,7 +496,7 @@ describe('Storage', () => {
         assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
         assert.strictEqual(
           calledWith.apiEndpoint,
-          'https://internal.benchmark.com/path'
+          'https://internal.benchmark.com/path',
         );
       });
 
@@ -523,7 +523,7 @@ describe('Storage', () => {
         assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
         assert.strictEqual(
           calledWith.apiEndpoint,
-          'https://internal.benchmark.com/path'
+          'https://internal.benchmark.com/path',
         );
       });
 
@@ -636,16 +636,16 @@ describe('Storage', () => {
     it('should make correct API request', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(
           reqOpts.uri,
-          `/projects/${storage.projectId}/hmacKeys`
+          `/projects/${storage.projectId}/hmacKeys`,
         );
         assert.strictEqual(
           reqOpts.qs.serviceAccountEmail,
-          SERVICE_ACCOUNT_EMAIL
+          SERVICE_ACCOUNT_EMAIL,
         );
 
         callback(null, response);
@@ -712,7 +712,7 @@ describe('Storage', () => {
           ]);
           assert.strictEqual(hmacKey.metadata, metadataResponse);
           done();
-        }
+        },
       );
     });
 
@@ -727,12 +727,12 @@ describe('Storage', () => {
           err: Error,
           _hmacKey: HmacKey,
           _secret: string,
-          apiResponse: HmacKeyResourceResponse
+          apiResponse: HmacKeyResourceResponse,
         ) => {
           assert.ifError(err);
           assert.strictEqual(apiResponse, response);
           done();
-        }
+        },
       );
     });
 
@@ -749,7 +749,7 @@ describe('Storage', () => {
           assert.strictEqual(err, error);
           assert.strictEqual(apiResponse, response);
           done();
-        }
+        },
       );
     });
   });
@@ -762,7 +762,7 @@ describe('Storage', () => {
     it('should make correct API request', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/b');
@@ -778,11 +778,11 @@ describe('Storage', () => {
     it('should accept a name, metadata, and callback', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(
           reqOpts.json,
-          Object.assign(METADATA, {name: BUCKET_NAME})
+          Object.assign(METADATA, {name: BUCKET_NAME}),
         );
         callback(null, METADATA);
       };
@@ -799,7 +799,7 @@ describe('Storage', () => {
     it('should accept a name and callback only', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback();
       };
@@ -832,7 +832,7 @@ describe('Storage', () => {
       };
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, METADATA);
       };
@@ -848,7 +848,7 @@ describe('Storage', () => {
       const error = new Error('Error.');
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error);
       };
@@ -862,7 +862,7 @@ describe('Storage', () => {
       const resp = {success: true};
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, resp);
       };
@@ -871,7 +871,7 @@ describe('Storage', () => {
         (err: Error, bucket: Bucket, apiResponse: unknown) => {
           assert.strictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -879,7 +879,7 @@ describe('Storage', () => {
       const storageClass = 'nearline';
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.json.storageClass, storageClass);
         callback(); // done
@@ -891,11 +891,11 @@ describe('Storage', () => {
       const storageClass = 'coldline';
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(
           reqOpts.json.storageClass,
-          storageClass.toUpperCase()
+          storageClass.toUpperCase(),
         );
         callback(); // done
       };
@@ -904,7 +904,7 @@ describe('Storage', () => {
         storage.createBucket(
           BUCKET_NAME,
           {storageClass, [storageClass]: true},
-          done
+          done,
         );
       });
     });
@@ -914,7 +914,7 @@ describe('Storage', () => {
       const rpo = 'ASYNC_TURBO';
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.json.location, location);
         assert.strictEqual(reqOpts.json.rpo, rpo);
@@ -931,7 +931,7 @@ describe('Storage', () => {
             storageClass: 'nearline',
             coldline: true,
           },
-          assert.ifError
+          assert.ifError,
         );
       }, /Both `coldline` and `storageClass` were provided./);
     });
@@ -939,7 +939,7 @@ describe('Storage', () => {
     it('should allow enabling object retention', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.qs.enableObjectRetention, true);
         callback();
@@ -950,7 +950,7 @@ describe('Storage', () => {
     it('should allow enabling hierarchical namespace', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.json.hierarchicalNamespace.enabled, true);
         callback();
@@ -958,7 +958,7 @@ describe('Storage', () => {
       storage.createBucket(
         BUCKET_NAME,
         {hierarchicalNamespace: {enabled: true}},
-        done
+        done,
       );
     });
 
@@ -1002,7 +1002,7 @@ describe('Storage', () => {
           {
             multiRegional: true,
           },
-          assert.ifError
+          assert.ifError,
         );
       });
 
@@ -1078,7 +1078,7 @@ describe('Storage', () => {
 
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, apiResponse);
       };
@@ -1091,7 +1091,7 @@ describe('Storage', () => {
           assert.strictEqual(nextQuery, null);
           assert.strictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -1099,7 +1099,7 @@ describe('Storage', () => {
       const token = 'next-page-token';
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {nextPageToken: token, items: []});
       };
@@ -1108,14 +1108,14 @@ describe('Storage', () => {
         (err: Error, results: {}, nextQuery: GetFilesOptions) => {
           assert.strictEqual(nextQuery.pageToken, token);
           assert.strictEqual(nextQuery.maxResults, 5);
-        }
+        },
       );
     });
 
     it('should return null nextQuery if there are no more results', () => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: []});
       };
@@ -1123,14 +1123,14 @@ describe('Storage', () => {
         {maxResults: 5},
         (err: Error, results: {}, nextQuery: {}) => {
           assert.strictEqual(nextQuery, null);
-        }
+        },
       );
     });
 
     it('should return Bucket objects', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: [{id: 'fake-bucket-name'}]});
       };
@@ -1145,7 +1145,7 @@ describe('Storage', () => {
       const resp = {items: [{id: 'fake-bucket-name'}]};
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, resp);
       };
@@ -1153,7 +1153,7 @@ describe('Storage', () => {
         (err: Error, buckets: Bucket[], nextQuery: {}, apiResponse: {}) => {
           assert.deepStrictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -1167,7 +1167,7 @@ describe('Storage', () => {
       };
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, {items: [bucketMetadata]});
       };
@@ -1185,7 +1185,7 @@ describe('Storage', () => {
 
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.qs.returnPartialSuccess, true);
         callback(null, resp);
@@ -1198,7 +1198,7 @@ describe('Storage', () => {
           assert.strictEqual(buckets.length, 2);
 
           const reachableBucket = buckets.find(
-            b => b.name === 'fake-bucket-name'
+            b => b.name === 'fake-bucket-name',
           );
           assert.ok(reachableBucket);
           assert.strictEqual(reachableBucket.unreachable, false);
@@ -1208,7 +1208,7 @@ describe('Storage', () => {
           assert.strictEqual(unreachableBucket.unreachable, true);
           assert.deepStrictEqual(apiResponse, resp);
           done();
-        }
+        },
       );
     });
 
@@ -1218,7 +1218,7 @@ describe('Storage', () => {
 
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.qs.returnPartialSuccess, true);
         callback(null, resp);
@@ -1233,7 +1233,7 @@ describe('Storage', () => {
           assert.strictEqual(buckets[0].unreachable, true);
           assert.deepStrictEqual(buckets[0].metadata, {});
           done();
-        }
+        },
       );
     });
 
@@ -1242,7 +1242,7 @@ describe('Storage', () => {
 
       storage.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.qs.returnPartialSuccess, true);
         callback(null, resp);
@@ -1255,7 +1255,7 @@ describe('Storage', () => {
           assert.strictEqual(buckets.length, 0);
           assert.deepStrictEqual(apiResponse, resp);
           done();
-        }
+        },
       );
     });
   });
@@ -1297,7 +1297,7 @@ describe('Storage', () => {
         const firstArg = storage.request.firstCall.args[0];
         assert.strictEqual(
           firstArg.uri,
-          `/projects/${storage.projectId}/hmacKeys`
+          `/projects/${storage.projectId}/hmacKeys`,
         );
         assert.deepStrictEqual(firstArg.qs, {});
         done();
@@ -1316,7 +1316,7 @@ describe('Storage', () => {
         const firstArg = storage.request.firstCall.args[0];
         assert.strictEqual(
           firstArg.uri,
-          `/projects/${storage.projectId}/hmacKeys`
+          `/projects/${storage.projectId}/hmacKeys`,
         );
         assert.deepStrictEqual(firstArg.qs, query);
         done();
@@ -1339,7 +1339,7 @@ describe('Storage', () => {
           assert.strictEqual(nextQuery, null);
           assert.strictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -1361,7 +1361,7 @@ describe('Storage', () => {
           assert.ifError(err);
           assert.deepStrictEqual(nextQuery, expectedNextQuery);
           done();
-        }
+        },
       );
     });
 
@@ -1388,7 +1388,7 @@ describe('Storage', () => {
           assert.ifError(err);
           assert.deepStrictEqual(resp, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -1415,7 +1415,7 @@ describe('Storage', () => {
       storage.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.uri,
-          `/projects/${storage.projectId}/serviceAccount`
+          `/projects/${storage.projectId}/serviceAccount`,
         );
         assert.deepStrictEqual(reqOpts.qs, {});
         done();
@@ -1445,7 +1445,7 @@ describe('Storage', () => {
       beforeEach(() => {
         storage.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(ERROR, API_RESPONSE);
         };
@@ -1458,7 +1458,7 @@ describe('Storage', () => {
             assert.strictEqual(serviceAccount, null);
             assert.strictEqual(apiResponse, API_RESPONSE);
             done();
-          }
+          },
         );
       });
     });
@@ -1469,7 +1469,7 @@ describe('Storage', () => {
       beforeEach(() => {
         storage.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, API_RESPONSE);
         };
@@ -1482,7 +1482,7 @@ describe('Storage', () => {
 
         storage.request = (
           reqOpts: DecorateRequestOptions,
-          callback: Function
+          callback: Function,
         ) => {
           callback(null, apiResponse);
         };
@@ -1490,16 +1490,16 @@ describe('Storage', () => {
         storage.getServiceAccount(
           (
             err: Error,
-            serviceAccount: {[index: string]: string | undefined}
+            serviceAccount: {[index: string]: string | undefined},
           ) => {
             assert.ifError(err);
             assert.strictEqual(
               serviceAccount.snakeCase,
-              apiResponse.snake_case
+              apiResponse.snake_case,
             );
             assert.strictEqual(serviceAccount.snake_case, undefined);
             done();
-          }
+          },
         );
       });
 
@@ -1510,7 +1510,7 @@ describe('Storage', () => {
             assert.deepStrictEqual(serviceAccount, {});
             assert.strictEqual(apiResponse, API_RESPONSE);
             done();
-          }
+          },
         );
       });
     });
@@ -1523,7 +1523,7 @@ describe('Storage', () => {
 
     it('should default protocol to https', () => {
       const endpoint = Storage.sanitizeEndpoint(
-        USER_DEFINED_SHORT_API_ENDPOINT
+        USER_DEFINED_SHORT_API_ENDPOINT,
       );
       assert.strictEqual(endpoint.match(PROTOCOL_REGEX)![1], 'https');
     });
@@ -1532,7 +1532,7 @@ describe('Storage', () => {
       const endpoint = Storage.sanitizeEndpoint(USER_DEFINED_FULL_API_ENDPOINT);
       assert.strictEqual(
         endpoint.match(PROTOCOL_REGEX)![1],
-        USER_DEFINED_PROTOCOL
+        USER_DEFINED_PROTOCOL,
       );
     });
 

--- a/handwritten/storage/test/nodejs-common/service-object.ts
+++ b/handwritten/storage/test/nodejs-common/service-object.ts
@@ -55,7 +55,7 @@ type FakeServiceObject = any;
 interface InternalServiceObject {
   request_: (
     reqOpts: DecorateRequestOptions,
-    callback?: BodyResponseCallback
+    callback?: BodyResponseCallback,
   ) => void | r.Request;
   createMethod?: Function;
   methods: SO.Methods;
@@ -63,7 +63,7 @@ interface InternalServiceObject {
 }
 
 function asInternal(
-  serviceObject: SO.ServiceObject<InternalServiceObject, SO.BaseMetadata>
+  serviceObject: SO.ServiceObject<InternalServiceObject, SO.BaseMetadata>,
 ) {
   return serviceObject as {} as InternalServiceObject;
 }
@@ -112,7 +112,7 @@ describe('ServiceObject', () => {
     it('should localize the createMethod', () => {
       assert.strictEqual(
         asInternal(serviceObject).createMethod,
-        CONFIG.createMethod
+        CONFIG.createMethod,
       );
     });
 
@@ -152,7 +152,7 @@ describe('ServiceObject', () => {
       const serviceObject = new ServiceObject(config);
       assert.strictEqual(
         typeof serviceObject.getRequestInterceptors,
-        'function'
+        'function',
       );
     });
   });
@@ -165,7 +165,7 @@ describe('ServiceObject', () => {
       function createMethod(
         id: string,
         options_: {},
-        callback: (err: Error | null, a: {}, b: {}) => void
+        callback: (err: Error | null, a: {}, b: {}) => void,
       ) {
         assert.strictEqual(id, config.id);
         assert.strictEqual(options_, options);
@@ -197,7 +197,7 @@ describe('ServiceObject', () => {
       function createMethod(
         id: string,
         options_: {},
-        callback: (err: Error | null, a: {}, b: {}) => void
+        callback: (err: Error | null, a: {}, b: {}) => void,
       ) {
         assert.strictEqual(id, config.id);
         assert.strictEqual(options_, options);
@@ -227,7 +227,7 @@ describe('ServiceObject', () => {
           assert.strictEqual(instance, null);
           assert.strictEqual(apiResponse_, apiResponse);
           done();
-        }
+        },
       );
     });
 
@@ -324,7 +324,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.delete,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.uri, 'v2');
           assert.deepStrictEqual(opts.method, 'PATCH');
@@ -392,7 +392,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.delete,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.qs, {
             defaultProperty: true,
@@ -499,7 +499,7 @@ describe('ServiceObject', () => {
         (options_: SO.GetMetadataOptions): void => {
           assert.deepStrictEqual(options, options_);
           done();
-        }
+        },
       );
       serviceObject.exists(options, assert.ifError);
     });
@@ -518,10 +518,10 @@ describe('ServiceObject', () => {
       serviceObject.getMetadata = promisify(
         (
           options: SO.GetMetadataOptions,
-          callback: SO.MetadataCallback<SO.BaseMetadata>
+          callback: SO.MetadataCallback<SO.BaseMetadata>,
         ) => {
           callback(error, metadata);
-        }
+        },
       );
 
       serviceObject.get((err, instance, metadata_) => {
@@ -539,10 +539,10 @@ describe('ServiceObject', () => {
       serviceObject.getMetadata = promisify(
         (
           options: SO.GetMetadataOptions,
-          callback: SO.MetadataCallback<SO.BaseMetadata>
+          callback: SO.MetadataCallback<SO.BaseMetadata>,
         ) => {
           callback(null, metadata);
-        }
+        },
       );
 
       serviceObject.get((err, instance, metadata_) => {
@@ -570,10 +570,10 @@ describe('ServiceObject', () => {
         serviceObject.getMetadata = promisify(
           (
             options: SO.GetMetadataOptions,
-            callback: SO.MetadataCallback<SO.BaseMetadata>
+            callback: SO.MetadataCallback<SO.BaseMetadata>,
           ) => {
             callback(ERROR, METADATA);
-          }
+          },
         );
       });
 
@@ -622,7 +622,7 @@ describe('ServiceObject', () => {
                 callback!(null); // done()
               });
               callback!(error, null, apiResponse);
-            }
+            },
           );
 
           serviceObject.get(AUTO_CREATE_CONFIG, (err, instance, resp) => {
@@ -656,7 +656,7 @@ describe('ServiceObject', () => {
       sandbox.stub(ServiceObject.prototype, 'request').callsFake(function (
         this: SO.ServiceObject<FakeServiceObject, SO.BaseMetadata>,
         reqOpts,
-        callback
+        callback,
       ) {
         const opts = reqOpts as r.OptionsWithUri;
         const cb = callback as BodyResponseCallback;
@@ -698,7 +698,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.getMetadata,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.uri, 'v2');
           done();
@@ -729,7 +729,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.getMetadata,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.qs, {
             defaultProperty: true,
@@ -820,7 +820,7 @@ describe('ServiceObject', () => {
 
       serviceObject.parent.getRequestInterceptors = () => {
         return serviceObject.parent.interceptors.map(
-          interceptor => interceptor.request
+          interceptor => interceptor.request,
         );
       };
 
@@ -841,21 +841,21 @@ describe('ServiceObject', () => {
       serviceObject.interceptors = [{request}];
 
       const originalParentInterceptors = [].slice.call(
-        serviceObject.parent.interceptors
+        serviceObject.parent.interceptors,
       );
       const originalLocalInterceptors = [].slice.call(
-        serviceObject.interceptors
+        serviceObject.interceptors,
       );
 
       serviceObject.getRequestInterceptors();
 
       assert.deepStrictEqual(
         serviceObject.parent.interceptors,
-        originalParentInterceptors
+        originalParentInterceptors,
       );
       assert.deepStrictEqual(
         serviceObject.interceptors,
-        originalLocalInterceptors
+        originalLocalInterceptors,
       );
     });
 
@@ -882,7 +882,7 @@ describe('ServiceObject', () => {
       sandbox.stub(ServiceObject.prototype, 'request').callsFake(function (
         this: SO.ServiceObject<FakeServiceObject, SO.BaseMetadata>,
         reqOpts,
-        callback
+        callback,
       ) {
         const opts = reqOpts as r.OptionsWithUri;
         const cb = callback as BodyResponseCallback;
@@ -927,7 +927,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.setMetadata,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.uri, 'v2');
           assert.deepStrictEqual(opts.method, 'PUT');
@@ -958,7 +958,7 @@ describe('ServiceObject', () => {
           const cb = callback as BodyResponseCallback;
           assert.deepStrictEqual(
             serviceObject.methods.setMetadata,
-            cachedMethodConfig
+            cachedMethodConfig,
           );
           assert.deepStrictEqual(opts.qs, {
             defaultProperty: true,
@@ -976,7 +976,7 @@ describe('ServiceObject', () => {
         {
           optionalProperty: true,
           thisPropertyWasOverridden: true,
-        }
+        },
       );
     });
 
@@ -1080,7 +1080,7 @@ describe('ServiceObject', () => {
         uri: '//1/2//',
       };
       const expectedUri = [serviceObject.baseUrl, serviceObject.id, '1/2'].join(
-        '/'
+        '/',
       );
       serviceObject.parent.request = (reqOpts_, callback) => {
         assert.strictEqual(reqOpts_.uri, expectedUri);
@@ -1113,20 +1113,20 @@ describe('ServiceObject', () => {
       sandbox
         .stub(
           parent.parent as SO.ServiceObject<FakeServiceObject, SO.BaseMetadata>,
-          'request'
+          'request',
         )
         .callsFake((reqOpts, callback) => {
           assert.deepStrictEqual(
             reqOpts.interceptors_![0].request({} as DecorateRequestOptions),
             {
               child: true,
-            }
+            },
           );
           assert.deepStrictEqual(
             reqOpts.interceptors_![1].request({} as DecorateRequestOptions),
             {
               parent: true,
-            }
+            },
           );
           callback(null, null, {} as r.Response);
         });
@@ -1148,7 +1148,7 @@ describe('ServiceObject', () => {
           asInternal(serviceObject).interceptors;
         assert.deepStrictEqual(
           reqOpts.interceptors_,
-          serviceObjectInterceptors
+          serviceObjectInterceptors,
         );
         assert.notStrictEqual(reqOpts.interceptors_, serviceObjectInterceptors);
         callback(null, null, {} as r.Response);

--- a/handwritten/storage/test/nodejs-common/service.ts
+++ b/handwritten/storage/test/nodejs-common/service.ts
@@ -45,12 +45,12 @@ const makeAuthRequestFactoryCache = util.makeAuthenticatedRequestFactory;
 let makeAuthenticatedRequestFactoryOverride:
   | null
   | ((
-      config: MakeAuthenticatedRequestFactoryConfig
+      config: MakeAuthenticatedRequestFactoryConfig,
     ) => MakeAuthenticatedRequest);
 
 util.makeAuthenticatedRequestFactory = function (
   this: Util,
-  config: MakeAuthenticatedRequestFactoryConfig
+  config: MakeAuthenticatedRequestFactoryConfig,
 ) {
   if (makeAuthenticatedRequestFactoryOverride) {
     return makeAuthenticatedRequestFactoryOverride.call(this, config);
@@ -101,7 +101,7 @@ describe('Service', () => {
       const authenticatedRequest = {} as MakeAuthenticatedRequest;
 
       makeAuthenticatedRequestFactoryOverride = (
-        config: MakeAuthenticatedRequestFactoryConfig
+        config: MakeAuthenticatedRequestFactoryConfig,
       ) => {
         const expectedConfig = {
           ...CONFIG,
@@ -296,7 +296,7 @@ describe('Service', () => {
       service.interceptors = [{request}];
 
       const originalGlobalInterceptors = [].slice.call(
-        service.globalInterceptors
+        service.globalInterceptors,
       );
       const originalLocalInterceptors = [].slice.call(service.interceptors);
 
@@ -304,7 +304,7 @@ describe('Service', () => {
 
       assert.deepStrictEqual(
         service.globalInterceptors,
-        originalGlobalInterceptors
+        originalGlobalInterceptors,
       );
       assert.deepStrictEqual(service.interceptors, originalLocalInterceptors);
     });
@@ -390,7 +390,7 @@ describe('Service', () => {
       const expectedUri = [service.baseUrl, reqOpts.uri].join('/');
       service.makeAuthenticatedRequest = (
         reqOpts_: DecorateRequestOptions,
-        callback: BodyResponseCallback
+        callback: BodyResponseCallback,
       ) => {
         assert.notStrictEqual(reqOpts_, reqOpts);
         assert.strictEqual(reqOpts_.uri, expectedUri);
@@ -464,7 +464,7 @@ describe('Service', () => {
       service.makeAuthenticatedRequest = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
           reqOpts.headers!['User-Agent'],
-          getUserAgentString()
+          getUserAgentString(),
         );
         done();
       };
@@ -478,7 +478,7 @@ describe('Service', () => {
         const r = new RegExp(
           `^gl-node/${process.versions.node} gccl/${
             pkg.version
-          }-${getModuleFormat()} gccl-invocation-id/(?<gcclInvocationId>[^W]+)$`
+          }-${getModuleFormat()} gccl-invocation-id/(?<gcclInvocationId>[^W]+)$`,
         );
         assert.ok(r.test(reqOpts.headers!['x-goog-api-client']));
         done();
@@ -494,7 +494,7 @@ describe('Service', () => {
         const r = new RegExp(
           `^gl-node/${process.versions.node} gccl/${
             pkg.version
-          }-${getModuleFormat()} gccl-invocation-id/(?<gcclInvocationId>[^W]+) gccl-gcs-cmd/${expected}$`
+          }-${getModuleFormat()} gccl-invocation-id/(?<gcclInvocationId>[^W]+) gccl-gcs-cmd/${expected}$`,
         );
         assert.ok(r.test(reqOpts.headers!['x-goog-api-client']));
         done();
@@ -502,7 +502,7 @@ describe('Service', () => {
 
       service.request_(
         {...reqOpts, [GCCL_GCS_CMD_KEY]: expected},
-        assert.ifError
+        assert.ifError,
       );
     });
 
@@ -515,7 +515,7 @@ describe('Service', () => {
           const expectedUri = [service.baseUrl, reqOpts.uri].join('/');
 
           service.makeAuthenticatedRequest = (
-            reqOpts_: DecorateRequestOptions
+            reqOpts_: DecorateRequestOptions,
           ) => {
             assert.strictEqual(reqOpts_.uri, expectedUri);
 
@@ -539,7 +539,7 @@ describe('Service', () => {
           ].join('/');
 
           service.makeAuthenticatedRequest = (
-            reqOpts_: DecorateRequestOptions
+            reqOpts_: DecorateRequestOptions,
           ) => {
             assert.strictEqual(reqOpts_.uri, expectedUri);
 
@@ -564,7 +564,7 @@ describe('Service', () => {
           ].join('/');
 
           service.makeAuthenticatedRequest = (
-            reqOpts_: DecorateRequestOptions
+            reqOpts_: DecorateRequestOptions,
           ) => {
             assert.strictEqual(reqOpts_.uri, expectedUri);
 
@@ -676,7 +676,7 @@ describe('Service', () => {
       const response = {body: {abc: '123'}, statusCode: 200};
       Service.prototype.request_ = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts, fakeOpts);
         callback(null, response.body, response);

--- a/handwritten/storage/test/nodejs-common/util.ts
+++ b/handwritten/storage/test/nodejs-common/util.ts
@@ -79,8 +79,8 @@ function fakeRequest() {
 fakeRequest.defaults = (defaults: r.CoreOptions) => {
   assert.ok(
     /^gl-node\/(?<nodeVersion>[^W]+) gccl\/(?<gccl>[^W]+) gccl-invocation-id\/(?<gcclInvocationId>[^W]+)$/.test(
-      defaults.headers!['x-goog-api-client']
-    )
+      defaults.headers!['x-goog-api-client'],
+    ),
   );
   return fakeRequest;
 };
@@ -97,7 +97,7 @@ function fakeReplaceProjectIdToken() {
   return (replaceProjectIdTokenOverride || replaceProjectIdToken).apply(
     null,
     // eslint-disable-next-line prefer-spread, prefer-rest-params
-    arguments
+    arguments,
   );
 }
 
@@ -116,7 +116,7 @@ describe('common/util', () => {
 
     errors = errors.map((error, i) => `    ${i + 1}. ${error}`);
     errors.unshift(
-      'Multiple errors occurred during the request. Please see the `errors` array for complete details.\n'
+      'Multiple errors occurred during the request. Please see the `errors` array for complete details.\n',
     );
     errors.push('\n');
 
@@ -371,7 +371,7 @@ describe('common/util', () => {
           assert.deepStrictEqual(body, fakeResponse.body);
           assert.deepStrictEqual(resp, fakeResponse);
           done();
-        }
+        },
       );
     });
 
@@ -441,7 +441,7 @@ describe('common/util', () => {
           }
 
           done();
-        }
+        },
       );
     });
   });
@@ -514,20 +514,20 @@ describe('common/util', () => {
           assert.strictEqual(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (mp[0] as any)['Content-Type'],
-            'application/json'
+            'application/json',
           );
           assert.strictEqual(mp[0].body, JSON.stringify(metadata));
 
           assert.strictEqual(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (mp[1] as any)['Content-Type'],
-            'application/octet-stream'
+            'application/octet-stream',
           );
           // (is a writable stream:)
           assert.strictEqual(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             typeof (mp[1].body as any)._writableState,
-            'object'
+            'object',
           );
 
           done();
@@ -622,7 +622,7 @@ describe('common/util', () => {
 
       requestOverride = (
         reqOpts: DecorateRequestOptions,
-        callback: (err: Error) => void
+        callback: (err: Error) => void,
       ) => {
         callback(error);
       };
@@ -657,7 +657,7 @@ describe('common/util', () => {
 
       requestOverride = (
         reqOpts: DecorateRequestOptions,
-        callback: (err: Error | null, res: r.Response) => void
+        callback: (err: Error | null, res: r.Response) => void,
       ) => {
         callback(null, fakeResponse);
       };
@@ -692,7 +692,7 @@ describe('common/util', () => {
 
       requestOverride = (
         reqOpts: DecorateRequestOptions,
-        callback: () => void
+        callback: () => void,
       ) => {
         callback();
       };
@@ -790,7 +790,7 @@ describe('common/util', () => {
     it('should return a function', () => {
       assert.strictEqual(
         typeof util.makeAuthenticatedRequestFactory({}),
-        'function'
+        'function',
       );
     });
 
@@ -834,7 +834,7 @@ describe('common/util', () => {
         makeAuthenticatedRequest(fakeReqOpts, {
           onAuthenticated(
             err: Error,
-            authenticatedReqOpts: DecorateRequestOptions
+            authenticatedReqOpts: DecorateRequestOptions,
           ) {
             assert.ifError(err);
             assert.strictEqual(authenticatedReqOpts, decoratedRequest);
@@ -861,7 +861,7 @@ describe('common/util', () => {
         makeAuthenticatedRequest(reqOpts, {
           onAuthenticated(
             err: Error,
-            authenticatedReqOpts: DecorateRequestOptions
+            authenticatedReqOpts: DecorateRequestOptions,
           ) {
             assert.ifError(err);
             assert.deepStrictEqual(reqOpts, authenticatedReqOpts);
@@ -955,7 +955,7 @@ describe('common/util', () => {
           });
 
           const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
-            {customEndpoint: true}
+            {customEndpoint: true},
           );
 
           makeAuthenticatedRequest(reqOpts, {
@@ -1056,7 +1056,7 @@ describe('common/util', () => {
         it('should attempt request anyway', done => {
           sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
           const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
-            {}
+            {},
           );
 
           const correctReqOpts = {} as DecorateRequestOptions;
@@ -1078,7 +1078,7 @@ describe('common/util', () => {
 
         it('should block 401 API errors', done => {
           const authClientError = new Error(
-            'Could not load the default credentials'
+            'Could not load the default credentials',
           );
           authClient.authorizeRequest = async () => {
             throw authClientError;
@@ -1094,7 +1094,7 @@ describe('common/util', () => {
           });
 
           const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
-            {}
+            {},
           );
           makeAuthenticatedRequest(
             {} as DecorateRequestOptions,
@@ -1103,7 +1103,7 @@ describe('common/util', () => {
               assert.strictEqual(arg2, makeRequestArg2);
               assert.strictEqual(arg3, makeRequestArg3);
               done();
-            }
+            },
           );
         });
 
@@ -1122,7 +1122,7 @@ describe('common/util', () => {
           });
 
           const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
-            {}
+            {},
           );
           makeAuthenticatedRequest(
             {} as DecorateRequestOptions,
@@ -1131,7 +1131,7 @@ describe('common/util', () => {
               assert.strictEqual(arg2, makeRequestArg2);
               assert.strictEqual(arg3, makeRequestArg3);
               done();
-            }
+            },
           );
         });
 
@@ -1143,7 +1143,7 @@ describe('common/util', () => {
           });
 
           const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
-            {}
+            {},
           );
           makeAuthenticatedRequest(fakeReqOpts, {
             onAuthenticated(err) {
@@ -1250,7 +1250,7 @@ describe('common/util', () => {
           const mar = util.makeAuthenticatedRequestFactory({});
           const authenticatedRequest = mar(
             reqOpts,
-            assert.ifError
+            assert.ifError,
           ) as Abortable;
 
           authenticatedRequest.abort(); // done()
@@ -1392,7 +1392,7 @@ describe('common/util', () => {
     function testNoRetryRequestConfig(done: () => void) {
       return (
         reqOpts: DecorateRequestOptions,
-        config: retryRequest.Options
+        config: retryRequest.Options,
       ) => {
         assert.strictEqual(config.retries, 0);
         done();
@@ -1411,27 +1411,27 @@ describe('common/util', () => {
     function testRetryOptions(done: () => void) {
       return (
         reqOpts: DecorateRequestOptions,
-        config: retryRequest.Options
+        config: retryRequest.Options,
       ) => {
         assert.strictEqual(
           config.retries,
-          0 //autoRetry was set to false, so shouldn't retry
+          0, //autoRetry was set to false, so shouldn't retry
         );
         assert.strictEqual(
           config.noResponseRetries,
-          0 //autoRetry was set to false, so shouldn't retry
+          0, //autoRetry was set to false, so shouldn't retry
         );
         assert.strictEqual(
           config.retryDelayMultiplier,
-          retryOptionsConfig.retryOptions.retryDelayMultiplier
+          retryOptionsConfig.retryOptions.retryDelayMultiplier,
         );
         assert.strictEqual(
           config.totalTimeout,
-          retryOptionsConfig.retryOptions.totalTimeout
+          retryOptionsConfig.retryOptions.totalTimeout,
         );
         assert.strictEqual(
           config.maxRetryDelay,
-          retryOptionsConfig.retryOptions.maxRetryDelay
+          retryOptionsConfig.retryOptions.maxRetryDelay,
         );
         done();
       };
@@ -1547,7 +1547,7 @@ describe('common/util', () => {
           util.makeRequest(
             {method: 'POST'} as DecorateRequestOptions,
             {stream: userStream},
-            util.noop
+            util.noop,
           );
         });
 
@@ -1560,7 +1560,7 @@ describe('common/util', () => {
               requestStream.abort = done;
               return requestStream;
             },
-            {defaults: () => requestOverride}
+            {defaults: () => requestOverride},
           );
 
           util.makeRequest(reqOpts, {stream: userStream}, util.noop);
@@ -1576,7 +1576,7 @@ describe('common/util', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           reqOpts,
           {},
-          assert.ifError
+          assert.ifError,
         );
       });
 
@@ -1585,7 +1585,7 @@ describe('common/util', () => {
         util.makeRequest(
           reqOpts,
           customRetryRequestFunctionConfig,
-          assert.ifError
+          assert.ifError,
         );
       });
 
@@ -1613,7 +1613,7 @@ describe('common/util', () => {
         util.makeRequest(
           reqOptsWithRetrySettings,
           noRetryRequestConfig,
-          assert.ifError
+          assert.ifError,
         );
       });
 
@@ -1633,7 +1633,7 @@ describe('common/util', () => {
         retryRequestOverride = (
           rOpts: DecorateRequestOptions,
           opts: MakeRequestConfig,
-          callback: r.RequestCallback
+          callback: r.RequestCallback,
         ) => {
           callback(error, fakeResponse, body);
         };
@@ -1657,7 +1657,7 @@ describe('common/util', () => {
         {
           autoPaginate: true,
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.autoPaginate, undefined);
@@ -1668,7 +1668,7 @@ describe('common/util', () => {
         {
           autoPaginateVal: true,
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.autoPaginateVal, undefined);
@@ -1679,7 +1679,7 @@ describe('common/util', () => {
         {
           objectMode: true,
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.objectMode, undefined);
@@ -1692,7 +1692,7 @@ describe('common/util', () => {
             autoPaginate: true,
           },
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.qs.autoPaginate, undefined);
@@ -1705,7 +1705,7 @@ describe('common/util', () => {
             autoPaginateVal: true,
           },
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.qs.autoPaginateVal, undefined);
@@ -1718,7 +1718,7 @@ describe('common/util', () => {
             autoPaginate: true,
           },
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.json.autoPaginate, undefined);
@@ -1731,7 +1731,7 @@ describe('common/util', () => {
             autoPaginateVal: true,
           },
         } as DecorateRequestOptions,
-        projectId
+        projectId,
       );
 
       assert.strictEqual(decoratedReqOpts.json.autoPaginateVal, undefined);
@@ -1817,7 +1817,7 @@ describe('common/util', () => {
       const decoratedRequest = util.decorateRequest(reqOpts, projectId);
       assert.strictEqual(
         (decoratedRequest.headers as any)['Content-Type'],
-        'application/json'
+        'application/json',
       );
     });
 
@@ -1837,7 +1837,7 @@ describe('common/util', () => {
       const decoratedRequest = util.decorateRequest(reqOpts as any, projectId);
       assert.strictEqual(
         (decoratedRequest.headers as any).get('Content-Type'),
-        'application/json'
+        'application/json',
       );
     });
 
@@ -1855,11 +1855,11 @@ describe('common/util', () => {
       const decoratedRequest = util.decorateRequest(reqOpts, projectId);
       assert.strictEqual(
         (decoratedRequest.headers as any)['content-type'],
-        'application/x-protobuf'
+        'application/x-protobuf',
       );
       assert.strictEqual(
         (decoratedRequest.headers as any)['Content-Type'],
-        undefined
+        undefined,
       );
     });
 
@@ -1942,7 +1942,7 @@ describe('common/util', () => {
       const callback = () => {};
       const [opts, cb] = util.maybeOptionsOrCallback(
         optionsOrCallback,
-        callback
+        callback,
       );
       assert.strictEqual(opts, optionsOrCallback);
       assert.strictEqual(cb, callback);

--- a/handwritten/storage/test/notification.ts
+++ b/handwritten/storage/test/notification.ts
@@ -140,7 +140,7 @@ describe('Notification', () => {
 
       BUCKET.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.strictEqual(reqOpts.method, 'DELETE');
         assert.strictEqual(reqOpts.uri, 'notificationConfigs/123');
@@ -154,7 +154,7 @@ describe('Notification', () => {
     it('should optionally accept options', done => {
       BUCKET.request = (
         reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         assert.deepStrictEqual(reqOpts.qs, {});
         callback(); // the done fn
@@ -166,7 +166,7 @@ describe('Notification', () => {
     it('should optionally accept a callback', done => {
       BUCKET.request = (
         _reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(); // the done fn
       };
@@ -250,7 +250,7 @@ describe('Notification', () => {
           {},
           {
             maxResults: 5,
-          }
+          },
         );
 
         notification.get = (config_: {}) => {
@@ -290,7 +290,7 @@ describe('Notification', () => {
               assert.strictEqual(instance, null);
               assert.strictEqual(resp, apiResponse);
               done();
-            }
+            },
           );
         });
 
@@ -342,7 +342,7 @@ describe('Notification', () => {
 
       BUCKET.request = (
         _reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(error, response, response);
       };
@@ -360,7 +360,7 @@ describe('Notification', () => {
 
       BUCKET.request = (
         _reqOpts: DecorateRequestOptions,
-        callback: Function
+        callback: Function,
       ) => {
         callback(null, response, response);
       };

--- a/handwritten/storage/test/resumable-upload.ts
+++ b/handwritten/storage/test/resumable-upload.ts
@@ -66,7 +66,7 @@ function mockAuthorizeRequest(
   code = 200,
   data: {} | string = {
     access_token: 'abc123',
-  }
+  },
 ) {
   return nock('https://www.googleapis.com')
     .post('/oauth2/v4/token')
@@ -184,7 +184,7 @@ describe('resumable-upload', () => {
       });
       assert.strictEqual(
         upWithZeroGeneration.cacheKey,
-        [BUCKET, FILE, 0].join('/')
+        [BUCKET, FILE, 0].join('/'),
       );
     });
 
@@ -533,7 +533,7 @@ describe('resumable-upload', () => {
 
       assert.equal(
         Buffer.compare(Buffer.concat(up.writeBuffers), Buffer.from('abcdef')),
-        0
+        0,
       );
     });
 
@@ -584,7 +584,7 @@ describe('resumable-upload', () => {
     it('should keep the desired last few bytes', () => {
       up.localWriteCache = [Buffer.from('123'), Buffer.from('456')];
       up.localWriteCacheByteLength = up.localWriteCache.reduce(
-        (a: Buffer, b: number) => a.byteLength + b
+        (a: Buffer, b: number) => a.byteLength + b,
       );
       up.writeBuffers = [Buffer.from('789')];
 
@@ -1079,7 +1079,7 @@ describe('resumable-upload', () => {
           assert.equal(data.contentLength, 24);
 
           done();
-        }
+        },
       );
 
       up.makeRequestStream = async (reqOpts: GaxiosOptions) => {
@@ -1168,10 +1168,10 @@ describe('resumable-upload', () => {
           assert(reqOpts.headers);
           assert.equal(
             reqOpts.headers['Content-Range'],
-            `bytes ${OFFSET}-*/${CONTENT_LENGTH}`
+            `bytes ${OFFSET}-*/${CONTENT_LENGTH}`,
           );
           assert.ok(
-            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
           );
           assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
 
@@ -1188,7 +1188,7 @@ describe('resumable-upload', () => {
           assert(reqOpts.headers);
           assert.equal(reqOpts.headers['Content-Range'], 'bytes 0-*/*');
           assert.ok(
-            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
           );
           assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
 
@@ -1219,10 +1219,10 @@ describe('resumable-upload', () => {
           assert.equal(reqOpts.headers['Content-Length'], CHUNK_SIZE);
           assert.equal(
             reqOpts.headers['Content-Range'],
-            `bytes ${OFFSET}-${endByte}/${CONTENT_LENGTH}`
+            `bytes ${OFFSET}-${endByte}/${CONTENT_LENGTH}`,
           );
           assert.ok(
-            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
           );
           assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
 
@@ -1235,7 +1235,7 @@ describe('resumable-upload', () => {
           const OFFSET = 100;
           const EXPECTED_STREAM_AMOUNT = Math.min(
             UPSTREAM_BUFFER_SIZE - OFFSET,
-            CHUNK_SIZE
+            CHUNK_SIZE,
           );
           const ENDING_BYTE = EXPECTED_STREAM_AMOUNT + OFFSET - 1;
 
@@ -1247,14 +1247,14 @@ describe('resumable-upload', () => {
           assert(reqOpts.headers);
           assert.equal(
             reqOpts.headers['Content-Length'],
-            EXPECTED_STREAM_AMOUNT
+            EXPECTED_STREAM_AMOUNT,
           );
           assert.equal(
             reqOpts.headers['Content-Range'],
-            `bytes ${OFFSET}-${ENDING_BYTE}/*`
+            `bytes ${OFFSET}-${ENDING_BYTE}/*`,
           );
           assert.ok(
-            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
           );
           assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
 
@@ -1278,14 +1278,14 @@ describe('resumable-upload', () => {
           assert(reqOpts.headers);
           assert.equal(
             reqOpts.headers['Content-Length'],
-            CONTENT_LENGTH - NUM_BYTES_WRITTEN
+            CONTENT_LENGTH - NUM_BYTES_WRITTEN,
           );
           assert.equal(
             reqOpts.headers['Content-Range'],
-            `bytes ${OFFSET}-${endByte}/${CONTENT_LENGTH}`
+            `bytes ${OFFSET}-${endByte}/${CONTENT_LENGTH}`,
           );
           assert.ok(
-            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+            X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
           );
           assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
           const data = await getAllDataFromRequest();
@@ -1309,7 +1309,7 @@ describe('resumable-upload', () => {
        */
       function createMockHashValidator(
         crc32cEnabled: boolean,
-        md5Enabled: boolean
+        md5Enabled: boolean,
       ) {
         const mockValidator = {
           crc32cEnabled: crc32cEnabled,
@@ -1351,7 +1351,10 @@ describe('resumable-upload', () => {
        * @param configOptions Partial UploadConfig to apply.
        */
       function setupHashUploadInstance(
-        configOptions: Partial<UploadConfig> & {crc32c?: boolean; md5?: boolean}
+        configOptions: Partial<UploadConfig> & {
+          crc32c?: boolean;
+          md5?: boolean;
+        },
       ) {
         up = upload({
           bucket: BUCKET,
@@ -1374,7 +1377,7 @@ describe('resumable-upload', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (up as any)['#hashValidator'] = createMockHashValidator(
             !!calculateCrc32c,
-            !!calculateMd5
+            !!calculateMd5,
           );
         }
       }
@@ -1385,13 +1388,13 @@ describe('resumable-upload', () => {
         data: Buffer,
         isMultiChunk: boolean,
         expectedCrc32c?: string,
-        expectedMd5?: string
+        expectedMd5?: string,
       ): Promise<GaxiosOptions[]> {
         const capturedReqOpts: GaxiosOptions[] = [];
         requestCount = 0;
 
         uploadInstance.makeRequestStream = async (
-          requestOptions: GaxiosOptions
+          requestOptions: GaxiosOptions,
         ) => {
           requestCount++;
           capturedReqOpts.push(requestOptions);
@@ -1455,7 +1458,7 @@ describe('resumable-upload', () => {
           assert.strictEqual(reqOpts.length, 1);
           assert.equal(
             reqOpts[0].headers!['X-Goog-Hash'],
-            `crc32c=${CALCULATED_CRC32C}`
+            `crc32c=${CALCULATED_CRC32C}`,
           );
         });
 
@@ -1465,7 +1468,7 @@ describe('resumable-upload', () => {
           assert.strictEqual(reqOpts.length, 1);
           assert.equal(
             reqOpts[0].headers!['X-Goog-Hash'],
-            `md5=${CALCULATED_MD5}`
+            `md5=${CALCULATED_MD5}`,
           );
         });
 
@@ -1492,12 +1495,12 @@ describe('resumable-upload', () => {
             up,
             DUMMY_CONTENT,
             false,
-            customCrc32c
+            customCrc32c,
           );
           assert.strictEqual(reqOpts.length, 1);
           assert.strictEqual(
             reqOpts[0].headers!['X-Goog-Hash'],
-            `crc32c=${customCrc32c}`
+            `crc32c=${customCrc32c}`,
           );
         });
 
@@ -1509,12 +1512,12 @@ describe('resumable-upload', () => {
             DUMMY_CONTENT,
             false,
             undefined,
-            customMd5
+            customMd5,
           );
           assert.strictEqual(reqOpts.length, 1);
           assert.strictEqual(
             reqOpts[0].headers!['X-Goog-Hash'],
-            `md5=${customMd5}`
+            `md5=${customMd5}`,
           );
         });
 
@@ -1759,13 +1762,13 @@ describe('resumable-upload', () => {
         assert.equal(up.offset, lastByteReceived + 1);
         assert.equal(
           Buffer.concat(up.writeBuffers).byteLength,
-          UPSTREAM_BUFFER_LENGTH + expectedUnshiftAmount
+          UPSTREAM_BUFFER_LENGTH + expectedUnshiftAmount,
         );
         assert.equal(
           Buffer.concat(up.writeBuffers)
             .subarray(0, expectedUnshiftAmount)
             .toString(),
-          'a'.repeat(expectedUnshiftAmount)
+          'a'.repeat(expectedUnshiftAmount),
         );
 
         // we should discard part of the last chunk, as we know what the server
@@ -1809,7 +1812,7 @@ describe('resumable-upload', () => {
     await up.getAndSetOffset();
     assert.notEqual(
       beforeCallInvocationId,
-      up.currentInvocationId.checkUploadStatus
+      up.currentInvocationId.checkUploadStatus,
     );
   });
 
@@ -1818,7 +1821,7 @@ describe('resumable-upload', () => {
     up.destroy = () => {
       assert.equal(
         beforeCallInvocationId,
-        up.currentInvocationId.checkUploadStatus
+        up.currentInvocationId.checkUploadStatus,
       );
       done();
     };
@@ -1843,7 +1846,7 @@ describe('resumable-upload', () => {
         assert.equal(reqOpts.headers['Content-Length'], 0);
         assert.equal(reqOpts.headers['Content-Range'], 'bytes */*');
         assert.ok(
-          X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
+          X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client']),
         );
         assert.ok(USER_AGENT_REGEX.test(reqOpts.headers['User-Agent']));
         done();
@@ -1904,7 +1907,7 @@ describe('resumable-upload', () => {
       assert.strictEqual(headers['x-goog-encryption-key'], up.encryption.key);
       assert.strictEqual(
         headers['x-goog-encryption-key-sha256'],
-        up.encryption.hash
+        up.encryption.hash,
       );
     });
 
@@ -2287,7 +2290,7 @@ describe('resumable-upload', () => {
         up.destroy = (err: Error) => {
           assert.strictEqual(
             err.message,
-            `Retry limit exceeded - ${JSON.stringify(RESP.data)}`
+            `Retry limit exceeded - ${JSON.stringify(RESP.data)}`,
           );
           done();
         };
@@ -2328,7 +2331,7 @@ describe('resumable-upload', () => {
             assert.strictEqual(up.numRetries, 3);
             assert.strictEqual(
               err.message,
-              `Retry limit exceeded - ${JSON.stringify(RESP.data)}`
+              `Retry limit exceeded - ${JSON.stringify(RESP.data)}`,
             );
             done();
           });
@@ -2423,7 +2426,7 @@ describe('resumable-upload', () => {
         assert.equal(up.localWriteCache.length, 0);
         assert.equal(
           Buffer.concat(up.writeBuffers).toString(),
-          'a'.repeat(12) + 'b'.repeat(10)
+          'a'.repeat(12) + 'b'.repeat(10),
         );
         assert.equal(up.offset, undefined);
 
@@ -2504,7 +2507,7 @@ describe('resumable-upload', () => {
         assert.strictEqual(
           url.input.match(PROTOCOL_REGEX) &&
             url.input.match(PROTOCOL_REGEX)![1],
-          url.match
+          url.match,
         );
       }
     });
@@ -2524,7 +2527,7 @@ describe('resumable-upload', () => {
       const endpoint = up.sanitizeEndpoint(USER_DEFINED_FULL_API_ENDPOINT);
       assert.strictEqual(
         endpoint.match(PROTOCOL_REGEX)![1],
-        USER_DEFINED_PROTOCOL
+        USER_DEFINED_PROTOCOL,
       );
     });
 
@@ -2596,7 +2599,7 @@ describe('resumable-upload', () => {
 
         up.contentLength = CHUNK_SIZE_MULTIPLE * 8;
         up.createURI = (
-          callback: (error: Error | null, uri: string) => void
+          callback: (error: Error | null, uri: string) => void,
         ) => {
           up.uri = uri;
           up.offset = 0;
@@ -2714,12 +2717,12 @@ describe('resumable-upload', () => {
           assert(request.opts.headers);
           assert.equal(
             request.opts.headers['Content-Range'],
-            `bytes 0-*/${CONTENT_LENGTH}`
+            `bytes 0-*/${CONTENT_LENGTH}`,
           );
           assert.ok(
             X_GOOG_API_HEADER_REGEX.test(
-              request.opts.headers['x-goog-api-client']
-            )
+              request.opts.headers['x-goog-api-client'],
+            ),
           );
           assert.ok(USER_AGENT_REGEX.test(request.opts.headers['User-Agent']));
 
@@ -2740,7 +2743,7 @@ describe('resumable-upload', () => {
         up.chunkSize = CHUNK_SIZE_MULTIPLE;
         up.contentLength = CHUNK_SIZE_MULTIPLE * 8;
         up.createURI = (
-          callback: (error: Error | null, uri: string) => void
+          callback: (error: Error | null, uri: string) => void,
         ) => {
           up.uri = uri;
           up.offset = 0;
@@ -2882,19 +2885,19 @@ describe('resumable-upload', () => {
               assert(request.opts.headers);
               assert.equal(
                 request.opts.headers['Content-Length'],
-                LAST_REQUEST_SIZE
+                LAST_REQUEST_SIZE,
               );
               assert.equal(
                 request.opts.headers['Content-Range'],
-                `bytes ${offset}-${endByte}/${CONTENT_LENGTH}`
+                `bytes ${offset}-${endByte}/${CONTENT_LENGTH}`,
               );
               assert.ok(
                 X_GOOG_API_HEADER_REGEX.test(
-                  request.opts.headers['x-goog-api-client']
-                )
+                  request.opts.headers['x-goog-api-client'],
+                ),
               );
               assert.ok(
-                USER_AGENT_REGEX.test(request.opts.headers['User-Agent'])
+                USER_AGENT_REGEX.test(request.opts.headers['User-Agent']),
               );
             } else {
               // The preceding chunks
@@ -2905,15 +2908,15 @@ describe('resumable-upload', () => {
               assert.equal(request.opts.headers['Content-Length'], CHUNK_SIZE);
               assert.equal(
                 request.opts.headers['Content-Range'],
-                `bytes ${offset}-${endByte}/${CONTENT_LENGTH}`
+                `bytes ${offset}-${endByte}/${CONTENT_LENGTH}`,
               );
               assert.ok(
                 X_GOOG_API_HEADER_REGEX.test(
-                  request.opts.headers['x-goog-api-client']
-                )
+                  request.opts.headers['x-goog-api-client'],
+                ),
               );
               assert.ok(
-                USER_AGENT_REGEX.test(request.opts.headers['User-Agent'])
+                USER_AGENT_REGEX.test(request.opts.headers['User-Agent']),
               );
             }
           }
@@ -2934,7 +2937,7 @@ describe('resumable-upload', () => {
 
         up.contentLength = 0;
         up.createURI = (
-          callback: (error: Error | null, uri: string) => void
+          callback: (error: Error | null, uri: string) => void,
         ) => {
           up.uri = uri;
           up.offset = 0;
@@ -3006,12 +3009,12 @@ describe('resumable-upload', () => {
 
           assert.equal(
             request.opts.headers['Content-Range'],
-            `bytes 0-*/${CONTENT_LENGTH}`
+            `bytes 0-*/${CONTENT_LENGTH}`,
           );
           assert.ok(
             X_GOOG_API_HEADER_REGEX.test(
-              request.opts.headers['x-goog-api-client']
-            )
+              request.opts.headers['x-goog-api-client'],
+            ),
           );
           assert.ok(USER_AGENT_REGEX.test(request.opts.headers['User-Agent']));
 
@@ -3103,14 +3106,14 @@ describe('resumable-upload', () => {
           up.on('error', (err: Error) => {
             assert.strictEqual(
               err.message,
-              FileExceptionMessages.UPLOAD_MISMATCH
+              FileExceptionMessages.UPLOAD_MISMATCH,
             );
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const detailError = (err as any).errors && (err as any).errors[0];
             assert.ok(
               detailError && detailError.message.includes(scenario.errorPart!),
-              `Error message should contain: ${scenario.errorPart}`
+              `Error message should contain: ${scenario.errorPart}`,
             );
             assert.strictEqual(up.uri, URI);
             done();
@@ -3119,8 +3122,8 @@ describe('resumable-upload', () => {
           up.on('finish', () => {
             done(
               new Error(
-                `Upload should have failed due to ${scenario.type} mismatch, but emitted finish.`
-              )
+                `Upload should have failed due to ${scenario.type} mismatch, but emitted finish.`,
+              ),
             );
           });
         }

--- a/handwritten/storage/test/signer.ts
+++ b/handwritten/storage/test/signer.ts
@@ -141,7 +141,7 @@ describe('signer', () => {
           assert.strictEqual(v2arg.contentType, CONFIG.contentType);
           assert.deepStrictEqual(
             v2arg.extensionHeaders,
-            CONFIG.extensionHeaders
+            CONFIG.extensionHeaders,
           );
         });
 
@@ -169,7 +169,7 @@ describe('signer', () => {
           assert.strictEqual(v4arg.contentType, CONFIG.contentType);
           assert.deepStrictEqual(
             v4arg.extensionHeaders,
-            CONFIG.extensionHeaders
+            CONFIG.extensionHeaders,
           );
         });
 
@@ -179,7 +179,7 @@ describe('signer', () => {
 
           assert.throws(
             () => signer.getSignedUrl(CONFIG),
-            /Invalid signed URL version: v42\. Supported versions are 'v2' and 'v4'\./
+            /Invalid signed URL version: v42\. Supported versions are 'v2' and 'v4'\./,
           );
         });
       });
@@ -289,7 +289,7 @@ describe('signer', () => {
 
           assert(
             (v2.getCall(0).args[0] as SignedUrlArgs).expiration,
-            expiresInSeconds
+            expiresInSeconds,
           );
         });
       });
@@ -380,8 +380,8 @@ describe('signer', () => {
               qsStringify({
                 ...query,
                 ...CONFIG.queryParams,
-              })
-            )
+              }),
+            ),
           );
         });
       });
@@ -419,8 +419,8 @@ describe('signer', () => {
         const signedUrl = await signer.getSignedUrl(CONFIG);
         assert(
           signedUrl.startsWith(
-            `https://${bucket.name}.storage.googleapis.com/${file.name}`
-          )
+            `https://${bucket.name}.storage.googleapis.com/${file.name}`,
+          ),
         );
       });
 
@@ -547,7 +547,7 @@ describe('signer', () => {
               '',
               CONFIG.expiration,
               'canonical-headers' + '/resource/path',
-            ].join('\n')
+            ].join('\n'),
           );
         });
       });
@@ -597,7 +597,7 @@ describe('signer', () => {
           },
           {
             message: `Max allowed expiration is seven days (${SEVEN_DAYS} seconds).`,
-          }
+          },
         );
       });
 
@@ -618,10 +618,10 @@ describe('signer', () => {
             assert(err instanceof Error);
             assert.strictEqual(
               err.message,
-              `Max allowed expiration is seven days (${SEVEN_DAYS_IN_SECONDS.toString()} seconds).`
+              `Max allowed expiration is seven days (${SEVEN_DAYS_IN_SECONDS.toString()} seconds).`,
             );
             return true;
-          }
+          },
         );
       });
 
@@ -635,7 +635,7 @@ describe('signer', () => {
           const arg = getCanonicalHeaders.getCall(0).args[0];
           assert.strictEqual(
             arg.host,
-            PATH_STYLED_HOST.replace('https://', '')
+            PATH_STYLED_HOST.replace('https://', ''),
           );
         });
 
@@ -782,11 +782,11 @@ describe('signer', () => {
 
           assert.strictEqual(
             arg['X-Goog-SignedHeaders'],
-            'host;x-foo;x-goog-acl'
+            'host;x-foo;x-goog-acl',
           );
           assert.strictEqual(
             query['X-Goog-SignedHeaders'],
-            'host;x-foo;x-goog-acl'
+            'host;x-foo;x-goog-acl',
           );
         });
 
@@ -876,8 +876,8 @@ describe('signer', () => {
 
         assert(
           blobToSign.startsWith(
-            ['GOOG4-RSA-SHA256', dateISO, credentialScope].join('\n')
-          )
+            ['GOOG4-RSA-SHA256', dateISO, credentialScope].join('\n'),
+          ),
         );
       });
 
@@ -900,7 +900,7 @@ describe('signer', () => {
 
         const query = (await signer['getSignedUrlV4'](CONFIG)) as Query;
         const signatureInHex = Buffer.from('signature', 'base64').toString(
-          'hex'
+          'hex',
         );
         assert.strictEqual(query['X-Goog-Signature'], signatureInHex);
       });
@@ -974,7 +974,7 @@ describe('signer', () => {
           'query',
           'headers',
           'signedHeaders',
-          SHA
+          SHA,
         );
 
         const EXPECTED = [

--- a/handwritten/storage/test/transfer-manager.ts
+++ b/handwritten/storage/test/transfer-manager.ts
@@ -58,7 +58,7 @@ describe('Transfer Manager', () => {
         },
         idempotencyStrategy: IdempotencyStrategy.RetryConditional,
       },
-    })
+    }),
   );
   let sandbox: sinon.SinonSandbox;
   let transferManager: TransferManager;
@@ -109,7 +109,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(bucket, 'upload').callsFake((path, options) => {
         assert.strictEqual(
           (options as UploadOptions).preconditionOpts?.ifGenerationMatch,
-          0
+          0,
         );
       });
 
@@ -129,7 +129,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(bucket, 'upload').callsFake((path, options) => {
         assert.strictEqual(
           (options as UploadOptions).destination,
-          expectedDestination
+          expectedDestination,
         );
       });
 
@@ -148,7 +148,7 @@ describe('Transfer Manager', () => {
       const result = await transferManager.uploadManyFiles(paths);
       assert.strictEqual(
         result[0][0].name,
-        paths[0].split(path.sep).join(path.posix.sep)
+        paths[0].split(path.sep).join(path.posix.sep),
       );
     });
 
@@ -158,7 +158,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(bucket, 'upload').callsFake(async (_path, options) => {
         assert.strictEqual(
           (options as UploadOptions)[GCCL_GCS_CMD_KEY],
-          'tm.upload_many'
+          'tm.upload_many',
         );
       });
 
@@ -225,7 +225,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(file, 'download').callsFake(options => {
         assert.strictEqual(
           (options as DownloadOptions).destination,
-          expectedDestination
+          expectedDestination,
         );
       });
       await transferManager.downloadManyFiles([file], {prefix});
@@ -240,7 +240,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(file, 'download').callsFake(options => {
         assert.strictEqual(
           (options as DownloadOptions).destination,
-          expectedDestination
+          expectedDestination,
         );
       });
       await transferManager.downloadManyFiles([file], {stripPrefix});
@@ -252,7 +252,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(file, 'download').callsFake(async options => {
         assert.strictEqual(
           (options as DownloadOptions)[GCCL_GCS_CMD_KEY],
-          'tm.download_many'
+          'tm.download_many',
         );
       });
 
@@ -265,7 +265,7 @@ describe('Transfer Manager', () => {
       };
       const filename = 'first.txt';
       const expectedDestination = path.normalize(
-        `${passthroughOptions.destination}/${filename}`
+        `${passthroughOptions.destination}/${filename}`,
       );
       const download = (optionsOrCb?: DownloadOptions | DownloadCallback) => {
         if (typeof optionsOrCb === 'function') {
@@ -286,14 +286,14 @@ describe('Transfer Manager', () => {
       sandbox.stub(firstFile, 'download').callsFake(options => {
         assert.strictEqual(
           (options as DownloadManyFilesOptions).skipIfExists,
-          0
+          0,
         );
       });
       const secondFile = new File(bucket, 'second.txt');
       sandbox.stub(secondFile, 'download').callsFake(options => {
         assert.strictEqual(
           (options as DownloadManyFilesOptions).skipIfExists,
-          0
+          0,
         );
       });
 
@@ -346,7 +346,7 @@ describe('Transfer Manager', () => {
       });
       assert.strictEqual(
         mkdirSpy.calledWith(expectedDir, {recursive: true}),
-        true
+        true,
       );
     });
 
@@ -365,7 +365,7 @@ describe('Transfer Manager', () => {
 
       const result = (await transferManager.downloadManyFiles(
         [maliciousFile, validFile],
-        {passthroughOptions: {destination: destination}}
+        {passthroughOptions: {destination: destination}},
       )) as DownloadResponseWithStatus[];
 
       assert.strictEqual(maliciousDownloadStub.called, false);
@@ -413,7 +413,7 @@ describe('Transfer Manager', () => {
       const file = new File(bucket, filename);
       const expectedDestination = path.resolve(
         destination,
-        filename.replace(/^\/+/, '')
+        filename.replace(/^\/+/, ''),
       );
 
       const downloadStub = sandbox
@@ -437,7 +437,7 @@ describe('Transfer Manager', () => {
       const filename = '/etc/passwd';
       const expectedDestination = path.resolve(
         destination,
-        filename.replace(/^\/+/, '')
+        filename.replace(/^\/+/, ''),
       );
 
       const file = new File(bucket, filename);
@@ -467,7 +467,7 @@ describe('Transfer Manager', () => {
 
       const result = (await transferManager.downloadManyFiles(
         [file],
-        options
+        options,
       )) as DownloadResponseWithStatus[];
 
       assert.strictEqual(downloadStub.called, false);
@@ -526,7 +526,7 @@ describe('Transfer Manager', () => {
       assert.strictEqual(
         result.length,
         fileNames.length,
-        `Parity Failure: Processed ${result.length} files but input had ${fileNames.length}`
+        `Parity Failure: Processed ${result.length} files but input had ${fileNames.length}`,
       );
 
       const downloads = result.filter(r => !r.skipped);
@@ -539,22 +539,22 @@ describe('Transfer Manager', () => {
       assert.strictEqual(
         downloads.length,
         expectedDownloads,
-        `Expected ${expectedDownloads} downloads but got ${downloads.length}`
+        `Expected ${expectedDownloads} downloads but got ${downloads.length}`,
       );
 
       assert.strictEqual(
         skips.length,
         expectedSkips,
-        `Expected ${expectedSkips} skips but got ${skips.length}`
+        `Expected ${expectedSkips} skips but got ${skips.length}`,
       );
 
       const traversalSkips = skips.filter(
-        f => f.reason === SkipReason.PATH_TRAVERSAL
+        f => f.reason === SkipReason.PATH_TRAVERSAL,
       );
       assert.strictEqual(traversalSkips.length, expectedTraversalSkips);
 
       const illegalCharSkips = skips.filter(
-        f => f.reason === SkipReason.ILLEGAL_CHARACTER
+        f => f.reason === SkipReason.ILLEGAL_CHARACTER,
       );
       assert.strictEqual(illegalCharSkips.length, 2);
     });
@@ -655,7 +655,7 @@ describe('Transfer Manager', () => {
         transferManager.downloadFileInChunks(file, {validation: 'crc32c'}),
         {
           code: 'CONTENT_DOWNLOAD_MISMATCH',
-        }
+        },
       );
     });
 
@@ -663,7 +663,7 @@ describe('Transfer Manager', () => {
       sandbox.stub(file, 'download').callsFake(async options => {
         assert.strictEqual(
           (options as DownloadOptions)[GCCL_GCS_CMD_KEY],
-          'tm.download_sharded'
+          'tm.download_sharded',
         );
         return [Buffer.alloc(100)];
       });
@@ -704,7 +704,7 @@ describe('Transfer Manager', () => {
 
     before(async () => {
       directory = await fsp.mkdtemp(
-        path.join(tmpdir(), 'tm-uploadFileInChunks-')
+        path.join(tmpdir(), 'tm-uploadFileInChunks-'),
       );
 
       filePath = path.join(directory, 't.txt');
@@ -734,7 +734,7 @@ describe('Transfer Manager', () => {
       await transferManager.uploadFileInChunks(
         filePath,
         {},
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
       assert.strictEqual(fakeHelper.initiateUpload.calledOnce, true);
       assert.strictEqual(fakeHelper.uploadPart.calledOnce, true);
@@ -749,7 +749,7 @@ describe('Transfer Manager', () => {
         {
           chunkSizeBytes: 32 * 1024 * 1024,
         },
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
 
       assert.strictEqual(readStreamSpy.calledOnceWith(filePath, options), true);
@@ -771,7 +771,7 @@ describe('Transfer Manager', () => {
           ]),
           chunkSizeBytes: 32 * 1024 * 1024,
         },
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
 
       assert.strictEqual(readStreamSpy.calledOnceWith(filePath, options), true);
@@ -787,7 +787,7 @@ describe('Transfer Manager', () => {
             [2, '321'],
           ]),
         },
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
 
       assert.strictEqual(fakeHelper.uploadId, '123');
@@ -798,7 +798,7 @@ describe('Transfer Manager', () => {
       const expectedErr = new MultiPartUploadError(
         'Hello World',
         '',
-        new Map<number, string>()
+        new Map<number, string>(),
       );
       mockGeneratorFunction = (bucket, fileName, uploadId, partsMap) => {
         fakeHelper = sandbox.createStubInstance(FakeXMLHelper);
@@ -814,9 +814,9 @@ describe('Transfer Manager', () => {
         transferManager.uploadFileInChunks(
           filePath,
           {autoAbortFailure: false},
-          mockGeneratorFunction
+          mockGeneratorFunction,
         ),
-        expectedErr
+        expectedErr,
       );
     });
 
@@ -844,7 +844,7 @@ describe('Transfer Manager', () => {
       await transferManager.uploadFileInChunks(
         filePath,
         {headers: headersToAdd},
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
     });
 
@@ -852,7 +852,7 @@ describe('Transfer Manager', () => {
       const expectedErr = new MultiPartUploadError(
         'Hello World',
         '',
-        new Map<number, string>()
+        new Map<number, string>(),
       );
       const fakeId = '123';
 
@@ -874,7 +874,7 @@ describe('Transfer Manager', () => {
       };
 
       assert.doesNotThrow(() =>
-        transferManager.uploadFileInChunks(filePath, {}, mockGeneratorFunction)
+        transferManager.uploadFileInChunks(filePath, {}, mockGeneratorFunction),
       );
     });
 
@@ -896,14 +896,14 @@ describe('Transfer Manager', () => {
           assert('x-goog-api-client' in opts.headers);
           assert.match(
             opts.headers['x-goog-api-client'],
-            /gccl-gcs-cmd\/tm.upload_sharded/
+            /gccl-gcs-cmd\/tm.upload_sharded/,
           );
 
           return {
             data: Buffer.from(
               `<InitiateMultipartUploadResult>
                 <UploadId>1</UploadId>
-              </InitiateMultipartUploadResult>`
+              </InitiateMultipartUploadResult>`,
             ),
             headers: {},
           } as GaxiosResponse;
@@ -941,7 +941,7 @@ describe('Transfer Manager', () => {
             data: Buffer.from(
               `<InitiateMultipartUploadResult>
                 <UploadId>1</UploadId>
-              </InitiateMultipartUploadResult>`
+              </InitiateMultipartUploadResult>`,
             ),
             headers: {},
           } as GaxiosResponse;
@@ -976,7 +976,7 @@ describe('Transfer Manager', () => {
       await transferManager.uploadFileInChunks(
         filePath,
         {validation: 'crc32c'},
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
 
       assert.strictEqual(fakeHelper.uploadPart.calledOnce, true);
@@ -1007,7 +1007,7 @@ describe('Transfer Manager', () => {
       await transferManager.uploadFileInChunks(
         filePath,
         {},
-        mockGeneratorFunction
+        mockGeneratorFunction,
       );
 
       assert.strictEqual(fakeHelper.uploadPart.calledOnce, true);


### PR DESCRIPTION
This PR applies consistent formatting to all manual client libraries in the `handwritten/` directory to bring them into compliance with the project's Prettier and Google TypeScript Style (GTS) formatting guidelines.

This is a preparatory change before enabling the centralized root-level linter checks for handwritten libraries, ensuring that the linter runs cleanly without failing on style or formatting violations.