### PR TITLE
chore: fix test breakage in error-reporting

### DIFF
--- a/handwritten/error-reporting/src/request-extractors/hapi.ts
+++ b/handwritten/error-reporting/src/request-extractors/hapi.ts
@@ -26,10 +26,12 @@ import * as hapi from '@hapi/hapi';
  * @returns {Number} - Either an HTTP status code or -1 in absence of an
  *  extractable status code.
  */
-function attemptToExtractStatusCode(req: hapi.Request) {
+function attemptToExtractStatusCode(
+  req: hapi.Request | Record<string, unknown>,
+) {
   // TODO: Handle the cases where `req.response` and `req.response.output` are
   // `null` in this function
-  if (typeof req.response === 'object') {
+  if (typeof req.response === 'object' && req.response !== null) {
     if ('statusCode' in req.response) {
       return (req.response as hapi.ResponseObject).statusCode;
     } else if (
@@ -52,11 +54,17 @@ function attemptToExtractStatusCode(req: hapi.Request) {
  * @returns {String} - Either an empty string if the IP cannot be extracted or
  *  a string that represents the remote IP address
  */
-function extractRemoteAddressFromRequest(req: hapi.Request) {
-  if ('x-forwarded-for' in req.headers) {
-    return req.headers['x-forwarded-for'];
+function extractRemoteAddressFromRequest(
+  req: hapi.Request | Record<string, unknown>,
+) {
+  if (
+    req.headers &&
+    typeof req.headers === 'object' &&
+    'x-forwarded-for' in req.headers
+  ) {
+    return (req.headers as Record<string, unknown>)['x-forwarded-for'];
   } else if (req.info?.toString() === '[object Object]') {
-    return req.info.remoteAddress;
+    return (req.info as {remoteAddress?: string}).remoteAddress;
   }
 
   return '';
@@ -65,10 +73,11 @@ function extractRemoteAddressFromRequest(req: hapi.Request) {
 /**
  * Helper to normalize headers that might be arrays into a single string.
  */
-function getSingleHeader(
-  val: string | string[] | undefined,
-): string | undefined {
-  return Array.isArray(val) ? val[0] : val;
+function getSingleHeader(val: unknown): string | undefined {
+  if (Array.isArray(val)) {
+    return typeof val[0] === 'string' ? val[0] : undefined;
+  }
+  return typeof val === 'string' ? val : undefined;
 }
 
 /**
@@ -80,7 +89,9 @@ function getSingleHeader(
  * @returns {RequestInformationContainer} - an object containing the request
  *  information in a standardized format
  */
-export function hapiRequestInformationExtractor(req?: hapi.Request) {
+export function hapiRequestInformationExtractor(
+  req?: hapi.Request | Record<string, unknown>,
+) {
   const returnObject = new RequestInformationContainer();
 
   if (
@@ -92,18 +103,24 @@ export function hapiRequestInformationExtractor(req?: hapi.Request) {
     return returnObject;
   }
 
-  let urlString: string;
+  let urlString = '';
   if (typeof req!.url === 'string') {
-    urlString = req!.url as {} as string;
-  } else {
-    urlString = req!.url.pathname;
+    urlString = req!.url;
+  } else if (
+    req!.url &&
+    typeof req!.url === 'object' &&
+    'pathname' in req!.url
+  ) {
+    urlString = (req!.url as {pathname: string}).pathname;
   }
 
+  const headers = req!.headers as Record<string, unknown>;
+
   returnObject
-    .setMethod(req!.method)
+    .setMethod(typeof req!.method === 'string' ? req!.method : '')
     .setUrl(urlString)
-    .setUserAgent(getSingleHeader(req!.headers['user-agent']))
-    .setReferrer(getSingleHeader(req!.headers.referrer))
+    .setUserAgent(getSingleHeader(headers['user-agent']))
+    .setReferrer(getSingleHeader(headers.referrer))
     .setStatusCode(attemptToExtractStatusCode(req!))
     .setRemoteAddress(getSingleHeader(extractRemoteAddressFromRequest(req!)));
 

--- a/handwritten/error-reporting/src/request-extractors/hapi.ts
+++ b/handwritten/error-reporting/src/request-extractors/hapi.ts
@@ -26,12 +26,10 @@ import * as hapi from '@hapi/hapi';
  * @returns {Number} - Either an HTTP status code or -1 in absence of an
  *  extractable status code.
  */
-function attemptToExtractStatusCode(
-  req: hapi.Request | Record<string, unknown>,
-) {
+function attemptToExtractStatusCode(req: hapi.Request) {
   // TODO: Handle the cases where `req.response` and `req.response.output` are
   // `null` in this function
-  if (typeof req.response === 'object' && req.response !== null) {
+  if (typeof req.response === 'object') {
     if ('statusCode' in req.response) {
       return (req.response as hapi.ResponseObject).statusCode;
     } else if (
@@ -54,17 +52,11 @@ function attemptToExtractStatusCode(
  * @returns {String} - Either an empty string if the IP cannot be extracted or
  *  a string that represents the remote IP address
  */
-function extractRemoteAddressFromRequest(
-  req: hapi.Request | Record<string, unknown>,
-) {
-  if (
-    req.headers &&
-    typeof req.headers === 'object' &&
-    'x-forwarded-for' in req.headers
-  ) {
-    return (req.headers as Record<string, unknown>)['x-forwarded-for'];
+function extractRemoteAddressFromRequest(req: hapi.Request) {
+  if ('x-forwarded-for' in req.headers) {
+    return req.headers['x-forwarded-for'];
   } else if (req.info?.toString() === '[object Object]') {
-    return (req.info as {remoteAddress?: string}).remoteAddress;
+    return req.info.remoteAddress;
   }
 
   return '';
@@ -89,9 +81,7 @@ function getSingleHeader(val: unknown): string | undefined {
  * @returns {RequestInformationContainer} - an object containing the request
  *  information in a standardized format
  */
-export function hapiRequestInformationExtractor(
-  req?: hapi.Request | Record<string, unknown>,
-) {
+export function hapiRequestInformationExtractor(req?: hapi.Request) {
   const returnObject = new RequestInformationContainer();
 
   if (
@@ -103,24 +93,18 @@ export function hapiRequestInformationExtractor(
     return returnObject;
   }
 
-  let urlString = '';
+  let urlString: string;
   if (typeof req!.url === 'string') {
-    urlString = req!.url;
-  } else if (
-    req!.url &&
-    typeof req!.url === 'object' &&
-    'pathname' in req!.url
-  ) {
-    urlString = (req!.url as {pathname: string}).pathname;
+    urlString = req!.url as {} as string;
+  } else {
+    urlString = req!.url.pathname;
   }
 
-  const headers = req!.headers as Record<string, unknown>;
-
   returnObject
-    .setMethod(typeof req!.method === 'string' ? req!.method : '')
+    .setMethod(req!.method)
     .setUrl(urlString)
-    .setUserAgent(getSingleHeader(headers['user-agent']))
-    .setReferrer(getSingleHeader(headers.referrer))
+    .setUserAgent(getSingleHeader(req!.headers['user-agent']))
+    .setReferrer(getSingleHeader(req!.headers.referrer))
     .setStatusCode(attemptToExtractStatusCode(req!))
     .setRemoteAddress(getSingleHeader(extractRemoteAddressFromRequest(req!)));
 

--- a/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
+++ b/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
@@ -153,6 +153,7 @@ describe('hapiRequestInformationExtractor behaviour', () => {
         referrer: 'www.ANOTHER-TEST.com',
         remoteAddress: '0.0.0.1',
       };
+      
       deepStrictEqual(
         hapiRequestInformationExtractor(REQUEST as {} as hapi.Request),
         EXPECTED,

--- a/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
+++ b/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
@@ -14,8 +14,7 @@
 
 import * as hapi from '@hapi/hapi';
 import {URL} from 'url';
-import {describe, it} from 'mocha';
-
+import * as assert from 'assert';
 import {hapiRequestInformationExtractor} from '../../../src/request-extractors/hapi';
 import {Fuzzer} from '../../../utils/fuzzer';
 import {deepStrictEqual} from '../../util';
@@ -137,6 +136,21 @@ describe('hapiRequestInformationExtractor behaviour', () => {
         hapiRequestInformationExtractor(REQUEST as {} as hapi.Request),
         EXPECTED,
       );
+    });
+    it('Should handle array headers correctly', () => {
+      const REQUEST = {
+        headers: {
+          'x-forwarded-for': ['0.0.0.1', '0.0.0.2'],
+          'user-agent': ['Mozilla/5.0', 'Chrome/90'],
+          referrer: ['www.ANOTHER-TEST.com'],
+        },
+      };
+
+      const actual = hapiRequestInformationExtractor(REQUEST);
+      
+      assert.strictEqual(actual.remoteAddress, '0.0.0.1');
+      assert.strictEqual(actual.userAgent, 'Mozilla/5.0');
+      assert.strictEqual(actual.referrer, 'www.ANOTHER-TEST.com');
     });
   });
 });

--- a/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
+++ b/handwritten/error-reporting/test/unit/request-extractors/hapi.ts
@@ -14,7 +14,8 @@
 
 import * as hapi from '@hapi/hapi';
 import {URL} from 'url';
-import * as assert from 'assert';
+import {describe, it} from 'mocha';
+
 import {hapiRequestInformationExtractor} from '../../../src/request-extractors/hapi';
 import {Fuzzer} from '../../../utils/fuzzer';
 import {deepStrictEqual} from '../../util';
@@ -139,18 +140,23 @@ describe('hapiRequestInformationExtractor behaviour', () => {
     });
     it('Should handle array headers correctly', () => {
       const REQUEST = {
+        ...FULL_REQ_DERIVATION_VALUE,
         headers: {
           'x-forwarded-for': ['0.0.0.1', '0.0.0.2'],
           'user-agent': ['Mozilla/5.0', 'Chrome/90'],
           referrer: ['www.ANOTHER-TEST.com'],
         },
       };
-
-      const actual = hapiRequestInformationExtractor(REQUEST);
-      
-      assert.strictEqual(actual.remoteAddress, '0.0.0.1');
-      assert.strictEqual(actual.userAgent, 'Mozilla/5.0');
-      assert.strictEqual(actual.referrer, 'www.ANOTHER-TEST.com');
+      const EXPECTED = {
+        ...FULL_REQ_EXPECTED_VALUE,
+        userAgent: 'Mozilla/5.0',
+        referrer: 'www.ANOTHER-TEST.com',
+        remoteAddress: '0.0.0.1',
+      };
+      deepStrictEqual(
+        hapiRequestInformationExtractor(REQUEST as {} as hapi.Request),
+        EXPECTED,
+      );
     });
   });
 });


### PR DESCRIPTION
## Why I am addressing this

I am trying to fix all of the current outstanding test breakages blocking the merge of our new Bun CI (https://github.com/googleapis/google-cloud-node/pull/8904). To verify this PR, we are running ALL unit tests in the monorepo. This has revealed a handful of existing breakages, including this one.

---

## The problem

In `@hapi/hapi` (and modern `@types/node` / HTTP header type definitions), `req.headers` elements are typed as `unknown` (e.g. Record<string, unknown>). Passing header values like `req.headers['user-agent']`, `req.headers.referrer`, or `extractRemoteAddressFromRequest(req)` directly into `getSingleHeader(val: string | string[] | undefined)` caused `TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | string[] | undefined'.`

---

## The fix

Update the internal implementation to correctly reflect the real types and add a new test to verify functionality.

I don't love the use of `as` casting in the tests, but mocking a type-compliant `hapi.Request` object is surprisingly difficult (it appears to require a running server to inject dependencies).  I spoke with Gemini about this and it recommended casting a bare JS object (like the existing tests). An alternative would be to update the implementation to have a less strict type, but I would prefer to keep the minimum diff.

