### PR TITLE
fix: Upgrade types sinon for databasecenter

### DIFF
--- a/packages/google-cloud-databasecenter/package.json
+++ b/packages/google-cloud-databasecenter/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.13.9",
-    "@types/sinon": "17.0.3",
+    "@types/sinon": "^21.0.0",
     "c8": "^10.1.3",
     "gapic-tools": "^2.0.0",
     "gts": "^6.0.2",

--- a/packages/google-cloud-databasecenter/package.json
+++ b/packages/google-cloud-databasecenter/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.13.9",
-    "@types/sinon": "^17.0.4",
+    "@types/sinon": "17.0.3",
     "c8": "^10.1.3",
     "gapic-tools": "^2.0.0",
     "gts": "^6.0.2",


### PR DESCRIPTION
## Description

A release failed because the databasecenter package isn't compiling. We should upgrade @types/sinon in this library so that it compiles.

## Impact

Unblocks releases for this package.
