### PR TITLE
fix: exclude generated and declaration files from linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,6 +88,7 @@
       }
     }
   ],
+  // LINT.IfChange(ignorePatterns)
   "ignorePatterns": [
     "**/node_modules",
     "**/build",
@@ -105,4 +106,5 @@
     "**/protos",
     "**/*.d.ts"
   ]
+  // LINT.ThenChange(bin/linter.mjs:ignored_path_segments)
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,14 @@
     "import/no-unresolved": "off",
     "import/no-extraneous-dependencies": "error",
     "promise/catch-or-return": "error",
-    "promise/always-return": "error"
+    "promise/always-return": "error",
+    // Enforces the standard on handwritten code, but permits class/interface extensions
+    "@typescript-eslint/no-empty-interface": [
+      "error",
+      {
+        "allowSingleExtends": true
+      }
+    ]
   },
   "overrides": [
     // The overrides below were migrated from handwritten/firestore/.eslintrc.json
@@ -84,10 +91,18 @@
   "ignorePatterns": [
     "**/node_modules",
     "**/build",
+    "**/dist",
     "**/system-test",
     "**/test/fixtures",
+    "**/test-fixtures",
+    "**/fixtures",
+    "**/baselines",
+    "**/baselines-esm",
     "**/samples/generated",
     "**/.coverage",
-    "**/coverage"
+    "**/coverage",
+    "**/.nyc_output",
+    "**/protos",
+    "**/*.d.ts"
   ]
 }

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -175,6 +175,7 @@ function getChangedFiles() {
 
 // --- ESLint Checker ---
 
+// LINT.IfChange(ignored_path_segments)
 const IGNORED_PATH_SEGMENTS = [
   'node_modules',
   'build',
@@ -190,6 +191,7 @@ const IGNORED_PATH_SEGMENTS = [
   '.nyc_output',
   'protos',
 ];
+// LINT.ThenChange(.eslintrc.json:ignorePatterns)
 
 /**
  * Determines whether a file should undergo ESLint checks.

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -42,12 +42,9 @@ async function run() {
     // Install missing package dependencies upfront before running linters or type checkers
     await ensurePackageDependencies(packagesToCheck);
 
-    // Filter out declaration files (*.d.ts), auto-generated files, and fixtures from ESLint
-    const filesToLint = changedTsFiles.filter(shouldLintFile);
-
     // Run ESLint and Type checks in parallel to optimize CPU utilization
     const [eslintPassed, typeSafetyPassed] = await Promise.all([
-      checkEslint(filesToLint),
+      checkEslint(changedTsFiles),
       checkTypeSafety(packagesToCheck),
     ]);
 

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -42,9 +42,12 @@ async function run() {
     // Install missing package dependencies upfront before running linters or type checkers
     await ensurePackageDependencies(packagesToCheck);
 
+    // Filter out declaration files (*.d.ts), auto-generated files, and fixtures from ESLint
+    const filesToLint = changedTsFiles.filter(shouldLintFile);
+
     // Run ESLint and Type checks in parallel to optimize CPU utilization
     const [eslintPassed, typeSafetyPassed] = await Promise.all([
-      checkEslint(changedTsFiles),
+      checkEslint(filesToLint),
       checkTypeSafety(packagesToCheck),
     ]);
 
@@ -175,18 +178,49 @@ function getChangedFiles() {
 
 // --- ESLint Checker ---
 
+const IGNORED_PATH_SEGMENTS = [
+  'node_modules',
+  'build',
+  'dist',
+  'system-test',
+  'fixtures',
+  'test-fixtures',
+  'baselines',
+  'baselines-esm',
+  'generated',
+  '.coverage',
+  'coverage',
+  '.nyc_output',
+  'protos',
+];
+
+/**
+ * Determines whether a file should undergo ESLint checks.
+ * Excludes declaration files (*.d.ts), auto-generated artifacts, and test baselines/fixtures.
+ */
+function shouldLintFile(filePath) {
+  if (filePath.endsWith('.d.ts')) {
+    return false;
+  }
+  const segments = filePath.split(path.sep);
+  return !segments.some(seg => IGNORED_PATH_SEGMENTS.includes(seg));
+}
+
 /**
  * Runs ESLint programmatically.
  * Blocks the PR if any rule configured as "error" (severity 2) fails.
  */
 async function checkEslint(filesToCheck) {
-  if (filesToCheck.length === 0) {
+  // Exclude declaration files (*.d.ts), auto-generated proto/sample files, and fixtures from ESLint
+  const filesToProcess = filesToCheck.filter(shouldLintFile);
+
+  if (filesToProcess.length === 0) {
     return true;
   }
 
   // Group files by package directory to set tsconfigRootDir properly for typescript-eslint
   const filesByPkg = new Map();
-  for (const file of filesToCheck) {
+  for (const file of filesToProcess) {
     const pkgDir = findTsconfigDir(file) || process.cwd();
     if (!filesByPkg.has(pkgDir)) {
       filesByPkg.set(pkgDir, []);

--- a/bin/linter.mjs
+++ b/bin/linter.mjs
@@ -202,7 +202,7 @@ function shouldLintFile(filePath) {
   if (filePath.endsWith('.d.ts')) {
     return false;
   }
-  const segments = filePath.split(path.sep);
+  const segments = filePath.split(/[\\/]/);
   return !segments.some(seg => IGNORED_PATH_SEGMENTS.includes(seg));
 }
 


### PR DESCRIPTION
- Exclude *.d.ts, protos, generated samples, and generator baselines/fixtures from ESLint checks in bin/linter.mjs
- Update .eslintrc.json ignorePatterns to include generated and fixture directories
- Configure @typescript-eslint/no-empty-interface with allowSingleExtends: true
- Fixes #9210