### PR TITLE
feat!: Update datastore to minimum Node version of 22.

### DIFF
--- a/handwritten/datastore/package.json
+++ b/handwritten/datastore/package.json
@@ -83,7 +83,7 @@
     "webpack-cli": "^6.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/handwritten/datastore"
 }


### PR DESCRIPTION
## Description

Upgrade the Node version from 18 to 22.

Towards #8985

