### PR TITLE
fix(linter): update ESLint extends path in handwritten packages

### DIFF
--- a/handwritten/bigquery-storage/.eslintrc.json
+++ b/handwritten/bigquery-storage/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/bigquery/.eslintrc.json
+++ b/handwritten/bigquery/.eslintrc.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./node_modules/gts",
+  "extends": "../../node_modules/gts",
   "root": true
 }

--- a/handwritten/bigtable/.eslintrc.json
+++ b/handwritten/bigtable/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/cloud-profiler/.eslintrc.json
+++ b/handwritten/cloud-profiler/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/datastore/.eslintrc.json
+++ b/handwritten/datastore/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/error-reporting/.eslintrc.json
+++ b/handwritten/error-reporting/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/firestore/.eslintrc.json
+++ b/handwritten/firestore/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": "./node_modules/gts",
+  "extends": "../../node_modules/gts",
   "overrides": [
     {
       "files": ["dev/src/**/*.ts"],

--- a/handwritten/google-cloud-dns/.eslintrc.json
+++ b/handwritten/google-cloud-dns/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/logging-bunyan/.eslintrc.json
+++ b/handwritten/logging-bunyan/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/logging-winston/.eslintrc.json
+++ b/handwritten/logging-winston/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/logging/.eslintrc.json
+++ b/handwritten/logging/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/pubsub/.eslintrc.json
+++ b/handwritten/pubsub/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/spanner-driver/.eslintrc.json
+++ b/handwritten/spanner-driver/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/spanner/.eslintrc.json
+++ b/handwritten/spanner/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }

--- a/handwritten/storage/.eslintrc.json
+++ b/handwritten/storage/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "../../node_modules/gts"
 }


### PR DESCRIPTION
In handwritten packages, .eslintrc.json previously specified "extends": "./node_modules/gts". In the monorepo CI linter workflow, dependencies (node_modules/gts) are installed only at the root of the monorepo and not in individual package subdirectories.

When bin/linter.mjs --strict runs on changed TypeScript files in a handwritten package, ESLint resolves ./node_modules/gts relative to the package directory (handwritten/<pkg>/node_modules/gts), which fails with:
  Failed to load config "./node_modules/gts" to extend from.
  Cannot read properties of undefined (reading 'fileExists')

Update "extends": "./node_modules/gts" to "extends": "../../node_modules/gts" across all 15 packages in handwritten/ so ESLint can resolve gts from the monorepo root.
