### PR TITLE
chore(deps): bump pprof version to 5.0.0 in cloud profiler

### DIFF
--- a/handwritten/cloud-profiler/package.json
+++ b/handwritten/cloud-profiler/package.json
@@ -39,7 +39,7 @@
     "extend": "^3.0.2",
     "gcp-metadata": "^6.0.0",
     "ms": "^2.1.3",
-    "pprof": "4.0.0",
+    "pprof": "5.0.0",
     "pretty-ms": "^7.0.0",
     "protobufjs": "~7.5.5",
     "semver": "^7.0.0",


### PR DESCRIPTION
Part of the process of releasing cloud profiler, bump pprof dep to [5.0.0](https://www.npmjs.com/package/pprof/v/5.0.0) (which I just released).