### PR TITLE
fix: add client_documentation_override for workloadmanager

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1789,6 +1789,7 @@ libraries:
     copyright_year: "2026"
     nodejs:
       default_version: v1
+      client_documentation_override: https://docs.cloud.google.com/nodejs/docs/reference/workloadmanager/latest
   - name: google-cloud-workstations
     version: 2.3.0
     apis:


### PR DESCRIPTION
Fixes incorrect client documentation link noted in b/527504125
