### PR TITLE
feat(google/cloud/workloadmanager/v1): onboard a new library

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1765,8 +1765,8 @@ libraries:
     version: 5.1.1
     apis:
       - path: google/cloud/workflows/v1
-      - path: google/cloud/workflows/v1beta
       - path: google/cloud/workflows/executions/v1
+      - path: google/cloud/workflows/v1beta
       - path: google/cloud/workflows/executions/v1beta
     copyright_year: "2026"
     nodejs:

--- a/packages/google-cloud-workloadmanager/.repo-metadata.json
+++ b/packages/google-cloud-workloadmanager/.repo-metadata.json
@@ -2,7 +2,7 @@
     "api_description": "Workload Manager is a service that provides tooling for enterprise\nworkloads to automate the deployment and validation of your workloads\nagainst best practices and recommendations.",
     "api_id": "workloadmanager.googleapis.com",
     "api_shortname": "workloadmanager",
-    "client_documentation": "https://cloud.google.com/nodejs/docs/reference/workloadmanager/latest",
+    "client_documentation": "https://cloud.google.com/nodejs/docs/reference/workload-manager/latest",
     "default_version": "v1",
     "distribution_name": "@google-cloud/workloadmanager",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=1631482&template=0",

--- a/packages/google-cloud-workloadmanager/README.md
+++ b/packages/google-cloud-workloadmanager/README.md
@@ -17,7 +17,7 @@ Workload Manager API client for Node.js
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [Workload Manager API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/workloadmanager/latest)
+* [Workload Manager API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/workload-manager/latest)
 * [Workload Manager API Documentation](https://docs.cloud.google.com/workload-manager/docs)
 
 Read more about the client libraries for Cloud APIs, including the older


### PR DESCRIPTION
Onboard the Workload Manager API (google/cloud/workloadmanager/v1) to Node.js monorepo using Librarian. This PR is a follow up of  #7253.


For b/484072416
For b/527504125