### PR TITLE
fix(ci): fix discovery.yaml by installing root dependencies

### DIFF
--- a/.github/workflows/discovery.yaml
+++ b/.github/workflows/discovery.yaml
@@ -19,8 +19,7 @@ jobs:
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: ^10.0.0
-      # Install root deps for ESLint
-      - run: pnpm install
+
       # Install all deps, including dev dependencies.
       - run: cd handwritten/bigquery && pnpm install
       # Generate types

--- a/.github/workflows/discovery.yaml
+++ b/.github/workflows/discovery.yaml
@@ -15,15 +15,18 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 16
+          node-version: 22
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: ^10.0.0
       # Install root deps for ESLint
-      - run: npm install
+      - run: pnpm install
       # Install all deps, including dev dependencies.
-      - run: cd handwritten/bigquery && npm install
+      - run: cd handwritten/bigquery && pnpm install
       # Generate types
-      - run: cd handwritten/bigquery && npm run types
+      - run: cd handwritten/bigquery && pnpm run types
       # Fix formatting
-      - run: cd handwritten/bigquery && npm run fix
+      - run: cd handwritten/bigquery && pnpm run fix
       # Submit pull request
       - uses: googleapis/code-suggester@f9fef85aa02459e30e62526abe950341cbbd768b # v5
         env:

--- a/.github/workflows/discovery.yaml
+++ b/.github/workflows/discovery.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16
+      # Install root deps for ESLint
+      - run: npm install
       # Install all deps, including dev dependencies.
       - run: cd handwritten/bigquery && npm install
       # Generate types

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -21,10 +21,29 @@ module.exports = {
         mutateC8(pkg.devDependencies, pkg.name, 'devDependencies', context);
       }
 
+      // Check if this package has brace-expansion as a dependency or devDependency
+      if (pkg.dependencies && pkg.dependencies['brace-expansion']) {
+        mutateBraceExpansion(pkg.dependencies, pkg.name, 'dependencies', context);
+      }
+      if (pkg.devDependencies && pkg.devDependencies['brace-expansion']) {
+        mutateBraceExpansion(pkg.devDependencies, pkg.name, 'devDependencies', context);
+      }
       return pkg;
     }
   }
 };
+
+function mutateBraceExpansion(deps, pkgName, depType, context) {
+  const nodeVersion = process.version;
+  const majorVersion = parseInt(nodeVersion.replace('v', '').split('.')[0], 10);
+
+  if (majorVersion === 18) {
+    if (deps['brace-expansion'] && deps['brace-expansion'].startsWith('^5.')) {
+      console.log(`[pnpmfile] Node.js version is 18. Overriding brace-expansion to 5.0.7 in ${pkgName}`);
+      deps['brace-expansion'] = '5.0.7';
+    }
+  }
+}
 
 function mutateYargs(deps, pkgName, depType, context) {
   const nodeVersion = process.version;

--- a/handwritten/bigquery/.eslintignore
+++ b/handwritten/bigquery/.eslintignore
@@ -5,3 +5,4 @@ build/
 docs/
 protos/
 samples/generated/
+system-test/fixtures

--- a/handwritten/bigquery/.eslintrc.json
+++ b/handwritten/bigquery/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "./node_modules/gts",
+  "root": true
 }


### PR DESCRIPTION
This fixes an issue where ESLint could not find the gts config because the root node_modules was empty, and ignores system-test/fixtures which are not included in the tsconfig.

Fixes #8954  🦕
