### PR TITLE
fix(ci): fix windows exempt test matching in run_conditional_tests.sh

### DIFF
--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -187,7 +187,7 @@ for subdir in ${subdirs[@]}; do
         if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
             is_exempt=false
             for exempt in ${windows_exempt_tests}; do
-                if [[ "${d}" == "${exempt}"* ]]; then
+                if [[ "${d}" == "${exempt}" || "${d}" == "${exempt}/"* ]]; then
                     is_exempt=true
                     break
                 fi

--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -185,7 +185,14 @@ for subdir in ${subdirs[@]}; do
 
         # Our CI uses Git Bash on Windows to execute this script, which returns "msys" or "cygwin" for OSTYPE.
         if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
-            if [[ "${windows_exempt_tests}" =~ "${d}" ]]; then
+            is_exempt=false
+            for exempt in ${windows_exempt_tests}; do
+                if [[ "${d}" == "${exempt}"* ]]; then
+                    is_exempt=true
+                    break
+                fi
+            done
+            if [[ "${is_exempt}" == "true" ]]; then
                 echo "Skipping ${d} on Windows (in exemption list)"
                 continue
             fi


### PR DESCRIPTION
Fix Windows test exemption prefix matching in `ci/run_conditional_tests.sh` so that package paths matching entries in `windows_exempt_tests` are accurately skipped on Windows runners.