### PR TITLE
fix: cast to service options for the auth library

### DIFF
--- a/packages/google-cloud-translate/package.json
+++ b/packages/google-cloud-translate/package.json
@@ -64,7 +64,7 @@
     "c8": "^10.1.3",
     "codecov": "^3.8.3",
     "gapic-tools": "^2.0.0",
-    "google-auth-library": "^10.6.2",
+    "google-auth-library": "^11.0.0",
     "gts": "^6.0.2",
     "http2spy": "^2.0.2",
     "jsdoc": "^4.0.4",

--- a/packages/google-cloud-translate/src/v2/index.ts
+++ b/packages/google-cloud-translate/src/v2/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Service, util, Metadata} from '@google-cloud/common';
+import {Service, ServiceOptions, util, Metadata} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import * as extend from 'extend';
@@ -149,7 +149,7 @@ export class Translate extends Service {
       projectIdRequired: false,
     };
 
-    super(config, options);
+    super(config, options as ServiceOptions);
     this.options = options || {};
     if (this.options.key) {
       this.key = this.options.key;


### PR DESCRIPTION
## Description

Upgrading the auth library causes a compiler error which we address with a cast. It won't affect how the code works and the compiler error looks like it was just caused by a difference in autogeneration where one interface property marks the auth client as optional as indicated by the `Type 'AuthClient' is not assignable to type 'AuthClient | GoogleAuth<AuthClient> | undefined'.` line in the console. This is unlikely to indicate a problem with upgrading the auth dependency.

## Impact

Completes the auth dependency upgrade

## Additional Information

Although the change is in the generated library section and ideally we don't make manual changes there, if the change gets overwritten then our CI pipeline will tell us immediately by reporting a compiler error. Therefore, it is fine if we upgrade the dependency now in order to ensure all Node dependencies are on version 22.