### PR TITLE
fix: prefer native fetch over node-fetch in Node.js

### DIFF
--- a/core/packages/gaxios/src/gaxios.ts
+++ b/core/packages/gaxios/src/gaxios.ts
@@ -283,16 +283,29 @@ export class Gaxios implements FetchCompliance {
     }
 
     switch (opts.responseType) {
-      case 'stream':
-        if (usingInternalFetch && res.body && !(res.body instanceof Readable)) {
-          // Native `fetch` resolves a `ReadableStream`, so convert it to retain
-          // the `stream.Readable` contract. A caller-provided
-          // `fetchImplementation` keeps its own body type.
+      case 'stream': {
+        // Native `fetch` resolves a `ReadableStream`, so convert it to retain
+        // the `stream.Readable` contract. Browser bundles stub or polyfill
+        // `stream` without `fromWeb` and have always resolved a
+        // `ReadableStream`, so the conversion is skipped there. A
+        // caller-provided `fetchImplementation` keeps its own body type.
+        const body = res.body as
+          | (ReadableStream & {getReader?: unknown})
+          | null;
+        const isWebStream = typeof body?.getReader === 'function';
+
+        if (
+          usingInternalFetch &&
+          isWebStream &&
+          typeof Readable?.fromWeb === 'function'
+        ) {
           return Readable.fromWeb(
-            res.body as unknown as import('stream/web').ReadableStream,
+            body as unknown as import('stream/web').ReadableStream,
           );
         }
+
         return res.body;
+      }
       case 'json': {
         const data = await res.text();
         try {

--- a/core/packages/gaxios/src/gaxios.ts
+++ b/core/packages/gaxios/src/gaxios.ts
@@ -147,6 +147,8 @@ export class Gaxios implements FetchCompliance {
   private async _defaultAdapter<T>(
     config: GaxiosOptionsPrepared,
   ): Promise<GaxiosResponse<T>> {
+    const usingInternalFetch =
+      !config.fetchImplementation && !this.defaults.fetchImplementation;
     const fetchImpl =
       config.fetchImplementation ||
       this.defaults.fetchImplementation ||
@@ -158,7 +160,7 @@ export class Gaxios implements FetchCompliance {
     delete preparedOpts.data;
 
     const res = (await fetchImpl(config.url, preparedOpts as {})) as Response;
-    const data = await this.getResponseData(config, res);
+    const data = await this.getResponseData(config, res, usingInternalFetch);
 
     if (!Object.getOwnPropertyDescriptor(res, 'data')?.configurable) {
       // Work-around for `node-fetch` v3 as accessing `data` would otherwise throw
@@ -227,6 +229,10 @@ export class Gaxios implements FetchCompliance {
         err = e;
       } else if (e instanceof Error) {
         err = new GaxiosError(e.message, opts, undefined, e);
+      } else if (typeof e === 'string') {
+        // Native `fetch` rejects with the `AbortSignal`'s reason as-is, which
+        // is not necessarily an `Error`.
+        err = new GaxiosError(e, opts, undefined, e);
       } else {
         err = new GaxiosError('Unexpected Gaxios Error', opts, undefined, e);
       }
@@ -257,6 +263,7 @@ export class Gaxios implements FetchCompliance {
   private async getResponseData(
     opts: GaxiosOptionsPrepared,
     res: Response,
+    usingInternalFetch = false,
   ): Promise<ReturnType<JSON['parse']>> {
     if (res.status === HTTP_STATUS_NO_CONTENT) {
       return '';
@@ -277,6 +284,14 @@ export class Gaxios implements FetchCompliance {
 
     switch (opts.responseType) {
       case 'stream':
+        if (usingInternalFetch && res.body && !(res.body instanceof Readable)) {
+          // Native `fetch` resolves a `ReadableStream`, so convert it to retain
+          // the `stream.Readable` contract. A caller-provided
+          // `fetchImplementation` keeps its own body type.
+          return Readable.fromWeb(
+            res.body as unknown as import('stream/web').ReadableStream,
+          );
+        }
         return res.body;
       case 'json': {
         const data = await res.text();
@@ -671,10 +686,16 @@ export class Gaxios implements FetchCompliance {
 
   static async #getFetch() {
     const hasWindow = typeof window !== 'undefined' && !!window;
+    const hasGlobalFetch = typeof globalThis.fetch === 'function';
 
+    // Prefer native `fetch`, available since Node 18 - this package's minimum
+    // supported version. `node-fetch` can intermittently fail requests with
+    // `Premature close` errors and remains only as a fallback.
     this.#fetch ||= hasWindow
       ? window.fetch
-      : (await import('node-fetch')).default;
+      : hasGlobalFetch
+        ? globalThis.fetch
+        : (await import('node-fetch')).default;
 
     return this.#fetch;
   }

--- a/core/packages/gaxios/test/test.getch.ts
+++ b/core/packages/gaxios/test/test.getch.ts
@@ -863,10 +863,7 @@ describe('🥁 configuration options', () => {
 
       await assert.rejects(
         () => gaxios.request({url, timeout, signal}),
-        // `node-fetch` always rejects with the generic 'abort' error:
-        /abort/,
-        // native `fetch` matches the error properly:
-        // new RegExp(message)
+        new RegExp(message),
       );
     });
   });


### PR DESCRIPTION
## Problem

`Gaxios.#getFetch()` only checks for a browser `window` before falling back to
`node-fetch`, so Node.js always uses `node-fetch` even though native `fetch` has
been available since Node 18 — this package's minimum supported version.

`node-fetch` intermittently rejects with `Premature close` on some networks. This
reproduces as a consistent `clasp login` failure, whose OAuth2 token exchange runs
through google-auth-library and gaxios:

```
Invalid response body while trying to fetch https://oauth2.googleapis.com/token: Premature close
```

The same POST succeeds via curl and via Node's native `fetch` on the same machine,
so the failure is specific to `node-fetch`.

## Change

Prefer native `fetch` in Node.js, keeping `node-fetch` as a fallback when no global
`fetch` exists. Browser behavior is unchanged.

Two implementation differences are normalized to preserve existing behavior:

- `responseType: 'stream'` converts native `fetch`'s `ReadableStream` back to a
  `stream.Readable`. A caller-supplied `fetchImplementation` still returns its own
  body type, as covered by the existing test.
- An `AbortSignal` reason that is not an `Error` is propagated rather than replaced
  with a generic message. The existing test for this case carried a comment
  anticipating the change, which is now applied.

## Testing

`npm test` — 129 passing.
