### PR TITLE
fix(ci): ensure package dependencies are installed before linting (#8968)

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -40,6 +40,9 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: ^10.0.0
       - run: npm install
       - run: node ./bin/linter.mjs --strict
         name: Run monorepo linter

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -24,6 +24,41 @@ const execFileAsync = promisify(execFile);
 const tsconfigCache = new Map();
 
 // --- Main Runner (Entry Point) ---
+
+/**
+ * Ensures that node_modules exists in all affected packages so ESLint can resolve
+ * configs (e.g. node_modules/gts) and TypeScript can resolve imported types.
+ */
+async function ensurePackageDependencies(filesToCheck) {
+  const affectedPackages = new Set();
+  for (const file of filesToCheck) {
+    const tsconfigDir = findTsconfigDir(file);
+    if (tsconfigDir && tsconfigDir !== process.cwd()) {
+      affectedPackages.add(tsconfigDir);
+    }
+  }
+
+  if (affectedPackages.size === 0) {
+    return;
+  }
+
+  console.log(`\nEnsuring package dependencies are installed in ${affectedPackages.size} package(s)...`);
+  for (const pkg of affectedPackages) {
+    if (!existsSync(path.join(pkg, 'node_modules'))) {
+      console.log(`  Installing dependencies in ${pkg}...`);
+      try {
+        await execFileAsync('pnpm', ['install', '--ignore-scripts'], { cwd: pkg });
+      } catch (err) {
+        try {
+          await execFileAsync('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund'], { cwd: pkg });
+        } catch (npmErr) {
+          console.warn(`  [WARN] Failed to install dependencies in ${pkg}: ${npmErr.message}`);
+        }
+      }
+    }
+  }
+}
+
 async function run() {
   try {
     const isStrict = Boolean(process.argv.includes('--strict'));
@@ -38,6 +73,8 @@ async function run() {
       console.log('No TypeScript files changed. Skipping checks.');
       return;
     }
+
+    await ensurePackageDependencies(changedTsFiles);
 
     // Run ESLint and Type checks in parallel to optimize CPU utilization
     const [eslintPassed, typeSafetyPassed] = await Promise.all([


### PR DESCRIPTION
Fixes ESLint and TypeScript checks in `bin/linter.mjs` when changed files belong to packages that require sub-package dependencies (e.g. `node_modules/gts`).

### Changes
- **`bin/linter.mjs`**: Automatically installs package dependencies in affected package directories before running ESLint or TypeScript type checks so extended ESLint configs (`gts`) and imported types resolve cleanly.
- **`.github/workflows/presubmit.yaml`**: Adds `pnpm/action-setup` to the `lint` job so package dependency installations are fast and cached in CI.