### PR TITLE
feat!: Update google-auth-library-nodejs to minimum Node version of 22.

### DIFF
--- a/core/packages/google-auth-library-nodejs/package.json
+++ b/core/packages/google-auth-library-nodejs/package.json
@@ -4,7 +4,7 @@
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985
