### PR TITLE
feat!: Update bigquery-storage to minimum Node version of 22.

### DIFF
--- a/handwritten/bigquery-storage/package.json
+++ b/handwritten/bigquery-storage/package.json
@@ -66,7 +66,7 @@
     "webpack-cli": "^6.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/handwritten/bigquery-storage"
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985

