### PR TITLE
chore(release-please): move handwritten libraries into monorepo release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -69,6 +69,39 @@
     "core/promisify": {
       "component": "promisify"
     },
+    "handwritten/bigquery": {
+      "component": "bigquery"
+    },
+    "handwritten/bigquery-storage": {
+      "component": "bigquery-storage"
+    },
+    "handwritten/bigtable": {
+      "component": "bigtable"
+    },
+    "handwritten/cloud-profiler": {
+      "component": "cloud-profiler"
+    },
+    "handwritten/datastore": {
+      "component": "datastore"
+    },
+    "handwritten/error-reporting": {
+      "component": "error-reporting"
+    },
+    "handwritten/google-cloud-dns": {
+      "component": "dns"
+    },
+    "handwritten/logging": {
+      "component": "logging"
+    },
+    "handwritten/logging-bunyan": {
+      "component": "logging-bunyan"
+    },
+    "handwritten/logging-winston": {
+      "component": "logging-winston"
+    },
+    "handwritten/pubsub": {
+      "component": "pubsub"
+    },
     "packages/google-ads-admanager": {},
     "packages/google-ads-datamanager": {},
     "packages/google-ai-generativelanguage": {},

--- a/release-please-submodules.json
+++ b/release-please-submodules.json
@@ -2,41 +2,8 @@
   "commit-batch-size": 10,
   "include-component-in-tag": true,
   "packages": {
-    "handwritten/bigquery": {
-      "component": "bigquery"
-    },
-    "handwritten/bigquery-storage": {
-      "component": "bigquery-storage"
-    },
-    "handwritten/bigtable": {
-      "component": "bigtable"
-    },
-    "handwritten/cloud-profiler": {
-      "component": "cloud-profiler"
-    },
-    "handwritten/datastore": {
-      "component": "datastore"
-    },
-    "handwritten/error-reporting": {
-      "component": "error-reporting"
-    },
     "handwritten/firestore": {
       "component": "firestore"
-    },
-    "handwritten/google-cloud-dns": {
-      "component": "dns"
-    },
-    "handwritten/logging": {
-      "component": "logging"
-    },
-    "handwritten/logging-bunyan": {
-      "component": "logging-bunyan"
-    },
-    "handwritten/logging-winston": {
-      "component": "logging-winston"
-    },
-    "handwritten/pubsub": {
-      "component": "pubsub"
     },
     "handwritten/spanner": {
       "component": "spanner"


### PR DESCRIPTION
Moves all handwritten libraries except @google-cloud/spanner, @google-cloud/storage, and @google-cloud/firestore from release-please-submodules.json into the monorepo release-please-config.json.