### PR TITLE
chore: add tools section to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -18,6 +18,30 @@ sources:
   googleapis:
     commit: b6f9ff05aaec18070232a1ab36da98e684bc7909
     sha256: 91788c6f956a0a409abe89a304c123cff73cb0ebb46b494e56d7ac9ece86f8cf
+tools:
+  pnpm:
+    - name: gapic-generator-typescript
+      version: "gapic-generator-v4.12.1"
+      package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz"
+      checksum: "477e4a9b3442457667846bd5c629d1c059e7caf2d5a3ebce95da626a2d42ea80"
+      build:
+        - "pnpm install"
+        # tsc only compiles TypeScript; the generator also needs templates/
+        # and protos/ in build/ (resolved via __dirname at runtime).
+        - "./node_modules/.bin/tsc"
+        - "cp -a templates protos build/"
+        # Pass the full directory name into "pnpm add" so that the generator
+        # is registered with the name "gapic-generator-typescript" rather than
+        # an arbitrary name such as "5".
+        - 'pnpm add -g "$PWD"'
+    - name: gapic-node-processing
+      version: "0.1.8"
+    - name: gapic-tools
+      version: "1.0.6"
+    - name: protobufjs-cli
+      version: "1.2.0"
+    - name: protobufjs
+      version: "7.5.8"
 default:
   keep:
     - librarian.js


### PR DESCRIPTION
Add the tools section to librarian.yaml in google-cloud-node as part of https://github.com/googleapis/librarian/issues/6509.

The content is copied from https://github.com/googleapis/librarian/blob/e26270201c2b0cd23ce7b13ecd873c25d234de67/internal/librarian/nodejs/librarian.yaml#L19.

This added section is not used until a new Librarian version with this feature https://github.com/googleapis/librarian/issues/6509 is used.