### PR TITLE
fix(cloud-profiler): re-enable tests

### DIFF
--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -92,7 +92,7 @@ tests_with_credentials="core/packages/google-auth-library-nodejs/ packages/googl
 # on Windows due to incompatible npm scripts.
 # 
 # Until these packages can be updated to be OS agnostic, we will skip them on Windows.
-windows_exempt_tests="core/ core/packages/ core/dev-packages/ .github/scripts/fixtures/ .github/scripts/tests/ core/packages/gapic-node-processing/ core/packages/typeless-sample-bot/"
+windows_exempt_tests="core/ core/packages/ core/dev-packages/ .github/scripts/fixtures/ .github/scripts/tests/ core/packages/gapic-node-processing/ core/packages/typeless-sample-bot/ handwritten/cloud-profiler/"
 
 for subdir in ${subdirs[@]}; do
     for d in `ls -d ${subdir}/*/`; do
@@ -133,8 +133,8 @@ for subdir in ${subdirs[@]}; do
             continue
         fi
 
-        # Our CI uses Git Bash on Windows to execute this script, which returns "msys" for OSTYPE.
-        if [[ "$OSTYPE" == "msys" ]]; then
+        # Our CI uses Git Bash on Windows to execute this script, which returns "msys" or "cygwin" for OSTYPE.
+        if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
             if [[ "${windows_exempt_tests}" =~ "${d}" ]]; then
                 echo "Skipping ${d} on Windows (in exemption list)"
                 continue

--- a/handwritten/cloud-profiler/package.json
+++ b/handwritten/cloud-profiler/package.json
@@ -11,7 +11,7 @@
   "types": "build/src/index.d.ts",
   "scripts": {
     "test": "c8 mocha 'build/test/test-*.js'",
-    "system-test": "c8 --no-clean mocha 'build/system-test/test-*.js' --timeout=60000",
+    "system-test": "echo 'skipping tests for time being'",
     "samples-test": "echo 'no sample tests'",
     "clean": "gts clean",
     "compile": "tsc -p .",
@@ -21,7 +21,6 @@
     "prelint": "cd samples; npm link ../; npm install",
     "prepare": "npm run compile",
     "pretest": "npm run compile && node-gyp rebuild --directory node_modules/pprof",
-    "presystem-test": "npm run compile && node-gyp rebuild --directory node_modules/pprof",
     "license-check": "jsgl --local .",
     "precompile": "gts clean"
   },

--- a/handwritten/cloud-profiler/package.json
+++ b/handwritten/cloud-profiler/package.json
@@ -10,8 +10,8 @@
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
-    "test": "echo 'skipping tests for time being'",
-    "system-test": "echo 'skipping tests for time being'",
+    "test": "c8 mocha 'build/test/test-*.js'",
+    "system-test": "c8 --no-clean mocha 'build/system-test/test-*.js' --timeout=60000",
     "samples-test": "echo 'no sample tests'",
     "clean": "gts clean",
     "compile": "tsc -p .",
@@ -20,7 +20,8 @@
     "docs": "jsdoc -c .jsdoc.js",
     "prelint": "cd samples; npm link ../; npm install",
     "prepare": "npm run compile",
-    "pretest": "npm run compile",
+    "pretest": "npm run compile && node-gyp rebuild --directory node_modules/pprof",
+    "presystem-test": "npm run compile && node-gyp rebuild --directory node_modules/pprof",
     "license-check": "jsgl --local .",
     "precompile": "gts clean"
   },


### PR DESCRIPTION
Restores the `test` (unit test) script that was previously disabled in googleapis/cloud-profiler-nodejs#1002.

Note: GCE system tests (`system-test`) remain disabled for now as they require a GCE project environment to run.

Note: Native module compilation (via `node-gyp`) fails on GitHub Actions Windows runners due to runner-specific environment issues. Consequently, `handwritten/cloud-profiler/` has been added to the Windows test exemption list in `ci/run_conditional_tests.sh`.
