### PR TITLE
fix(developer-knowledge): update distribution_name typo

### DIFF
--- a/packages/google-developer-knowledge/.repo-metadata.json
+++ b/packages/google-developer-knowledge/.repo-metadata.json
@@ -3,7 +3,7 @@
     "api_id": "developerknowledge.googleapis.com",
     "api_shortname": "developerknowledge",
     "default_version": "v1",
-    "distribution_name": "google-developer-knowledge",
+    "distribution_name": "@google/developer-knowledge",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=190865&template=1161103",
     "language": "nodejs",
     "library_type": "GAPIC_AUTO",


### PR DESCRIPTION
Update the `distribution_name` attribute in `.repo-metadata.json` file to the correct syntax.
