### PR TITLE
fix: update JSDoc @extends tag to match class definition

### DIFF
--- a/core/precise-date/src/index.ts
+++ b/core/precise-date/src/index.ts
@@ -73,7 +73,7 @@ enum Sign {
  * in addition to several custom types as noted below.
  *
  * @class
- * @extends external:Date
+ * @extends Date
  *
  * @param {number|string|bigint|Date|DateTuple|DateStruct} [time] The time
  *     value.


### PR DESCRIPTION
TypeScript 7+ enforces that JSDoc @'extends tags match the actual class extends clause. Changing '@'extends external:Date' to '@'extends Date' resolves the compilation error TS8023 when the library is consumed in projects with strict type checking and newer TypeScript versions.

Fixes: #9031
