### PR TITLE
chore: fix c8 dependency breakage on node <= 18

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -8,6 +8,19 @@ module.exports = {
       if (pkg.devDependencies && pkg.devDependencies.yargs) {
         mutateYargs(pkg.devDependencies, pkg.name, 'devDependencies', context);
       }
+
+      // C8 broke Node 18 compatibility the week of July 20th 2026. 
+      // Until we complete the upgrade, we need this workaround to enable CI
+      // to continue running.
+      //
+      // TODO: Remove this workaround after Node 22 upgrade.
+      if (pkg.dependencies && pkg.dependencies.c8) {
+        mutateC8(pkg.dependencies, pkg.name, 'dependencies', context);
+      }
+      if (pkg.devDependencies && pkg.devDependencies.c8) {
+        mutateC8(pkg.devDependencies, pkg.name, 'devDependencies', context);
+      }
+
       return pkg;
     }
   }
@@ -22,3 +35,19 @@ function mutateYargs(deps, pkgName, depType, context) {
     deps.yargs = '18.0.0';
   }
 }
+
+/**
+ * Override C8 dependency for versions of Node <=18 to enable CI to continue functioning.
+ * 
+ * Otherwise, continue to use 10+ version.
+ */
+function mutateC8(deps, pkgName, depType, context) {
+  const nodeVersion = process.version;
+  const majorVersion = parseInt(nodeVersion.replace('v', '').split('.')[0], 10);
+  
+  if (majorVersion <= 18) {
+    console.log(`[pnpmfile] Node.js version is ${nodeVersion} (<= 18). Overriding c8 to ^9.1.0 in ${pkgName}`);
+    deps.c8 = '^9.1.0';
+  }
+}
+


### PR DESCRIPTION
# The Issue

The error blocking release:
```
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

This error happened while installing the dependencies of c8@10.1.3
 at test-exclude@7.0.2
 at minimatch@10.2.5

Your Node version is incompatible with "brace-expansion@5.0.8".

Expected version: 20 || >=22
Got: v18.20.8

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```

---
# The Fix

Here is the exact dependency chain that triggered the failure:

```
c8@10.1.3
  └── test-exclude@7.0.2
      └── minimatch@10.2.5
          └── brace-expansion@5.0.8 (requires node: "20 || >=22")
```

1. c8@10.1.3 pulled in test-exclude@7.0.2.
2. test-exclude@7.0.2 updated its dependency to minimatch@10.2.5.
3. minimatch@10.2.5 pulled in brace-expansion@5.0.8.
4. **brace-expansion@5.0.8 strictly requires Node 20 || >=22 in its engines specification, breaking installation under Node 18.**

As a result, we need to pin to an older version of C8 for versions of Node older than 18. Rather that implementing a global override, updating the .pnpmfile.cjs enables us to do a targeted override ONLY for Node 18. That means that as we upgrade to Node 22, every other package can continue to use 10+ like they do currently.

---
# Why this works

Note, this works because in our CI we explicitly set the PNPM file on install: https://github.com/googleapis/google-cloud-node/blob/main/ci/run_single_test.sh#L45