### PR TITLE
fix(workloadidentity): update release level to preview

### DIFF
--- a/packages/google-cloud-workloadidentity/.repo-metadata.json
+++ b/packages/google-cloud-workloadidentity/.repo-metadata.json
@@ -10,6 +10,6 @@
     "name": "workloadidentity",
     "name_pretty": "Workload Identity",
     "product_documentation": "https://cloud.google.com/iam/docs",
-    "release_level": "stable",
+    "release_level": "preview",
     "repo": "googleapis/google-cloud-node"
 }


### PR DESCRIPTION
The library was onboarded with version 0.1.0 but marked as stable. This caused the librarian generate check to fail as it wants to set it to preview. Updating the release level to preview to match the version.

Fixes: #9096