### PR TITLE
chore: fix unit test failure in error-reporting library

### DIFF
--- a/handwritten/error-reporting/src/configuration.ts
+++ b/handwritten/error-reporting/src/configuration.ts
@@ -179,7 +179,11 @@ export class Configuration {
      * @defaultvalue null
      */
     this._givenConfiguration =
-      givenConfig?.toString() === '[object Object]' ? givenConfig! : {};
+      typeof givenConfig === 'object' &&
+      givenConfig !== null &&
+      !Array.isArray(givenConfig)
+        ? givenConfig
+        : {};
     this._checkLocalServiceContext();
     this._gatherLocalConfiguration();
   }


### PR DESCRIPTION
The intention of this check is to verify that the configuration is a non-null Object. I have updated the check to do this explicitly rather than relying on toString.

The failure is caused by fragile object check patterns (specifically, givenConfig?.toString() === '[object Object]') evaluating to true when the input is a single-element array containing an object (e.g. [ { ... } ]). This is because Array.prototype.toString() falls back to joining its elements, which converts the single object inside it to "[object Object]".
