### PR TITLE
ci(workflows): add librarian generation check presubmit

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -1,5 +1,6 @@
 ---
 name: generation-check
+
 on:
   push:
     branches:
@@ -7,12 +8,22 @@ on:
   pull_request:
   # Allows manual triggering for debugging purpose.
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  issues: write
+
 jobs:
   regeneration:
+    name: Regenerate and verify clean git tree
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # zizmor: ignore[undocumented-permissions] - Required for creating issue on main branch failure
+      issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -24,8 +35,8 @@ jobs:
             librarian:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
-      # main corresponds to the action's source definition.
-      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
+      # action is pinned to commit SHA to satisfy blanket security policy.
+      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
       - name: Install tools
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -44,7 +55,7 @@ jobs:
           fi
       - name: Create issue if previous step fails
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main # zizmor: ignore[unpinned-uses]
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
         with:
           title: "Librarian generate diff check failed on main branch"
           body: |

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -1,56 +1,55 @@
+---
 name: generation-check
-
 on:
   push:
     branches:
       - main
   pull_request:
+  # Allows manual triggering for debugging purpose.
   workflow_dispatch:
-
 permissions:
   contents: read
-
+  issues: write
 jobs:
   regeneration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
             librarian:
               - 'librarian.yaml'
-              - '.readme-partials.yaml'
-              - '**/librarian.js'
-              - '**/librarian.ts'
-
-      - name: Setup Node.js
+      # Version of librarian is pulled from librarian.yaml,
+      # main corresponds to the action's source definition.
+      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - uses: googleapis/librarian@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
-        if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-
       - name: Install tools
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: librarian install
-
-      - name: Regenerate and Assert Clean Git Tree
+      - name: Regenerate
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
           librarian generate --all
           if [ -n "$(git status --porcelain)" ]; then
             git status
             echo "==================== GIT DIFF ===================="
-            git add -N .
             git diff
             echo "=================================================="
-            echo "Regeneration failed. Please run 'librarian generate --all' locally to update generated files."
+            echo "Regeneration failed. Please run 'librarian generate --all' to update the generated files."
             exit 1
           fi
+      - name: Create issue if previous step fails
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main # zizmor: ignore[unpinned-uses]
+        with:
+          title: "Librarian generate diff check failed on main branch"
+          body: |
+            The librarian generate diff check failed on main branch.
+
+            To keep the `main` branch healthy, please consider **reverting the triggering change** first. Once the revert is merged, you can investigate the failure and submit a new PR with the fix.
+
+            Please check the logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -24,10 +24,10 @@ jobs:
       contents: read # Read repository contents
       issues: write # Required for creating issue on main branch failure
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -35,7 +35,7 @@ jobs:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # action is pinned to commit SHA to satisfy blanket security policy.
-      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
+      - uses: googleapis/librarian@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
       - name: Install tools
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -54,7 +54,7 @@ jobs:
           fi
       - name: Create issue if previous step fails
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: googleapis/librarian/.github/actions/create-issue-on-failure@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
         with:
           title: "Librarian generate diff check failed on main branch"
           body: |

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -14,16 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: read # Read repository contents
 
 jobs:
   regeneration:
     name: Regenerate and verify clean git tree
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      # zizmor: ignore[excessive-permissions,undocumented-permissions] - Required for creating issue on main branch failure
-      issues: write
+      contents: read # Read repository contents
+      issues: write # Required for creating issue on main branch failure
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -24,10 +24,10 @@ jobs:
       contents: read # Read repository contents
       issues: write # Required for creating issue on main branch failure
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
         id: changes
         with:
           filters: |

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # zizmor: ignore[undocumented-permissions] - Required for creating issue on main branch failure
+      # zizmor: ignore[excessive-permissions,undocumented-permissions] - Required for creating issue on main branch failure
       issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -1,0 +1,56 @@
+name: generation-check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  regeneration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
+        id: changes
+        with:
+          filters: |
+            librarian:
+              - 'librarian.yaml'
+              - '.readme-partials.yaml'
+              - '**/librarian.js'
+              - '**/librarian.ts'
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.27.1
+        if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+      - name: Install tools
+        if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: librarian install
+
+      - name: Regenerate and Assert Clean Git Tree
+        if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: |
+          librarian generate --all
+          if [ -n "$(git status --porcelain)" ]; then
+            git status
+            echo "==================== GIT DIFF ===================="
+            git add -N .
+            git diff
+            echo "=================================================="
+            echo "Regeneration failed. Please run 'librarian generate --all' locally to update generated files."
+            exit 1
+          fi

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.27.1
+      - uses: googleapis/librarian@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
         if: steps.changes.outputs.librarian == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
       - name: Install tools

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -1,0 +1,42 @@
+name: librarian tidy
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tidy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        with:
+          filters: |
+            librarian:
+              - 'librarian.yaml'
+      # Version of librarian is pulled from librarian.yaml,
+      # main corresponds to the action's source definition.
+      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
+
+      - name: Run librarian tidy
+        if: steps.changes.outputs.librarian == 'true'
+        run: librarian tidy
+
+      - name: Check for diff
+        if: steps.changes.outputs.librarian == 'true'
+        run: |
+          if ! git diff --exit-code; then
+            V=$(librarian config get version 2>/dev/null || echo "latest")
+            echo "librarian.yaml is not tidy. Please run:"
+            echo ""
+            echo "  librarian tidy"
+            echo ""
+            echo "to tidy librarian.yaml and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -27,7 +27,7 @@ jobs:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # action is pinned to commit SHA to satisfy blanket security policy.
-      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
+      - uses: googleapis/librarian@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
 
       - name: Run librarian tidy
         if: steps.changes.outputs.librarian == 'true'

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -3,11 +3,16 @@ name: librarian tidy
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   tidy-check:
+    name: Verify librarian.yaml is tidy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,8 +26,8 @@ jobs:
             librarian:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
-      # main corresponds to the action's source definition.
-      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
+      # action is pinned to commit SHA to satisfy blanket security policy.
+      - uses: googleapis/librarian@a02c28273b3c9ddb33bbe5849a44b6a678d28404 # v0.31.1
 
       - name: Run librarian tidy
         if: steps.changes.outputs.librarian == 'true'

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
         id: changes
         with:
           filters: |


### PR DESCRIPTION
Modifications to librarian configuration and generator scripts require downstream generated code to be kept in sync with upstream changes.

Adds .github/workflows/generation_check.yaml to run on pull requests that modify librarian.yaml, .readme-partials.yaml, librarian.js, or librarian.ts, as well as on main branch pushes and workflow_dispatch events. The workflow sets up Node.js 22, installs Librarian dependencies, executes librarian generate --all across configured packages, and asserts zero uncommitted git diffs exist.

Closes googleapis/librarian#5352
