### PR TITLE
feat!: Update nodejs-googleapis-common to minimum Node version of 22.

### DIFF
--- a/core/packages/nodejs-googleapis-common/package.json
+++ b/core/packages/nodejs-googleapis-common/package.json
@@ -87,7 +87,7 @@
     "webpack-cli": "^6.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/nodejs-googleapis-common"
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985