### PR TITLE
fix(precise-date): support TypeScript 7

### DIFF
--- a/core/precise-date/src/index.ts
+++ b/core/precise-date/src/index.ts
@@ -73,7 +73,6 @@ enum Sign {
  * in addition to several custom types as noted below.
  *
  * @class
- * @extends external:Date
  *
  * @param {number|string|bigint|Date|DateTuple|DateStruct} [time] The time
  *     value.


### PR DESCRIPTION
Fixes #9031

## Summary

Remove the legacy `@extends external:Date` JSDoc tag from `PreciseDate`. The TypeScript declaration already expresses the inheritance as `extends Date`; TypeScript 7 treats the mismatched JSDoc target as error TS8023.

## Validation

- [x] Confirmed unmodified `main` fails under TypeScript 7.0.2 with the reported TS8023 error
- [x] Compiled the package successfully with TypeScript 5.8 and TypeScript 7.0.2 after the change
- [x] Compiled a TypeScript 7.0.2 consumer against the emitted declaration
- [x] Ran all 51 package tests successfully
- [x] Ran the Google TypeScript Style ESLint configuration successfully
- [x] Confirmed code coverage does not decrease
- [x] Updated the affected documentation comment