### PR TITLE
chore(ci): rename conformance workflows for clarity

### DIFF
--- a/.github/workflows/bigtable-conformance.yaml
+++ b/.github/workflows/bigtable-conformance.yaml
@@ -25,7 +25,7 @@ on:
   pull_request:
     paths:
     - 'handwritten/bigtable/**'
-name: conformance
+name: bigtable-conformance
 jobs:
   conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/storage-conformance.yaml
+++ b/.github/workflows/storage-conformance.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
     paths:
       - 'handwritten/storage/**'
-name: conformance
+name: storage-conformance
 jobs:
   conformance-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Separated from #9058 to isolate GitHub Actions workflow renames:
- Renames .github/workflows/conformance.yaml -> .github/workflows/bigtable-conformance.yaml (and updates name field to bigtable-conformance)
- Renames .github/workflows/conformance-test.yaml -> .github/workflows/storage-conformance.yaml (and updates name field to storage-conformance)