### PR TITLE
chore: ignore minified proto runtime scripts in CI header check

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -11,6 +11,7 @@ sourceFileExtensions:
 ignoreFiles:
   - 'packages/*/webpack.config.js'
   - 'packages/*/__snapshots__/**/*.js'
+  - '**/protos/protos.js'
   - 'core/packages/typeless-sample-bot/test/fixtures/**/*.ts'
   - 'core/packages/typeless-sample-bot/test/fixtures/**/*.js'
 ignoreLicenseYear: true


### PR DESCRIPTION
Add minified protobuf runtime scripts (protos/protos.js) to ignoreFiles in .github/header-checker-lint.yml.

Copyright headers do not need to be validated in minified protobuf scripts because these files are automatically generated during the build process. The compilation step strips comments and whitespace to reduce bundle size, which removes the copyright header and causes false positives in CI validation.
