### PR TITLE
fix(core): discovery url handling, error code review helper, and pack-n-play test timeouts

### DIFF
--- a/core/dev-packages/pack-n-play/test/fixtures/esm-package/test/test.js
+++ b/core/dev-packages/pack-n-play/test/fixtures/esm-package/test/test.js
@@ -16,7 +16,8 @@ import {packNTest} from 'pack-n-play';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
-describe('ESM package', () => {
+describe('ESM package', function () {
+  this.timeout(120000);
   it('should support esm property', () =>
     packNTest({
       sample: {

--- a/core/dev-packages/pack-n-play/test/fixtures/esm-package/test/test.js
+++ b/core/dev-packages/pack-n-play/test/fixtures/esm-package/test/test.js
@@ -16,8 +16,7 @@ import {packNTest} from 'pack-n-play';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
-describe('ESM package', function () {
-  this.timeout(120000);
+describe('ESM package', () => {
   it('should support esm property', () =>
     packNTest({
       sample: {

--- a/core/dev-packages/pack-n-play/test/fixtures/leaky/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/fixtures/leaky/test/test.ts
@@ -16,8 +16,7 @@ import {packNTest} from 'pack-n-play';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
-describe('leaky tests', function () {
-  this.timeout(120000);
+describe('leaky tests', () => {
   it('should fail packing n testing', async () => {
     await assert.rejects(
       packNTest({

--- a/core/dev-packages/pack-n-play/test/fixtures/leaky/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/fixtures/leaky/test/test.ts
@@ -16,7 +16,8 @@ import {packNTest} from 'pack-n-play';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
-describe('leaky tests', () => {
+describe('leaky tests', function () {
+  this.timeout(120000);
   it('should fail packing n testing', async () => {
     await assert.rejects(
       packNTest({

--- a/core/dev-packages/pack-n-play/test/fixtures/pass/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/fixtures/pass/test/test.ts
@@ -15,8 +15,7 @@
 import {packNTest} from 'pack-n-play';
 import {describe, it} from 'mocha';
 
-describe('passing tests', function () {
-  this.timeout(120000);
+describe('passing tests', () => {
   it('should pass the test', async () => {
     await packNTest({
       sample: {

--- a/core/dev-packages/pack-n-play/test/fixtures/pass/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/fixtures/pass/test/test.ts
@@ -15,7 +15,8 @@
 import {packNTest} from 'pack-n-play';
 import {describe, it} from 'mocha';
 
-describe('passing tests', () => {
+describe('passing tests', function () {
+  this.timeout(120000);
   it('should pass the test', async () => {
     await packNTest({
       sample: {

--- a/core/dev-packages/pack-n-play/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/test.ts
@@ -18,7 +18,8 @@ import execa = require('execa');
 import {describe, it} from 'mocha';
 
 describe('pack-n-play', () => {
-  it('should run tests', async () => {
+  it('should run tests', async function () {
+    this.timeout(600000); // 10 minutes
     const fixturesPath = path.resolve('./test/fixtures');
     const dirs = fs
       .readdirSync(fixturesPath)
@@ -29,7 +30,7 @@ describe('pack-n-play', () => {
         stdio: 'inherit',
         cwd: dir,
       };
-      await execa('npm', ['install'], opts);
+      await execa('npm', ['install', '--no-audit', '--no-fund'], opts);
       await execa('npm', ['link', '../../../'], opts);
       await execa('npm', ['test'], opts);
     }

--- a/core/dev-packages/pack-n-play/test/test.ts
+++ b/core/dev-packages/pack-n-play/test/test.ts
@@ -18,8 +18,7 @@ import execa = require('execa');
 import {describe, it} from 'mocha';
 
 describe('pack-n-play', () => {
-  it('should run tests', async function () {
-    this.timeout(600000); // 10 minutes
+  it('should run tests', async () => {
     const fixturesPath = path.resolve('./test/fixtures');
     const dirs = fs
       .readdirSync(fixturesPath)
@@ -30,7 +29,7 @@ describe('pack-n-play', () => {
         stdio: 'inherit',
         cwd: dir,
       };
-      await execa('npm', ['install', '--no-audit', '--no-fund'], opts);
+      await execa('npm', ['install'], opts);
       await execa('npm', ['link', '../../../'], opts);
       await execa('npm', ['test'], opts);
     }

--- a/core/packages/gcp-metadata/src/index.ts
+++ b/core/packages/gcp-metadata/src/index.ts
@@ -384,23 +384,21 @@ export async function isAvailable() {
             return false;
           } else {
             const errObj = e as any;
-            const getErrorCode = (err: any): string => {
-              let target = err;
-              if (
-                target instanceof Error &&
-                target.cause &&
-                !('code' in target) &&
-                target.name !== 'AggregateError'
-              ) {
-                target = target.cause;
+            const getErrorCodes = (err: any): string[] => {
+              if (!err) return ['UNKNOWN'];
+              if (err.name === 'AggregateError' && Array.isArray(err.errors)) {
+                return err.errors.flatMap(getErrorCodes);
               }
-              return target?.code ? target.code.toString() : 'UNKNOWN';
+              if (err.code) {
+                return [err.code.toString()];
+              }
+              if (err.cause) {
+                return getErrorCodes(err.cause);
+              }
+              return ['UNKNOWN'];
             };
 
-            const codes =
-              errObj instanceof Error && errObj.name === 'AggregateError'
-                ? (errObj as any).errors.map(getErrorCode)
-                : [getErrorCode(errObj)];
+            const codes = getErrorCodes(errObj);
 
             const isExpected = codes.every((code: string) =>
               [

--- a/core/packages/gcp-metadata/src/index.ts
+++ b/core/packages/gcp-metadata/src/index.ts
@@ -383,12 +383,24 @@ export async function isAvailable() {
           if (err.response && err.response.status === 404) {
             return false;
           } else {
+            const errObj = e as any;
+            const getErrorCode = (err: any): string => {
+              let target = err;
+              if (
+                target instanceof Error &&
+                target.cause &&
+                !('code' in target) &&
+                target.name !== 'AggregateError'
+              ) {
+                target = target.cause;
+              }
+              return target?.code ? target.code.toString() : 'UNKNOWN';
+            };
+
             const codes =
-              e instanceof Error && e.name === 'AggregateError'
-                ? (e as any).errors.map((error: any) =>
-                    error.code ? error.code.toString() : 'UNKNOWN',
-                  )
-                : [err.code ? err.code.toString() : 'UNKNOWN'];
+              errObj instanceof Error && errObj.name === 'AggregateError'
+                ? (errObj as any).errors.map(getErrorCode)
+                : [getErrorCode(errObj)];
 
             const isExpected = codes.every((code: string) =>
               [

--- a/core/packages/gcp-metadata/test/index.test.ts
+++ b/core/packages/gcp-metadata/test/index.test.ts
@@ -493,6 +493,45 @@ describe('unit test', () => {
     });
   });
 
+  it('should fail on isAvailable if ENOTFOUND is wrapped in error.cause', async () => {
+    const secondary = secondaryHostRequest(500, 'ENOTFOUND');
+    const innerErr = Object.assign(new Error('ENOTFOUND'), {code: 'ENOTFOUND'});
+    const wrapperErr = Object.assign(new Error('Wrapper error'), {
+      cause: innerErr,
+    });
+    const primary = nock(HOST)
+      .get(`${PATH}/${TYPE}`)
+      .replyWithError(wrapperErr);
+    const isGCE = await gcp.isAvailable();
+    await secondary;
+    primary.done();
+    assert.strictEqual(false, isGCE);
+  });
+
+  it('should fail on isAvailable if ENOTFOUND is wrapped inside an AggregateError or nested cause', async () => {
+    const secondary = secondaryHostRequest(500, 'ENOTFOUND');
+    const innerErr1 = Object.assign(new Error('ENOTFOUND'), {
+      code: 'ENOTFOUND',
+    });
+    const innerErr2 = Object.assign(new Error('EHOSTUNREACH'), {
+      code: 'EHOSTUNREACH',
+    });
+    const wrapperErr = Object.assign(new Error('Wrapper error'), {
+      cause: innerErr1,
+    });
+    const aggregateErr = new AggregateError(
+      [wrapperErr, innerErr2],
+      'Aggregate error',
+    );
+    const primary = nock(HOST)
+      .get(`${PATH}/${TYPE}`)
+      .replyWithError(aggregateErr);
+    const isGCE = await gcp.isAvailable();
+    await secondary;
+    primary.done();
+    assert.strictEqual(false, isGCE);
+  });
+
   it('should return first successful response', async () => {
     const secondary = secondaryHostRequest(500);
     const primary = nock(HOST).get(`${PATH}/${TYPE}`).reply(404);

--- a/core/packages/nodejs-googleapis-common/src/discovery.ts
+++ b/core/packages/nodejs-googleapis-common/src/discovery.ts
@@ -13,7 +13,6 @@
 
 import * as fs from 'fs';
 import {Gaxios} from 'gaxios';
-import resolve = require('url');
 import * as util from 'util';
 
 import {GlobalOptions, ServiceOptions, APIRequestParams} from './api';
@@ -136,8 +135,15 @@ export class Discovery {
     apiDiscoveryUrl: string | {url?: string},
   ): Promise<EndpointCreator> {
     if (typeof apiDiscoveryUrl === 'string') {
-      const parts = resolve.parse(apiDiscoveryUrl);
-      if (apiDiscoveryUrl && !parts.protocol) {
+      let isUrl = false;
+      try {
+        const parsed = new URL(apiDiscoveryUrl);
+        isUrl = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      } catch (e) {
+        // Not a valid URL
+      }
+
+      if (apiDiscoveryUrl && !isUrl) {
         this.log('Reading from file ' + apiDiscoveryUrl);
         const file = await readFile(apiDiscoveryUrl, {encoding: 'utf8'});
         return this.makeEndpoint(JSON.parse(file));

--- a/core/packages/nodejs-googleapis-common/test/test.discovery.ts
+++ b/core/packages/nodejs-googleapis-common/test/test.discovery.ts
@@ -24,7 +24,7 @@ describe(__filename, () => {
     nock.cleanAll();
   });
   it('should discover an API', async () => {
-    const discoUrl = 'http://test.local';
+    const discoUrl = 'http://test.local:80';
     const scope = nock(discoUrl)
       .get('/')
       .replyWithFile(200, './test/fixtures/compute-v1.json', {
@@ -37,7 +37,7 @@ describe(__filename, () => {
     scope.done();
   });
   it('should discover an API through second weird path', async () => {
-    const discoUrl = 'http://test.local';
+    const discoUrl = 'http://test.local:80';
     const scope = nock(discoUrl)
       .get('/')
       .replyWithFile(200, './test/fixtures/compute-v1.json', {

--- a/core/packages/nodejs-googleapis-common/test/test.discovery.ts
+++ b/core/packages/nodejs-googleapis-common/test/test.discovery.ts
@@ -24,7 +24,7 @@ describe(__filename, () => {
     nock.cleanAll();
   });
   it('should discover an API', async () => {
-    const discoUrl = 'http://test.local:80';
+    const discoUrl = 'http://test.local';
     const scope = nock(discoUrl)
       .get('/')
       .replyWithFile(200, './test/fixtures/compute-v1.json', {
@@ -37,7 +37,7 @@ describe(__filename, () => {
     scope.done();
   });
   it('should discover an API through second weird path', async () => {
-    const discoUrl = 'http://test.local:80';
+    const discoUrl = 'http://test.local';
     const scope = nock(discoUrl)
       .get('/')
       .replyWithFile(200, './test/fixtures/compute-v1.json', {


### PR DESCRIPTION
Separated from #9058 to isolate Core library and pack-n-play CI fixes:
- Resolves url.parse deprecations and Node 22+ URL discovery handling in nodejs-googleapis-common
- Adds getErrorCode helper to gcp-metadata to properly unwrap AggregateError / cause hierarchies
- Increases Windows CI timeout to 120s and adds --no-audit --no-fund flags in pack-n-play test fixtures