### PR TITLE
chore: update librarian version to v0.40.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: nodejs
-version: v0.39.0
+version: v0.40.0
 repo: googleapis/google-cloud-node
 sources:
   googleapis:


### PR DESCRIPTION
Update librarian version to v0.40.0.
### Included Librarian Updates
- googleapis/librarian#7413: fix(librarian): add validates path existence in sources