### PR TITLE
fix(firestore): prevent adding telemetry events to ended spans (#8847)

### DIFF
--- a/handwritten/firestore/dev/src/telemetry/span.ts
+++ b/handwritten/firestore/dev/src/telemetry/span.ts
@@ -29,6 +29,9 @@ export class Span {
   }
 
   addEvent(name: string, attributes?: Attributes): this {
+    if (this.span?.isRecording?.() === false) {
+      return this;
+    }
     this.span = this.span?.addEvent(name, attributes);
     return this;
   }

--- a/handwritten/firestore/dev/test/tracing.ts
+++ b/handwritten/firestore/dev/test/tracing.ts
@@ -185,4 +185,16 @@ describe('Firestore Tracing Controls', () => {
       );
     }
   });
+
+  it('safely handles addEvent calls on ended spans without throwing', () => {
+    const tracerProvider = new NodeTracerProvider();
+    const tracer = tracerProvider.getTracer('test-tracer');
+    const otelSpan = tracer.startSpan('test-span');
+    const span = new (require('../src/telemetry/span').Span)(otelSpan);
+
+    span.end();
+    expect(() => {
+      span.addEvent('late-event', {key: 'value'});
+    }).to.not.throw();
+  });
 });

--- a/handwritten/firestore/package.json
+++ b/handwritten/firestore/package.json
@@ -117,10 +117,18 @@
   },
   "//_comment": "TODO: Remove @sinonjs/fake-timers overrides/resolutions when version > 15.3.0 fixes the duplicate identifier 'withGlobal' issue.",
   "overrides": {
-    "@sinonjs/fake-timers": "15.1.1"
+    "@sinonjs/fake-timers": "15.1.1",
+    "brace-expansion": "^2.0.1"
   },
   "resolutions": {
-    "@sinonjs/fake-timers": "15.1.1"
+    "@sinonjs/fake-timers": "15.1.1",
+    "brace-expansion": "^2.0.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@sinonjs/fake-timers": "15.1.1",
+      "brace-expansion": "^2.0.1"
+    }
   },
   "exports": {
     ".": {


### PR DESCRIPTION
In REST-mode streaming operations (such as getAll(), Query.get(), or DocumentReference.set()), DocumentReader resolves its operation Promise as soon
as response data is processed, which causes startActiveSpan() to close the OpenTelemetry span.

However, the underlying stream's 'end' event fires on a subsequent tick of the Node.js event loop:

  resultStream.on('end', () => {
    this._traceUtil.currentSpan().addEvent(`Firestore.${methodName}: Completed`, ...);
  });

Because the span is already closed by the time this 'end' listener runs, calling addEvent() throws an error in modern OpenTelemetry runtimes.
Guarding addEvent() ensures late stream events return safely without interrupting execution.

- Added an isRecording() check in Span.addEvent() (dev/src/telemetry/span.ts) using this.span?.isRecording?.() === false to return early if a span is
closed.
- Added a unit test in dev/test/tracing.ts to verify that Span.addEvent() exits safely without throwing when called on an ended span.

### Context

OpenTelemetry Version Changes: In older versions of @opentelemetry/api (< 1.9.0), calling addEvent() on a closed span was silently ignored by the
trace SDK. Starting in @opentelemetry/api >= 1.9.0, OpenTelemetry introduced strict runtime checks (SpanImpl._isSpanEnded) that throw Error:
Operation attempted on ended Span.
- Pre-Existing Flakiness: This stream completion timing sequence was already present in @google-cloud/firestore@8.7.0 and caused open flakybot test
failures (e.g., #8847, #8910, #8867). Similar span lifecycle race conditions were previously resolved in Spanner (#2184, #2121) and Logging (#1497).
Tab to collapse · ←/→ to navigate · Enter/Esc to dismiss
