### PR TITLE
feat: add missing src_dir for gapic-generator-typescript

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -28,6 +28,7 @@ tools:
         - pnpm install --frozen-lockfile --config.auto-install-peers=true
         - pnpm run compile
         - pnpm add -g "$PWD"
+      src_dir: core/generator/gapic-generator-typescript
     - name: gapic-node-processing
       version: 0.1.11
     - name: gapic-tools


### PR DESCRIPTION
Add `src_dir: core/generator/gapic-generator-typescript` to the `gapic-generator-typescript` pnpm tool configuration in `librarian.yaml`.

Following tool installation refactoring in Librarian (`internal/tool/pnpm`), librarian now requires an explicitly declared `src_dir` path rather than relying on Node-specific fallbacks. 

For https://github.com/googleapis/librarian/issues/6857