### PR TITLE
fix(pubsub-api): use the release version of gax

### DIFF
--- a/packages/google-cloud-pubsub-api/package.json
+++ b/packages/google-cloud-pubsub-api/package.json
@@ -42,7 +42,7 @@
     "test": "c8 mocha --config ../../.mocharc.cjs build/test"
   },
   "dependencies": {
-    "google-gax": "^5.1.1-rc.1"
+    "google-gax": "^5.0.7"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
This was using the old template, so it got the false beta version of gax.
