### PR TITLE
fix(common): prevent path traversal and parameter injection in REST clients

### DIFF
--- a/core/common/src/service-object.ts
+++ b/core/common/src/service-object.ts
@@ -563,16 +563,24 @@ class ServiceObject<T = any> extends EventEmitter {
     const uriComponents = [this.baseUrl, this.id || '', reqOpts.uri];
 
     if (isAbsoluteUrl) {
-      uriComponents.splice(0, uriComponents.indexOf(reqOpts.uri));
+      const url = new URL(reqOpts.uri);
+      const encodedPath = util.encodeURIPath(url.pathname);
+      url.pathname = encodedPath;
+      let res = url.toString();
+      if (!reqOpts.uri.endsWith('/') && res.endsWith('/')) {
+        res = res.slice(0, -1);
+      }
+      reqOpts.uri = res;
+    } else {
+      reqOpts.uri = uriComponents
+        .filter(x => x!.trim()) // Limit to non-empty strings.
+        .map(uriComponent => {
+          const trimSlashesRegex = /^\/*|\/*$/g;
+          const trimmed = uriComponent!.replace(trimSlashesRegex, '');
+          return util.encodeURIPath(trimmed);
+        })
+        .join('/');
     }
-
-    reqOpts.uri = uriComponents
-      .filter(x => x!.trim()) // Limit to non-empty strings.
-      .map(uriComponent => {
-        const trimSlashesRegex = /^\/*|\/*$/g;
-        return uriComponent!.replace(trimSlashesRegex, '');
-      })
-      .join('/');
 
     const childInterceptors = (arrify as unknown as (arg1: any) => [])(
       reqOpts.interceptors_!,

--- a/core/common/src/service.ts
+++ b/core/common/src/service.ts
@@ -212,19 +212,27 @@ export class Service {
     uriComponents.push(reqOpts.uri);
 
     if (isAbsoluteUrl) {
-      uriComponents.splice(0, uriComponents.indexOf(reqOpts.uri));
+      const url = new URL(reqOpts.uri);
+      const encodedPath = util.encodeURIPath(url.pathname);
+      url.pathname = encodedPath;
+      let res = url.toString();
+      if (!reqOpts.uri.endsWith('/') && res.endsWith('/')) {
+        res = res.slice(0, -1);
+      }
+      reqOpts.uri = res;
+    } else {
+      reqOpts.uri = uriComponents
+        .map(uriComponent => {
+          const trimSlashesRegex = /^\/*|\/*$/g;
+          const trimmed = uriComponent.replace(trimSlashesRegex, '');
+          return util.encodeURIPath(trimmed);
+        })
+        .join('/')
+        // Some URIs have colon separators.
+        // Bad: https://.../projects/:list
+        // Good: https://.../projects:list
+        .replace(/\/:/g, ':');
     }
-
-    reqOpts.uri = uriComponents
-      .map(uriComponent => {
-        const trimSlashesRegex = /^\/*|\/*$/g;
-        return uriComponent.replace(trimSlashesRegex, '');
-      })
-      .join('/')
-      // Some URIs have colon separators.
-      // Bad: https://.../projects/:list
-      // Good: https://.../projects:list
-      .replace(/\/:/g, ':');
 
     const requestInterceptors = this.getRequestInterceptors();
 

--- a/core/common/src/util.ts
+++ b/core/common/src/util.ts
@@ -913,6 +913,10 @@ export class Util {
     return dup;
   }
 
+  encodeWithSlashes = encodeWithSlashes;
+  encodeWithoutSlashes = encodeWithoutSlashes;
+  encodeURIPath = encodeURIPath;
+
   /**
    * Decorate the options about to be made in a request.
    *
@@ -1022,6 +1026,51 @@ class ProgressStream extends Transform {
     this.push(chunk);
     callback();
   }
+}
+
+export function encodeWithSlashes(str: string, propertyName = 'resource ID field'): string {
+  const segments = str.split('/');
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..') {
+      throw new Error(
+        `Value for ${propertyName} must not contain segments that are exactly . or .. .`,
+      );
+    }
+  }
+  return encodeURIComponent(str)
+    .replace(/%2F/gi, '/')
+    .replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
+export function encodeWithoutSlashes(str: string, propertyName = 'resource ID field'): string {
+  if (str === '.' || str === '..') {
+    throw new Error(`Invalid value ${str} for ${propertyName}.`);
+  }
+  return encodeURIComponent(str)
+    .replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
+export function encodeURIPath(uri: string): string {
+  const parts = uri.split('/');
+  return parts
+    .map(part => {
+      if (part === '') {
+        return '';
+      }
+      if (part.includes(':')) {
+        const subparts = part.split(':');
+        return subparts
+          .map(subpart => {
+            if (subpart === '') {
+              return '';
+            }
+            return encodeWithoutSlashes(subpart, 'path segment');
+          })
+          .join(':');
+      }
+      return encodeWithoutSlashes(part, 'path segment');
+    })
+    .join('/');
 }
 
 const util = new Util();

--- a/core/common/test/util.ts
+++ b/core/common/test/util.ts
@@ -1903,6 +1903,58 @@ describe('common/util', () => {
     });
   });
 
+  describe('encodeWithSlashes & encodeWithoutSlashes', () => {
+    it('encodeWithSlashes should allow valid path segments and encode special characters', () => {
+      assert.strictEqual(
+        util.encodeWithSlashes('foo/bar-123_~.baz'),
+        'foo/bar-123_~.baz',
+      );
+      assert.strictEqual(
+        util.encodeWithSlashes('foo/bar baz'),
+        'foo/bar%20baz',
+      );
+    });
+
+    it('encodeWithSlashes should throw if any segment is . or ..', () => {
+      assert.throws(() => {
+        util.encodeWithSlashes('foo/./bar', 'testField');
+      }, /Value for testField must not contain segments that are exactly \. or \.\. \./);
+
+      assert.throws(() => {
+        util.encodeWithSlashes('foo/../bar', 'testField');
+      }, /Value for testField must not contain segments that are exactly \. or \.\. \./);
+    });
+
+    it('encodeWithoutSlashes should allow valid characters and encode slashes and special characters', () => {
+      assert.strictEqual(
+        util.encodeWithoutSlashes('foo-123_~.baz'),
+        'foo-123_~.baz',
+      );
+      assert.strictEqual(
+        util.encodeWithoutSlashes('foo/bar'),
+        'foo%2Fbar',
+      );
+      assert.strictEqual(
+        util.encodeWithoutSlashes('photo_😀.png'),
+        'photo_%F0%9F%98%80.png',
+      );
+      assert.strictEqual(
+        util.encodeWithoutSlashes('test*file!'),
+        'test%2Afile%21',
+      );
+    });
+
+    it('encodeWithoutSlashes should throw if the value is . or ..', () => {
+      assert.throws(() => {
+        util.encodeWithoutSlashes('.', 'testField');
+      }, /Invalid value \. for testField\./);
+
+      assert.throws(() => {
+        util.encodeWithoutSlashes('..', 'testField');
+      }, /Invalid value \.\. for testField\./);
+    });
+  });
+
   describe('maybeOptionsOrCallback', () => {
     it('should allow passing just a callback', () => {
       const optionsOrCallback = () => {};

--- a/handwritten/storage/src/nodejs-common/service-object.ts
+++ b/handwritten/storage/src/nodejs-common/service-object.ts
@@ -562,16 +562,24 @@ class ServiceObject<T, K extends BaseMetadata> extends EventEmitter {
     const uriComponents = [this.baseUrl, this.id || '', reqOpts.uri];
 
     if (isAbsoluteUrl) {
-      uriComponents.splice(0, uriComponents.indexOf(reqOpts.uri));
+      const url = new URL(reqOpts.uri);
+      const encodedPath = util.encodeURIPath(url.pathname);
+      url.pathname = encodedPath;
+      let res = url.toString();
+      if (!reqOpts.uri.endsWith('/') && res.endsWith('/')) {
+        res = res.slice(0, -1);
+      }
+      reqOpts.uri = res;
+    } else {
+      reqOpts.uri = uriComponents
+        .filter(x => x!.trim()) // Limit to non-empty strings.
+        .map(uriComponent => {
+          const trimSlashesRegex = /^\/*|\/*$/g;
+          const trimmed = uriComponent!.replace(trimSlashesRegex, '');
+          return util.encodeURIPath(trimmed);
+        })
+        .join('/');
     }
-
-    reqOpts.uri = uriComponents
-      .filter(x => x!.trim()) // Limit to non-empty strings.
-      .map(uriComponent => {
-        const trimSlashesRegex = /^\/*|\/*$/g;
-        return uriComponent!.replace(trimSlashesRegex, '');
-      })
-      .join('/');
 
     const childInterceptors = Array.isArray(reqOpts.interceptors_)
       ? reqOpts.interceptors_

--- a/handwritten/storage/src/nodejs-common/service.ts
+++ b/handwritten/storage/src/nodejs-common/service.ts
@@ -234,19 +234,27 @@ export class Service {
     uriComponents.push(reqOpts.uri);
 
     if (isAbsoluteUrl) {
-      uriComponents.splice(0, uriComponents.indexOf(reqOpts.uri));
+      const url = new URL(reqOpts.uri);
+      const encodedPath = util.encodeURIPath(url.pathname);
+      url.pathname = encodedPath;
+      let res = url.toString();
+      if (!reqOpts.uri.endsWith('/') && res.endsWith('/')) {
+        res = res.slice(0, -1);
+      }
+      reqOpts.uri = res;
+    } else {
+      reqOpts.uri = uriComponents
+        .map(uriComponent => {
+          const trimSlashesRegex = /^\/*|\/*$/g;
+          const trimmed = uriComponent.replace(trimSlashesRegex, '');
+          return util.encodeURIPath(trimmed);
+        })
+        .join('/')
+        // Some URIs have colon separators.
+        // Bad: https://.../projects/:list
+        // Good: https://.../projects:list
+        .replace(/\/:/g, ':');
     }
-
-    reqOpts.uri = uriComponents
-      .map(uriComponent => {
-        const trimSlashesRegex = /^\/*|\/*$/g;
-        return uriComponent.replace(trimSlashesRegex, '');
-      })
-      .join('/')
-      // Some URIs have colon separators.
-      // Bad: https://.../projects/:list
-      // Good: https://.../projects:list
-      .replace(/\/:/g, ':');
 
     const requestInterceptors = this.getRequestInterceptors();
     const interceptorArray = Array.isArray(reqOpts.interceptors_)

--- a/handwritten/storage/src/nodejs-common/util.ts
+++ b/handwritten/storage/src/nodejs-common/util.ts
@@ -1041,6 +1041,10 @@ export class Util {
       : [optionsOrCallback as T, cb as C];
   }
 
+  encodeWithSlashes = encodeWithSlashes;
+  encodeWithoutSlashes = encodeWithoutSlashes;
+  encodeURIPath = encodeURIPath;
+
   _getDefaultHeaders(gcclGcsCmd?: string) {
     const headers = {
       'User-Agent': getUserAgentString(),
@@ -1070,6 +1074,51 @@ class ProgressStream extends Transform {
     this.push(chunk);
     callback();
   }
+}
+
+export function encodeWithSlashes(str: string, propertyName = 'resource ID field'): string {
+  const segments = str.split('/');
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..') {
+      throw new Error(
+        `Value for ${propertyName} must not contain segments that are exactly . or .. .`,
+      );
+    }
+  }
+  return encodeURIComponent(str)
+    .replace(/%2F/gi, '/')
+    .replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
+export function encodeWithoutSlashes(str: string, propertyName = 'resource ID field'): string {
+  if (str === '.' || str === '..') {
+    throw new Error(`Invalid value ${str} for ${propertyName}.`);
+  }
+  return encodeURIComponent(str)
+    .replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
+export function encodeURIPath(uri: string): string {
+  const parts = uri.split('/');
+  return parts
+    .map(part => {
+      if (part === '') {
+        return '';
+      }
+      if (part.includes(':')) {
+        const subparts = part.split(':');
+        return subparts
+          .map(subpart => {
+            if (subpart === '') {
+              return '';
+            }
+            return encodeWithoutSlashes(subpart, 'path segment');
+          })
+          .join(':');
+      }
+      return encodeWithoutSlashes(part, 'path segment');
+    })
+    .join('/');
 }
 
 const util = new Util();

--- a/handwritten/storage/test/bucket.ts
+++ b/handwritten/storage/test/bucket.ts
@@ -1878,6 +1878,28 @@ describe('Bucket', () => {
     });
   });
 
+  describe('security - URI encoding and path traversal protection', () => {
+    it('should throw error when bucket name or object path segment is dot or dot-dot', () => {
+      assert.throws(() => {
+        const invalidBucket = new Bucket(STORAGE, '..');
+        invalidBucket.getMetadata(assert.ifError);
+      }, /Invalid value \.\. for path segment\./);
+    });
+
+    it('should percent-encode query parameter injection payload in file name', done => {
+      const maliciousFileName = 'file_name?\\$httpMethod=DELETE#';
+      const file = bucket.file(maliciousFileName);
+
+      bucket.request = (reqOpts: DecorateRequestOptions) => {
+        assert(reqOpts.uri.includes('file_name%3F%24httpMethod%3DDELETE%23'));
+        assert(!reqOpts.uri.includes('?$httpMethod=DELETE#'));
+        done();
+      };
+
+      file.getMetadata(assert.ifError);
+    });
+  });
+
   describe('file', () => {
     const FILE_NAME = 'remote-file-name.jpg';
     let file: FakeFile;


### PR DESCRIPTION
Fixes path traversal and parameter injection vulnerabilities in Node.js REST clients by validating `.` and `..` path segments and percent-encoding URL-unsafe characters.

---
*PR created automatically by Jules for task [10569082496054868007](https://jules.google.com/task/10569082496054868007) started by @danieljbruce*