### PR TITLE
feat!: Update typeless-sample-bot to minimum Node version of 22.

### DIFF
--- a/core/packages/typeless-sample-bot/package.json
+++ b/core/packages/typeless-sample-bot/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "repository": "googleapis/google-cloud-node",
   "bin": "./build/src/bin/typeless-sample-bot.js",


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985
