### PR TITLE
feat!: Update bigtable to minimum Node version of 22.

### DIFF
--- a/handwritten/bigtable/package.json
+++ b/handwritten/bigtable/package.json
@@ -111,7 +111,7 @@
     "webpack-cli": "^6.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/handwritten/bigtable"
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985

