### PR TITLE
fix(bigtable): avoid self-referential error on RPC-level mutate failure

### DIFF
--- a/handwritten/bigtable/src/utils/mutateInternal.ts
+++ b/handwritten/bigtable/src/utils/mutateInternal.ts
@@ -159,6 +159,14 @@ export function mutateInternal(
               // of recursing into `errors` (e.g. pino).
               const entryError = new Error(rpcError.message) as ServiceError;
               entryError.code = rpcError.code;
+              // Preserve the gRPC debugging context that the former
+              // self-reference carried for each entry.
+              if (rpcError.metadata) {
+                entryError.metadata = rpcError.metadata;
+              }
+              if (rpcError.details) {
+                entryError.details = rpcError.details;
+              }
               return entryError;
             }),
         );

--- a/handwritten/bigtable/src/utils/mutateInternal.ts
+++ b/handwritten/bigtable/src/utils/mutateInternal.ts
@@ -146,13 +146,23 @@ export function mutateInternal(
          a status code, the RPC level failure error code will be used as the
          entry failure code.
         */
-      (err as ServiceError & {errors?: ServiceError[]}).errors =
+      const rpcError = err;
+      (rpcError as ServiceError & {errors?: ServiceError[]}).errors =
         mutationErrors.concat(
           [...pendingEntryIndices]
             .filter(index => !mutationErrorsByEntryIndex.has(index))
-            .map(() => err),
+            .map((): ServiceError => {
+              // Carry the RPC-level code and message on a fresh error rather
+              // than pushing `rpcError` into its own `errors` array. A
+              // self-reference makes the returned error impossible to
+              // serialize for tools that follow the AggregateError convention
+              // of recursing into `errors` (e.g. pino).
+              const entryError = new Error(rpcError.message) as ServiceError;
+              entryError.code = rpcError.code;
+              return entryError;
+            }),
         );
-      collectMetricsCallback(err, err);
+      collectMetricsCallback(rpcError, rpcError);
       return;
     }
     collectMetricsCallback(null, null);

--- a/handwritten/bigtable/test/table.ts
+++ b/handwritten/bigtable/test/table.ts
@@ -19,7 +19,7 @@ import * as proxyquire from 'proxyquire';
 import * as pumpify from 'pumpify';
 import * as sinon from 'sinon';
 import {PassThrough, Writable, Duplex} from 'stream';
-import {ServiceError} from 'google-gax';
+import {grpc, ServiceError} from 'google-gax';
 
 import * as inst from '../src/instance';
 import {ChunkTransformer} from '../src/chunktransformer.js';
@@ -2861,6 +2861,9 @@ describe('Bigtable/Table', () => {
         ];
         const unretriableError = new Error('not retryable') as ServiceError;
         unretriableError.code = 3; // INVALID_ARGUMENT
+        unretriableError.metadata = new grpc.Metadata();
+        unretriableError.metadata.set('x-goog-error', 'context');
+        unretriableError.details = 'invalid argument details';
         emitters = [
           ((stream: Writable) => {
             stream.emit('data', {
@@ -2894,6 +2897,13 @@ describe('Bigtable/Table', () => {
               // error can no longer be serialized (e.g. by pino).
               assert.notStrictEqual(err.errors[0], err);
               assert.doesNotThrow(() => JSON.stringify(err));
+              // The per-entry error keeps the gRPC metadata and details from
+              // the RPC-level failure so debugging context isn't lost.
+              assert.strictEqual(err.errors[0].metadata, err.metadata);
+              assert.strictEqual(
+                err.errors[0].details,
+                'invalid argument details',
+              );
               done();
             } catch (e) {
               done(e);

--- a/handwritten/bigtable/test/table.ts
+++ b/handwritten/bigtable/test/table.ts
@@ -2889,6 +2889,11 @@ describe('Bigtable/Table', () => {
               assert.strictEqual(err.errors.length, 1);
               assert.strictEqual(err.errors[0].code, 3);
               assert.strictEqual(err.errors[0].message, 'not retryable');
+              // Regression test for #8075: the per-entry error must not be
+              // `err` itself, otherwise `err.errors` references `err` and the
+              // error can no longer be serialized (e.g. by pino).
+              assert.notStrictEqual(err.errors[0], err);
+              assert.doesNotThrow(() => JSON.stringify(err));
               done();
             } catch (e) {
               done(e);


### PR DESCRIPTION
When `Table#mutate` / `Table#insert` hits an RPC-level failure with entries still pending and no per-entry mutation errors, `mutateInternal` set `err.errors` to an array containing `err` itself. The resulting cycle (`err.errors[i] === err`) makes the error impossible to serialize with anything that follows the `AggregateError` convention of recursing into `errors` — for example pino, which throws `RangeError: Maximum call stack size exceeded`.

This pushes a fresh error carrying the RPC-level `code` and `message` for each pending entry instead of `err` itself. The `errors` array is only consumed for its per-entry `code`/`message` (the existing `Table#mutate` error tests and the `callback.err.errors` docs), so nothing relies on the former self-reference.

The existing "not retryable" test already exercises this branch (an index-0 success followed by a stream error); it now also asserts that `err.errors[0]` is not `err` and that the resulting error can be serialized.

- [x] Make sure to open an issue as a bug before writing your code, and reference it in your PR.
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #8075 🦕
