### PR TITLE
feat!: Update bigquery to minimum Node version of 22.

### DIFF
--- a/handwritten/bigquery/package.json
+++ b/handwritten/bigquery/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985