### PR TITLE
feat!: Update gapic-node-processing to minimum Node version of 22.

### DIFF
--- a/core/packages/gapic-node-processing/package.json
+++ b/core/packages/gapic-node-processing/package.json
@@ -40,7 +40,7 @@
     "snap-shot-it": "^7.9.10"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985