### PR TITLE
fix(gapic-node-processing): move typescript to dependencies for AST runtime execution

### DIFF
--- a/core/packages/gapic-node-processing/package.json
+++ b/core/packages/gapic-node-processing/package.json
@@ -37,8 +37,7 @@
     "gts": "^6.0.2",
     "mocha": "^11.1.0",
     "sinon": "21.0.3",
-    "snap-shot-it": "^7.9.10",
-    "typescript": "^5.8.2"
+    "snap-shot-it": "^7.9.10"
   },
   "engines": {
     "node": ">=18"
@@ -53,6 +52,7 @@
     "@octokit/rest": "^20.0.0",
     "js-yaml": "^4.1.0",
     "nunjucks": "^3.2.4",
+    "typescript": "^5.8.2",
     "yargs": "^17.7.2"
   },
   "overrides": {


### PR DESCRIPTION
For https://github.com/googleapis/librarian/issues/6969