### PR TITLE
chore: add protoc 33.2

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -37,6 +37,9 @@ tools:
       version: 7.5.8
     - name: protobufjs-cli
       version: 1.2.0
+  protoc:
+    version: "33.2"
+    sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf
 default:
   keep:
     - librarian.js


### PR DESCRIPTION
During rotation this week, I noticed that librarian did not have an explicit protoc version, and it was just grabbing my local version. This PR specifically was generated with 33.2 unknowingly: https://github.com/googleapis/google-cloud-node/pull/9091.

So, I decided to set it explicitly and run generate --all. No new diffs were found.