### PR TITLE
fix: use pull_request_target for auto assign reviewers workflow

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,7 +1,7 @@
 name: Auto Assign Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 permissions:


### PR DESCRIPTION
The `assign-reviewers` workflow currently fails to identify organization membership when a contributor opens a pull request from a fork. Repository secrets (such as `GOOGLER_CHECK_TOKEN`) are not passed to the runner for security reasons and causes the workflow to fall back to the default `GITHUB_TOKEN`.

Membership checks for these users fail with `404`, and the workflow mistakenly skips reviewer auto-assignment.
This PR changes the workflow trigger event to `pull_request_target` so the workflow executes in the context of the base repository/branch, making `secrets.GOOGLER_CHECK_TOKEN` available even for pull requests submitted from forks.
- The workflow does not checkout or execute any code from the incoming pull request (it only uses the GitHub API to fetch metadata and the base `CODEOWNERS` file), making it safe to run under `pull_request_target`.
