### PR TITLE
fix(docs): add correct homepage URL in /core/packages/proto3-json-serializer-nodejs

### DIFF
--- a/core/packages/proto3-json-serializer-nodejs/package.json
+++ b/core/packages/proto3-json-serializer-nodejs/package.json
@@ -55,5 +55,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/core/packages/proto3-json-serializer-nodejs"
 }


### PR DESCRIPTION
Adds the `homepage` field to `core/packages/proto3-json-serializer-nodejs/package.json` pointing to its package directory in the repository instead of the generic repo homepage, improving package metadata and npm registry documentation.

https://www.npmjs.com/package/proto3-json-serializer