### PR TITLE
feat!: Update jsdoc-region-tag to minimum Node version of 22.

### DIFF
--- a/core/dev-packages/jsdoc-region-tag/package.json
+++ b/core/dev-packages/jsdoc-region-tag/package.json
@@ -43,6 +43,6 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985