### PR TITLE
chore: separate google-ads-datamanager into individual release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -103,7 +103,6 @@
       "component": "pubsub"
     },
     "packages/google-ads-admanager": {},
-    "packages/google-ads-datamanager": {},
     "packages/google-ai-generativelanguage": {},
     "packages/google-analytics-admin": {},
     "packages/google-analytics-data": {},

--- a/release-please-submodules.json
+++ b/release-please-submodules.json
@@ -10,6 +10,9 @@
     },
     "handwritten/storage": {
       "component": "storage"
+    },
+    "packages/google-ads-datamanager": {
+      "component": "google-ads-datamanager"
     }
   },
   "plugins": [


### PR DESCRIPTION
So that Node can mark the breaking change in google-ads-datamanager as breaking