### PR TITLE
fix(pubsub): upgrade @opentelemetry/core to ^2.8.0 to resolve CVE-2026-54285 (#8792)

### DIFF
--- a/handwritten/pubsub/package.json
+++ b/handwritten/pubsub/package.json
@@ -56,7 +56,7 @@
     "@google-cloud/promisify": "^5.0.0",
     "@google-cloud/pubsub-api": "^0.2.1",
     "@opentelemetry/api": "~1.9.0",
-    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/semantic-conventions": "~1.39.0",
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.8.0",
-    "@opentelemetry/sdk-trace-base": "^1.17.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@types/duplexify": "^3.6.4",
     "@types/extend": "^3.0.4",
     "@types/lodash.snakecase": "^4.1.9",

--- a/handwritten/pubsub/test/subscriber.ts
+++ b/handwritten/pubsub/test/subscriber.ts
@@ -1200,7 +1200,10 @@ describe('Subscriber', () => {
       assert.strictEqual(spans[0].events.length, 2);
       const firstSpan = spans.pop();
       assert.ok(firstSpan);
-      assert.strictEqual(firstSpan.parentSpanId, parentSpanContext.spanId);
+      assert.strictEqual(
+        firstSpan.parentSpanContext?.spanId,
+        parentSpanContext.spanId,
+      );
       assert.strictEqual(
         firstSpan.name,
         `${subId} subscribe`,

--- a/handwritten/pubsub/test/telemetry-tracing.ts
+++ b/handwritten/pubsub/test/telemetry-tracing.ts
@@ -361,7 +361,7 @@ describe('OpenTelemetryTracer', () => {
         'receive',
       );
       assert.strictEqual(childReadSpan.kind, SpanKind.CONSUMER);
-      assert.ok(childReadSpan.parentSpanId);
+      assert.ok(childReadSpan.parentSpanContext?.spanId);
     });
 
     it('creates publish RPC spans', () => {
@@ -373,7 +373,6 @@ describe('OpenTelemetryTracer', () => {
         'test',
       ) as trace.Span;
       message.parentSpan = span;
-      span.end();
 
       const publishSpan = otel.PubsubSpans.createPublishRpcSpan(
         [message],
@@ -381,6 +380,7 @@ describe('OpenTelemetryTracer', () => {
         'test',
       );
 
+      span.end();
       publishSpan?.end();
       const spans = exporter.getFinishedSpans();
       const publishReadSpan = spans.pop();

--- a/handwritten/pubsub/test/tracing.ts
+++ b/handwritten/pubsub/test/tracing.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {trace} from '@opentelemetry/api';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -36,6 +37,7 @@ import {
  * its defined beforehand.
  */
 export const exporter: InMemorySpanExporter = new InMemorySpanExporter();
-export const provider: BasicTracerProvider = new BasicTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-provider.register();
+export const provider: BasicTracerProvider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+trace.setGlobalTracerProvider(provider);


### PR DESCRIPTION
This PR resolves [CVE-2026-54285](https://nvd.nist.gov/vuln/detail/CVE-2026-54285) by upgrading `@opentelemetry/core` to `^2.8.0` and devDependency `@opentelemetry/sdk-trace-base` to `^2.8.0`. It includes only the minimal required changes to OpenTelemetry SDK 2.x test initialization and `ReadableSpan` assertions without unrelated refactoring.

Fixes #8792