### PR TITLE
feat!: Update gapic-tools to minimum Node version of 22.

### DIFF
--- a/core/packages/tools/package.json
+++ b/core/packages/tools/package.json
@@ -65,6 +65,6 @@
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/tools",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985 