### PR TITLE
fix(firestore): observe rejection of lazily-started transaction ID promise

### DIFF
--- a/handwritten/firestore/dev/src/transaction.ts
+++ b/handwritten/firestore/dev/src/transaction.ts
@@ -791,7 +791,7 @@ export class Transaction implements firestore.Transaction {
         // macrotask boundary. Node then reports an unhandled rejection, which
         // terminates the process under the default `--unhandled-rejections=throw`.
         // Observe the rejection here; awaiters still see it.
-        this._transactionIdPromise.catch(() => {});
+        void this._transactionIdPromise.catch(() => {});
 
         return resultPromise.then(r => r.result);
       }

--- a/handwritten/firestore/dev/src/transaction.ts
+++ b/handwritten/firestore/dev/src/transaction.ts
@@ -784,6 +784,15 @@ export class Transaction implements firestore.Transaction {
           return r.transaction;
         });
 
+        // Nothing awaits `_transactionIdPromise` until a subsequent read, a
+        // commit, or a rollback. When the first read is the operation that
+        // fails, `rollback()` returns early for read-only transactions and never
+        // awaits it, and a read-write transaction can leave it rejected across a
+        // macrotask boundary. Node then reports an unhandled rejection, which
+        // terminates the process under the default `--unhandled-rejections=throw`.
+        // Observe the rejection here; awaiters still see it.
+        this._transactionIdPromise.catch(() => {});
+
         return resultPromise.then(r => r.result);
       }
     }

--- a/handwritten/firestore/dev/test/transaction.ts
+++ b/handwritten/firestore/dev/test/transaction.ts
@@ -514,6 +514,37 @@ describe('failed transactions', () => {
     }
   });
 
+  it('does not orphan the transaction ID promise when the first read fails', async () => {
+    // The transaction ID promise is derived from the first read. On this path
+    // nothing ever awaits it, so without an attached handler Node reports an
+    // unhandled rejection and terminates the process.
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) =>
+      unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const serverError = new GoogleError('Test Error');
+    serverError.code = Status.UNAUTHENTICATED;
+
+    try {
+      await expect(
+        runTransaction(
+          /* transactionOptions= */ {readOnly: true},
+          (transaction, docRef) => transaction.get(docRef),
+          getDocument({newTransaction: {readOnly: {}}, error: serverError}),
+          // No rollback because the lazy-start operation failed
+        ),
+      ).to.eventually.be.rejected;
+
+      // Node reports unhandled rejections once the microtask queue drains, so
+      // yield a macrotask before asserting.
+      await new Promise(resolve => setImmediate(resolve));
+      expect(unhandledRejections).to.be.empty;
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
   it('retries commit for expired transaction', async () => {
     // The transaction needs to perform a read or write otherwise it will be
     // a no-op and will not retry


### PR DESCRIPTION
## Problem

When the first read of a transaction fails, the client can emit an `unhandledRejection`. Under Node's default `--unhandled-rejections=throw` this terminates the process, even though the application handled the error that `runTransaction()` returned.

`withLazyStartedTransaction()` derives a second promise from the first read:

```js
const resultPromise = resultFn.call(this, param, opts);

this._transactionIdPromise = resultPromise.then(r => { ... });

return resultPromise.then(r => r.result);
```

The caller handles the returned promise. Nothing attaches a handler to `_transactionIdPromise` at creation time. Its only handler comes later, from a subsequent read, `commit()`, or `rollback()`. Two cases leave it unobserved:

1. **Read-only transactions.** `rollback()` returns early when `this._writeBatch` is unset, so it never awaits `_transactionIdPromise`. No handler is ever attached.
2. **Read-write transactions where the callback continues after a failed read.** `rollback()` does await the promise, but only after the callback returns. If the callback yields to the event loop in between, Node has already reported the rejection. Node also logs `PromiseRejectionHandledWarning` here, which confirms the handler arrived too late.

Case 1 is deterministic: for a read-only transaction, no handler is ever attached, so any failure of the first read terminates the process.

We hit case 1 in production on `@google-cloud/firestore@8.7.1`. The first read of a read-only transaction, a `BatchGetDocuments`, stalled for 293 seconds and then failed with `16 UNAUTHENTICATED`. The application caught the error from `runTransaction()`, and the process still died on the orphaned rejection. Read-only transactions set `_maxAttempts` to 1, so no retry masked it.

## Reproduction

Point the client at a port where nothing listens, then run a read-only transaction whose first read fails:

```js
const firestore = new Firestore({
  projectId: 'repro-project',
  host: 'localhost:1',
  ssl: false,
});

process.on('unhandledRejection', err => console.log('unhandled:', err.code));

try {
  await firestore.runTransaction(
    async txn => {
      await txn.get(firestore.doc('things/one'));
    },
    {readOnly: true},
  );
} catch {
  // The caller handles the error, and the process still dies without the
  // `process.on` above.
}
```

Before this change the listener fires with code 14. After it, it does not. The same script reproduces case 2 with a read-write transaction whose callback swallows the read error and then awaits a timer.

## Fix

Attach a no-op handler to `_transactionIdPromise` when it is created. This marks the rejection observed. Later awaiters in `commit()` and `rollback()` still reject exactly as before, so error propagation is unchanged.

## Test

Adds a regression test to `handwritten/firestore/dev/test/transaction.ts`. It records `unhandledRejection` events while a read-only transaction's first read fails, and asserts none are emitted.

Verified both directions against the `firestore` package:

- Without the source change: `1 failing` — `expected [ Error: Test Error, …(1) ] to be empty`.
- With it: the new test passes and the full `transaction` suite is green at `37 passing`.
