### PR TITLE
fix(ci): improve changed file detection in linter script

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -34,10 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 300
+          fetch-depth: 2
           persist-credentials: false
-      - name: Fetch base branch for linter diff
-        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       - name: Use Node.js 24
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -47,4 +45,4 @@ jobs:
         name: Run monorepo linter
         env:
           STRICT: "true"
-          GIT_DIFF_ARG: "origin/${{ github.base_ref }}...HEAD"
+          GIT_DIFF_ARG: "HEAD^1"

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -41,5 +41,5 @@ jobs:
         with:
           node-version: 24
       - run: npm install
-      - run: npm run lint
+      - run: node ./bin/linter.mjs --strict --git-diff-arg "origin/${{ github.base_ref }}...HEAD"
         name: Run monorepo linter

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -41,8 +41,7 @@ jobs:
         with:
           node-version: 24
       - run: npm install
-      - run: node ./bin/linter.mjs
+      - run: node ./bin/linter.mjs --strict
         name: Run monorepo linter
         env:
-          STRICT: "true"
           GIT_DIFF_ARG: "HEAD^1"

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -36,6 +36,8 @@ jobs:
         with:
           fetch-depth: 300
           persist-credentials: false
+      - name: Fetch base branch for linter diff
+        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       - name: Use Node.js 24
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -43,5 +43,8 @@ jobs:
         with:
           node-version: 24
       - run: npm install
-      - run: node ./bin/linter.mjs --strict --git-diff-arg "origin/${{ github.base_ref }}...HEAD"
+      - run: node ./bin/linter.mjs
         name: Run monorepo linter
+        env:
+          STRICT: "true"
+          GIT_DIFF_ARG: "origin/${{ github.base_ref }}...HEAD"

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -94,7 +94,6 @@ function getDiffFiles(ref) {
 
 /**
  * Returns a list of changed TypeScript files comparing against target branches/references.
- * Fully hermetic (uses local git references and merge-base with no network calls).
  */
 function getChangedFiles() {
   const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
@@ -117,7 +116,7 @@ function getChangedFiles() {
       // Continue with fallback refs if branch detection fails
     }
 
-    refsToTry = currentBranch === 'main'
+    refsToTry = (currentBranch === 'main')
       ? ['origin/main', 'upstream/main', 'HEAD~1']
       : ['upstream/main', 'origin/main', 'main'];
   }

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -112,7 +112,6 @@ function getChangedFilesStrict() {
  */
 function getChangedFiles() {
   const base = process.env.GITHUB_BASE_REF || 'main';
-
   const refsToTry = [
     `origin/${base}...HEAD`,
     `${base}...HEAD`,

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -64,72 +64,83 @@ function runGit(args, options = {}) {
 }
 
 /**
+ * Helper to get modified/added TypeScript files against a given git ref.
+ * Uses merge-base when possible to compare against the common ancestor (e.g. when base and branch have both moved).
+ */
+function getDiffFiles(ref) {
+  let diffTarget = ref;
+  try {
+    const mergeBase = runGit(['merge-base', ref, 'HEAD']).trim();
+    if (mergeBase) {
+      diffTarget = mergeBase;
+    }
+  } catch {
+    // If merge-base fails (e.g. shallow clone or invalid ref), fall back to using ref directly
+  }
+
+  const output = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRT',
+    diffTarget,
+    '--',
+    '*.ts',
+  ]);
+  return output
+    .split('\n')
+    .map(f => f.trim())
+    .filter(f => f.length > 0 && existsSync(f));
+}
+
+/**
  * Returns a list of changed TypeScript files comparing against target branches/references.
  */
 function getChangedFiles() {
-  const base = process.env.GITHUB_BASE_REF || 'main';
+  const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
 
-  // Attempt to fetch the base branch and set origin/${base} so it doesn't compare against itself
-  if (process.env.GITHUB_BASE_REF) {
+  if (isCI) {
+    const baseRef = process.env.GITHUB_BASE_REF;
+    if (!baseRef) {
+      throw new Error('Running in CI but GITHUB_BASE_REF environment variable is not set.');
+    }
     try {
-      runGit([
-        'fetch',
-        'origin',
-        `+refs/heads/${base}:refs/remotes/origin/${base}`,
-        '--depth=1',
-      ]);
+      const files = getDiffFiles(baseRef);
+      console.log(`Comparing against base reference: ${baseRef}`);
+      return files;
     } catch {
-      // Continue if network fetch fails or remote does not exist
+      throw new Error(`Failed to determine changed files against GITHUB_BASE_REF '${baseRef}' in CI.`);
     }
   }
 
-  const refsToTry = [
-    `origin/${base}...HEAD`,
-    `${base}...HEAD`,
-    `upstream/${base}...HEAD`,
-    `origin/${base}`,
-    base,
-    `upstream/${base}`,
-    'HEAD~1',
-    'HEAD^',
-  ];
+  let currentBranch = '';
+  try {
+    currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+  } catch {
+    // Continue with fallback refs if branch detection fails
+  }
 
+  if (currentBranch === 'main') {
+    try {
+      const files = getDiffFiles('HEAD~1');
+      console.log('Comparing against base reference: HEAD~1');
+      return files;
+    } catch {
+      throw new Error("Failed to determine changed files against 'HEAD~1' on main branch.");
+    }
+  }
+
+  const refsToTry = ['upstream/main', 'origin/main', 'main'];
   for (const ref of refsToTry) {
     try {
-      const output = runGit([
-        'diff',
-        '--name-only',
-        '--diff-filter=ACMRT',
-        ref,
-        '--',
-        '*.ts',
-      ]);
-      return output
-        .split('\n')
-        .map(f => f.trim())
-        .filter(f => f.length > 0 && existsSync(f));
+      const files = getDiffFiles(ref);
+      console.log(`Comparing against base reference: ${ref}`);
+      return files;
     } catch {
-      // Continue to the next fallback ref
+      // Continue to next ref if this one fails/does not exist
     }
   }
 
-  // Fallback to checking uncommitted working tree changes against HEAD if all specific refs fail
-  try {
-    const output = runGit([
-      'diff',
-      '--name-only',
-      '--diff-filter=ACMRT',
-      'HEAD',
-      '--',
-      '*.ts',
-    ]);
-    return output
-      .split('\n')
-      .map(f => f.trim())
-      .filter(f => f.length > 0 && existsSync(f));
-  } catch {
-    return [];
-  }
+  throw new Error(`Failed to determine changed files. Tried refs: ${refsToTry.join(', ')}`);
 }
 
 // --- ESLint Checker ---

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -26,7 +26,13 @@ const tsconfigCache = new Map();
 // --- Main Runner (Entry Point) ---
 async function run() {
   try {
-    const changedTsFiles = getChangedFiles();
+    const isStrict = Boolean(process.env.STRICT);
+    let changedTsFiles;
+    if (isStrict) {
+      changedTsFiles = getChangedFilesStrict();
+    } else {
+      changedTsFiles = getChangedFiles();
+    }
 
     if (changedTsFiles.length === 0) {
       console.log('No TypeScript files changed. Skipping checks.');
@@ -63,40 +69,18 @@ function runGit(args, options = {}) {
   });
 }
 
-/**
- * Helper to get modified/added TypeScript files against a given git ref.
- * Uses merge-base when possible to compare against the common ancestor (e.g. when base and branch have both moved).
- */
-function getDiffFiles(ref) {
-  let diffTarget = ref;
-  try {
-    const mergeBase = runGit(['merge-base', ref, 'HEAD']).trim();
-    if (mergeBase) {
-      diffTarget = mergeBase;
-    }
-  } catch {
-    // If merge-base fails (e.g. shallow clone or invalid ref), fall back to using ref directly
+function getChangedFilesStrict() {
+  const gitDiffArg = getGitDiffArg();
+
+  if (!gitDiffArg) {
+    throw new Error(
+      'Strict mode is enabled, but GIT_DIFF_ARG environment variable was not provided. ' +
+      'Please set the GIT_DIFF_ARG environment variable.'
+    );
   }
 
-  const output = runGit([
-    'diff',
-    '--name-only',
-    '--diff-filter=ACMRT',
-    diffTarget,
-    '--',
-    '*.ts',
-  ]);
-  return output
-    .split('\n')
-    .map(f => f.trim())
-    .filter(f => f.length > 0 && existsSync(f));
-}
+  console.log(`Strict mode enabled. Comparing using GIT_DIFF_ARG: ${gitDiffArg}`);
 
-/**
- * Helper to get modified/added TypeScript files in strict mode given GIT_DIFF_ARG.
- * Validates that `git diff --quiet ${gitDiffArg}` succeeds (exit code 0 or 1).
- */
-function getStrictDiffFiles(gitDiffArg) {
   const args = gitDiffArg.trim().split(/\s+/);
 
   try {
@@ -125,41 +109,42 @@ function getStrictDiffFiles(gitDiffArg) {
     .filter(f => f.length > 0 && existsSync(f));
 }
 
-/**
- * Retrieves the GIT_DIFF_ARG from CLI flags or environment variable.
- */
 function getGitDiffArg() {
-  const cliIndex = process.argv.findIndex(arg => arg.startsWith('--git-diff-arg'));
-  if (cliIndex !== -1) {
-    const arg = process.argv[cliIndex];
-    if (arg.includes('=')) {
-      return arg.substring(arg.indexOf('=') + 1);
-    }
-    if (process.argv[cliIndex + 1] && !process.argv[cliIndex + 1].startsWith('-')) {
-      return process.argv[cliIndex + 1];
-    }
-  }
   return process.env.GIT_DIFF_ARG;
 }
 
 /**
- * Returns a list of changed TypeScript files comparing against target branches/references.
+ * Helper to get modified/added TypeScript files against a given git ref when not in "strict mode"
+ */
+function getDiffFiles(ref) {
+  let diffTarget = ref;
+  try {
+    const mergeBase = runGit(['merge-base', ref, 'HEAD']).trim();
+    if (mergeBase) {
+      diffTarget = mergeBase;
+    }
+  } catch {
+    // If merge-base fails, fall back to using ref directly
+  }
+
+  const output = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRT',
+    diffTarget,
+    '--',
+    '*.ts',
+  ]);
+  return output
+    .split('\n')
+    .map(f => f.trim())
+    .filter(f => f.length > 0 && existsSync(f));
+}
+
+/**
+ * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode
  */
 function getChangedFiles() {
-  const isStrict = process.argv.includes('--strict');
-
-  const gitDiffArg = getGitDiffArg();
-
-  if (isStrict) {
-    if (!gitDiffArg) {
-      throw new Error(
-        'Strict mode is enabled (--strict), but GIT_DIFF_ARG was not provided. ' +
-        'Please supply --git-diff-arg <arg> or set the GIT_DIFF_ARG environment variable.'
-      );
-    }
-    console.log(`Strict mode enabled. Comparing using GIT_DIFF_ARG: ${gitDiffArg}`);
-    return getStrictDiffFiles(gitDiffArg);
-  }
 
   const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
 

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -145,7 +145,6 @@ function getDiffFiles(ref) {
  * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode
  */
 function getChangedFiles() {
-
   const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
 
   let refsToTry = [];

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -72,7 +72,12 @@ function getChangedFiles() {
   // Attempt to fetch the base branch and set origin/${base} so it doesn't compare against itself
   if (process.env.GITHUB_BASE_REF) {
     try {
-      runGit(['fetch', 'origin', base, '--depth=1']);
+      runGit([
+        'fetch',
+        'origin',
+        `+refs/heads/${base}:refs/remotes/origin/${base}`,
+        '--depth=1',
+      ]);
     } catch {
       // Continue if network fetch fails or remote does not exist
     }

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -124,19 +124,30 @@ function getChangedFilesStrict() {
 }
 
 /**
- * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode.
+ * Returns a list of changed TypeScript files comparing against target branches/references.
  */
 function getChangedFiles() {
-  let currentBranch = '';
-  try {
-    currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
-  } catch {
-    // Continue with fallback refs if branch detection fails
+  const base = process.env.GITHUB_BASE_REF || 'main';
+
+  // Attempt to fetch the base branch and set origin/${base} so it doesn't compare against itself
+  if (process.env.GITHUB_BASE_REF) {
+    try {
+      runGit(['fetch', 'origin', base, '--depth=1']);
+    } catch {
+      // Continue if network fetch fails or remote does not exist
+    }
   }
 
-  const refsToTry = (currentBranch === 'main')
-    ? ['origin/main', 'upstream/main', 'HEAD~1']
-    : ['upstream/main', 'origin/main', 'main'];
+  const refsToTry = [
+    `origin/${base}...HEAD`,
+    `${base}...HEAD`,
+    `upstream/${base}...HEAD`,
+    `origin/${base}`,
+    base,
+    `upstream/${base}`,
+    'HEAD~1',
+    'HEAD^',
+  ];
 
   for (const ref of refsToTry) {
     try {
@@ -144,21 +155,36 @@ function getChangedFiles() {
         'diff',
         '--name-only',
         '--diff-filter=ACMRT',
-        `${ref}...HEAD`,
+        ref,
         '--',
         '*.ts',
       ]);
-      console.log(`Comparing against base reference: ${ref}`);
       return output
         .split('\n')
         .map(f => f.trim())
         .filter(f => f.length > 0 && existsSync(f));
     } catch {
-      // Continue to next ref if this one fails/does not exist
+      // Continue to the next fallback ref
     }
   }
 
-  throw new Error(`Failed to determine changed files. Tried refs: ${refsToTry.join(', ')}`);
+  // Fallback to checking uncommitted working tree changes against HEAD if all specific refs fail
+  try {
+    const output = runGit([
+      'diff',
+      '--name-only',
+      '--diff-filter=ACMRT',
+      'HEAD',
+      '--',
+      '*.ts',
+    ]);
+    return output
+      .split('\n')
+      .map(f => f.trim())
+      .filter(f => f.length > 0 && existsSync(f));
+  } catch {
+    return [];
+  }
 }
 
 // --- ESLint Checker ---

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -26,7 +26,7 @@ const tsconfigCache = new Map();
 // --- Main Runner (Entry Point) ---
 async function run() {
   try {
-    const isStrict = Boolean(process.env.STRICT || process.argv.includes('--strict'));
+    const isStrict = Boolean(process.argv.includes('--strict'));
     let changedTsFiles;
     if (isStrict) {
       changedTsFiles = getChangedFilesStrict();
@@ -69,22 +69,8 @@ function runGit(args, options = {}) {
   });
 }
 
-function getGitDiffArg() {
-  const cliIndex = process.argv.findIndex(arg => arg.startsWith('--git-diff-arg'));
-  if (cliIndex !== -1) {
-    const arg = process.argv[cliIndex];
-    if (arg.includes('=')) {
-      return arg.substring(arg.indexOf('=') + 1);
-    }
-    if (process.argv[cliIndex + 1] && !process.argv[cliIndex + 1].startsWith('-')) {
-      return process.argv[cliIndex + 1];
-    }
-  }
-  return process.env.GIT_DIFF_ARG;
-}
-
 function getChangedFilesStrict() {
-  const gitDiffArg = getGitDiffArg();
+  const gitDiffArg = process.env.GIT_DIFF_ARG;
 
   if (!gitDiffArg) {
     throw new Error(
@@ -98,7 +84,18 @@ function getChangedFilesStrict() {
   const args = gitDiffArg.trim().split(/\s+/);
 
   try {
-    runGit(['diff', '--quiet', ...args]);
+    const output = runGit([
+      'diff',
+      '--name-only',
+      '--diff-filter=ACMRT',
+      ...args,
+      '--',
+      '*.ts',
+    ]);
+    return output
+      .split('\n')
+      .map(f => f.trim())
+      .filter(f => f.length > 0 && existsSync(f));
   } catch (err) {
     if (err.status !== 1) {
       throw new Error(
@@ -108,19 +105,6 @@ function getChangedFilesStrict() {
       );
     }
   }
-
-  const output = runGit([
-    'diff',
-    '--name-only',
-    '--diff-filter=ACMRT',
-    ...args,
-    '--',
-    '*.ts',
-  ]);
-  return output
-    .split('\n')
-    .map(f => f.trim())
-    .filter(f => f.length > 0 && existsSync(f));
 }
 
 /**
@@ -128,15 +112,6 @@ function getChangedFilesStrict() {
  */
 function getChangedFiles() {
   const base = process.env.GITHUB_BASE_REF || 'main';
-
-  // Attempt to fetch the base branch and set origin/${base} so it doesn't compare against itself
-  if (process.env.GITHUB_BASE_REF) {
-    try {
-      runGit(['fetch', 'origin', base, '--depth=1']);
-    } catch {
-      // Continue if network fetch fails or remote does not exist
-    }
-  }
 
   const refsToTry = [
     `origin/${base}...HEAD`,

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -70,7 +70,7 @@ function runGit(args, options = {}) {
 }
 
 function getChangedFilesStrict() {
-  const gitDiffArg = getGitDiffArg();
+  const gitDiffArg = process.env.GIT_DIFF_ARG;
 
   if (!gitDiffArg) {
     throw new Error(
@@ -107,10 +107,6 @@ function getChangedFilesStrict() {
     .split('\n')
     .map(f => f.trim())
     .filter(f => f.length > 0 && existsSync(f));
-}
-
-function getGitDiffArg() {
-  return process.env.GIT_DIFF_ARG;
 }
 
 /**

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -120,13 +120,17 @@ function getChangedFiles() {
   }
 
   if (currentBranch === 'main') {
-    try {
-      const files = getDiffFiles('HEAD~1');
-      console.log('Comparing against base reference: HEAD~1');
-      return files;
-    } catch {
-      throw new Error("Failed to determine changed files against 'HEAD~1' on main branch.");
+    const mainRefs = ['origin/main', 'upstream/main', 'HEAD~1'];
+    for (const ref of mainRefs) {
+      try {
+        const files = getDiffFiles(ref);
+        console.log(`Comparing against base reference: ${ref}`);
+        return files;
+      } catch {
+        // Continue to next ref
+      }
     }
+    throw new Error("Failed to determine changed files on main branch.");
   }
 
   const refsToTry = ['upstream/main', 'origin/main', 'main'];

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -26,7 +26,7 @@ const tsconfigCache = new Map();
 // --- Main Runner (Entry Point) ---
 async function run() {
   try {
-    const isStrict = Boolean(process.env.STRICT);
+    const isStrict = Boolean(process.env.STRICT || process.argv.includes('--strict'));
     let changedTsFiles;
     if (isStrict) {
       changedTsFiles = getChangedFilesStrict();
@@ -69,13 +69,27 @@ function runGit(args, options = {}) {
   });
 }
 
+function getGitDiffArg() {
+  const cliIndex = process.argv.findIndex(arg => arg.startsWith('--git-diff-arg'));
+  if (cliIndex !== -1) {
+    const arg = process.argv[cliIndex];
+    if (arg.includes('=')) {
+      return arg.substring(arg.indexOf('=') + 1);
+    }
+    if (process.argv[cliIndex + 1] && !process.argv[cliIndex + 1].startsWith('-')) {
+      return process.argv[cliIndex + 1];
+    }
+  }
+  return process.env.GIT_DIFF_ARG;
+}
+
 function getChangedFilesStrict() {
-  const gitDiffArg = process.env.GIT_DIFF_ARG;
+  const gitDiffArg = getGitDiffArg();
 
   if (!gitDiffArg) {
     throw new Error(
-      'Strict mode is enabled, but GIT_DIFF_ARG environment variable was not provided. ' +
-      'Please set the GIT_DIFF_ARG environment variable.'
+      'Strict mode is enabled, but GIT_DIFF_ARG environment variable or --git-diff-arg flag was not provided. ' +
+      'Please set the GIT_DIFF_ARG environment variable or provide --git-diff-arg <arg>.'
     );
   }
 

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -110,35 +110,7 @@ function getChangedFilesStrict() {
 }
 
 /**
- * Helper to get modified/added TypeScript files against a given git ref when not in "strict mode"
- */
-function getDiffFiles(ref) {
-  let diffTarget = ref;
-  try {
-    const mergeBase = runGit(['merge-base', ref, 'HEAD']).trim();
-    if (mergeBase) {
-      diffTarget = mergeBase;
-    }
-  } catch {
-    // If merge-base fails, fall back to using ref directly
-  }
-
-  const output = runGit([
-    'diff',
-    '--name-only',
-    '--diff-filter=ACMRT',
-    diffTarget,
-    '--',
-    '*.ts',
-  ]);
-  return output
-    .split('\n')
-    .map(f => f.trim())
-    .filter(f => f.length > 0 && existsSync(f));
-}
-
-/**
- * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode
+ * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode.
  */
 function getChangedFiles() {
   let currentBranch = '';
@@ -154,9 +126,19 @@ function getChangedFiles() {
 
   for (const ref of refsToTry) {
     try {
-      const files = getDiffFiles(ref);
+      const output = runGit([
+        'diff',
+        '--name-only',
+        '--diff-filter=ACMRT',
+        `${ref}...HEAD`,
+        '--',
+        '*.ts',
+      ]);
       console.log(`Comparing against base reference: ${ref}`);
-      return files;
+      return output
+        .split('\n')
+        .map(f => f.trim())
+        .filter(f => f.length > 0 && existsSync(f));
     } catch {
       // Continue to next ref if this one fails/does not exist
     }

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -17,7 +17,7 @@ import {existsSync} from 'fs';
 import path from 'path';
 import {promisify} from 'util';
 import {ESLint} from 'eslint';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 // --- Globals & Promisified API Wrappers ---
 const execFileAsync = promisify(execFile);

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -93,9 +93,74 @@ function getDiffFiles(ref) {
 }
 
 /**
+ * Helper to get modified/added TypeScript files in strict mode given GIT_DIFF_ARG.
+ * Validates that `git diff --quiet ${gitDiffArg}` succeeds (exit code 0 or 1).
+ */
+function getStrictDiffFiles(gitDiffArg) {
+  const args = gitDiffArg.trim().split(/\s+/);
+
+  try {
+    runGit(['diff', '--quiet', ...args]);
+  } catch (err) {
+    if (err.status !== 1) {
+      throw new Error(
+        `Strict mode error: git diff --quiet ${gitDiffArg} failed with exit code ${err.status}.\n` +
+        `Ensure that the git reference '${gitDiffArg}' exists locally and that you have fetched the required commits/branches.\n` +
+        `Details: ${String(err.stderr || err.message || '').trim()}`
+      );
+    }
+  }
+
+  const output = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRT',
+    ...args,
+    '--',
+    '*.ts',
+  ]);
+  return output
+    .split('\n')
+    .map(f => f.trim())
+    .filter(f => f.length > 0 && existsSync(f));
+}
+
+/**
+ * Retrieves the GIT_DIFF_ARG from CLI flags or environment variable.
+ */
+function getGitDiffArg() {
+  const cliIndex = process.argv.findIndex(arg => arg.startsWith('--git-diff-arg'));
+  if (cliIndex !== -1) {
+    const arg = process.argv[cliIndex];
+    if (arg.includes('=')) {
+      return arg.substring(arg.indexOf('=') + 1);
+    }
+    if (process.argv[cliIndex + 1] && !process.argv[cliIndex + 1].startsWith('-')) {
+      return process.argv[cliIndex + 1];
+    }
+  }
+  return process.env.GIT_DIFF_ARG;
+}
+
+/**
  * Returns a list of changed TypeScript files comparing against target branches/references.
  */
 function getChangedFiles() {
+  const isStrict = process.argv.includes('--strict');
+
+  const gitDiffArg = getGitDiffArg();
+
+  if (isStrict) {
+    if (!gitDiffArg) {
+      throw new Error(
+        'Strict mode is enabled (--strict), but GIT_DIFF_ARG was not provided. ' +
+        'Please supply --git-diff-arg <arg> or set the GIT_DIFF_ARG environment variable.'
+      );
+    }
+    console.log(`Strict mode enabled. Comparing using GIT_DIFF_ARG: ${gitDiffArg}`);
+    return getStrictDiffFiles(gitDiffArg);
+  }
+
   const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
 
   let refsToTry = [];

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -145,30 +145,16 @@ function getDiffFiles(ref) {
  * Returns a list of changed TypeScript files comparing against target branches/references when not in strict mode
  */
 function getChangedFiles() {
-  const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
-
-  let refsToTry = [];
-  let isStrictCI = false;
-
-  if (isCI) {
-    const baseRef = process.env.GITHUB_BASE_REF;
-    if (!baseRef) {
-      throw new Error('Running in CI but GITHUB_BASE_REF environment variable is not set.');
-    }
-    refsToTry = baseRef.startsWith('origin/') ? [baseRef] : [`origin/${baseRef}`, baseRef];
-    isStrictCI = true;
-  } else {
-    let currentBranch = '';
-    try {
-      currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
-    } catch {
-      // Continue with fallback refs if branch detection fails
-    }
-
-    refsToTry = (currentBranch === 'main')
-      ? ['origin/main', 'upstream/main', 'HEAD~1']
-      : ['upstream/main', 'origin/main', 'main'];
+  let currentBranch = '';
+  try {
+    currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+  } catch {
+    // Continue with fallback refs if branch detection fails
   }
+
+  const refsToTry = (currentBranch === 'main')
+    ? ['origin/main', 'upstream/main', 'HEAD~1']
+    : ['upstream/main', 'origin/main', 'main'];
 
   for (const ref of refsToTry) {
     try {
@@ -178,10 +164,6 @@ function getChangedFiles() {
     } catch {
       // Continue to next ref if this one fails/does not exist
     }
-  }
-
-  if (isStrictCI) {
-    throw new Error(`Failed to determine changed files against GITHUB_BASE_REF '${refsToTry[0]}' in CI.`);
   }
 
   throw new Error(`Failed to determine changed files. Tried refs: ${refsToTry.join(', ')}`);

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -106,7 +106,7 @@ function getChangedFiles() {
     if (!baseRef) {
       throw new Error('Running in CI but GITHUB_BASE_REF environment variable is not set.');
     }
-    refsToTry = [baseRef];
+    refsToTry = baseRef.startsWith('origin/') ? [baseRef] : [`origin/${baseRef}`, baseRef];
     isStrictCI = true;
   } else {
     let currentBranch = '';

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -17,7 +17,7 @@ import {existsSync} from 'fs';
 import path from 'path';
 import {promisify} from 'util';
 import {ESLint} from 'eslint';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 // --- Globals & Promisified API Wrappers ---
 const execFileAsync = promisify(execFile);

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -68,11 +68,23 @@ function runGit(args, options = {}) {
  */
 function getChangedFiles() {
   const base = process.env.GITHUB_BASE_REF || 'main';
+
+  // Attempt to fetch the base branch and set origin/${base} so it doesn't compare against itself
+  if (process.env.GITHUB_BASE_REF) {
+    try {
+      runGit(['fetch', 'origin', base, '--depth=1']);
+    } catch {
+      // Continue if network fetch fails or remote does not exist
+    }
+  }
+
   const refsToTry = [
+    `origin/${base}...HEAD`,
+    `${base}...HEAD`,
+    `upstream/${base}...HEAD`,
+    `origin/${base}`,
     base,
     `upstream/${base}`,
-    `origin/${base}`,
-    'FETCH_HEAD',
     'HEAD~1',
     'HEAD^',
   ];

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -94,46 +94,34 @@ function getDiffFiles(ref) {
 
 /**
  * Returns a list of changed TypeScript files comparing against target branches/references.
+ * Fully hermetic (uses local git references and merge-base with no network calls).
  */
 function getChangedFiles() {
   const isCI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITHUB_BASE_REF);
+
+  let refsToTry = [];
+  let isStrictCI = false;
 
   if (isCI) {
     const baseRef = process.env.GITHUB_BASE_REF;
     if (!baseRef) {
       throw new Error('Running in CI but GITHUB_BASE_REF environment variable is not set.');
     }
+    refsToTry = [baseRef];
+    isStrictCI = true;
+  } else {
+    let currentBranch = '';
     try {
-      const files = getDiffFiles(baseRef);
-      console.log(`Comparing against base reference: ${baseRef}`);
-      return files;
+      currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
     } catch {
-      throw new Error(`Failed to determine changed files against GITHUB_BASE_REF '${baseRef}' in CI.`);
+      // Continue with fallback refs if branch detection fails
     }
+
+    refsToTry = currentBranch === 'main'
+      ? ['origin/main', 'upstream/main', 'HEAD~1']
+      : ['upstream/main', 'origin/main', 'main'];
   }
 
-  let currentBranch = '';
-  try {
-    currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
-  } catch {
-    // Continue with fallback refs if branch detection fails
-  }
-
-  if (currentBranch === 'main') {
-    const mainRefs = ['origin/main', 'upstream/main', 'HEAD~1'];
-    for (const ref of mainRefs) {
-      try {
-        const files = getDiffFiles(ref);
-        console.log(`Comparing against base reference: ${ref}`);
-        return files;
-      } catch {
-        // Continue to next ref
-      }
-    }
-    throw new Error("Failed to determine changed files on main branch.");
-  }
-
-  const refsToTry = ['upstream/main', 'origin/main', 'main'];
   for (const ref of refsToTry) {
     try {
       const files = getDiffFiles(ref);
@@ -142,6 +130,10 @@ function getChangedFiles() {
     } catch {
       // Continue to next ref if this one fails/does not exist
     }
+  }
+
+  if (isStrictCI) {
+    throw new Error(`Failed to determine changed files against GITHUB_BASE_REF '${refsToTry[0]}' in CI.`);
   }
 
   throw new Error(`Failed to determine changed files. Tried refs: ${refsToTry.join(', ')}`);


### PR DESCRIPTION
Fixes an issue where `./bin/linter.mjs` skipped TypeScript checks in CI pull request workflows because it's incorrectly detecting no TS file changes. Updates linter logic to be hermetic.

It looks like the CI was comparing "head" to "head". It was running `git diff FETCH_HEAD -- *.ts`, but we need to fetch from origin before doing that. Previously, the linter was going in order of the `refsToTry` array to check which reference existed in order to diff against it:
1. `main`, `upstream/main`, and `origin/main` failed
2. `'FETCH_HEAD'`, existed and pointed to the checked-out PR commit (`HEAD`).
3. Running `git diff --name-only FETCH_HEAD -- *.ts` compared `HEAD` against itself, which succeeded with an exit code of `0` and returned an empty file list (`""`)

Fixes:
- Removed git fetch calls so the script relies solely on local Git history provided by actions/checkout.
- Added `STRICT` mode to ./bin/linter.mjs, configured in presubmit.yaml
- Uses git merge-base to accurately identify changed files when both main and the branch have moved.
- Fails explicitly in CI if GITHUB_BASE_REF is missing or invalid, or if the GIT_DIFF_ARG is missing in STRICT mode
- Streamlined reference resolution for local development and added logging for the chosen base reference.