### PR TITLE
chore(deps): bump gaxios to ^7.3.0 in googleapis-common

### DIFF
--- a/core/packages/nodejs-googleapis-common/package.json
+++ b/core/packages/nodejs-googleapis-common/package.json
@@ -37,7 +37,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "extend": "^3.0.2",
-    "gaxios": "7.1.3",
+    "gaxios": "^7.3.0",
     "google-auth-library": "^11.0.0",
     "google-logging-utils": "^2.0.0",
     "qs": "^6.7.0",


### PR DESCRIPTION
Updates the `gaxios` dependency in `core/packages/nodejs-googleapis-common` from pinned `7.1.3` to `^7.3.0` to allow compatible minor/patch updates and ensure alignment with the latest releases