### PR TITLE
chore: gax linter fixes

### DIFF
--- a/core/packages/gax/test/unit/grpc-fallback.ts
+++ b/core/packages/gax/test/unit/grpc-fallback.ts
@@ -290,7 +290,7 @@ describe('grpc-fallback', () => {
     );
   });
 
-  it('should make a request', done => {
+  it('should make a request', async () => {
     const requestObject = {content: 'test-content'};
     const responseType = protos.lookupType('EchoResponse');
     const response = responseType.create(requestObject); // request === response for EchoService
@@ -300,7 +300,8 @@ describe('grpc-fallback', () => {
       new Response(Buffer.from(JSON.stringify(response))),
     );
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error, result?: {}) => {
         try {
           assert.strictEqual(err, null);
@@ -308,15 +309,15 @@ describe('grpc-fallback', () => {
             requestObject.content,
             (result as {content: string}).content,
           );
-          done();
-        } catch (err) {
-          done(err);
+          resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });
   });
 
-  it('should handle an API error', done => {
+  it('should handle an API error', async () => {
     const requestObject = {content: 'test-content'};
     // example of an actual google.rpc.Status error message returned by Language API
     const expectedMessage =
@@ -355,7 +356,8 @@ describe('grpc-fallback', () => {
       new Response(Buffer.from(JSON.stringify(jsonError)), {status: 400}),
     );
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         try {
           assert(err instanceof GoogleError);
@@ -365,15 +367,15 @@ describe('grpc-fallback', () => {
             JSON.stringify(err.statusDetails),
             JSON.stringify(expectedError.details),
           );
-          done();
+          resolve();
         } catch (e) {
-          done(e);
+          reject(e);
         }
       });
     });
   });
 
-  it('service stub should handle a null response from the API with a 204 ', done => {
+  it('service stub should handle a null response from the API with a 204 ', async () => {
     const requestObject = {content: 'test-content'};
 
     const emptyResponse = {
@@ -381,7 +383,8 @@ describe('grpc-fallback', () => {
     };
     setMockFallbackResponse(gaxGrpc, new Response(null, {status: 204}));
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error, resp?: {}) => {
         try {
           assert.strictEqual(err, null);
@@ -389,33 +392,34 @@ describe('grpc-fallback', () => {
             JSON.stringify(resp),
             JSON.stringify(emptyResponse),
           );
-          done();
-        } catch (err) {
-          done(err);
+          resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });
   });
-  it('should handle a null response from the API ', done => {
+  it('should handle a null response from the API ', async () => {
     const requestObject = {content: 'test-content'};
     const expectedMessage = 'Received null response from RPC Echo';
 
     setMockFallbackResponse(gaxGrpc, new Response(Buffer.from('')));
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         try {
           assert(err instanceof Error);
           assert.strictEqual(err.message, expectedMessage);
-          done();
-        } catch (err) {
-          done(err);
+          resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });
   });
 
-  it('should handle a fetch error', done => {
+  it('should handle a fetch error', async () => {
     const requestObject = {content: 'test-content'};
 
     setMockFallbackResponse(
@@ -425,19 +429,20 @@ describe('grpc-fallback', () => {
       }),
     );
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         try {
           assert.strictEqual(err?.message, 'fetch error');
-          done();
-        } catch (err) {
-          done(err);
+          resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });
   });
 
-  it('should promote ErrorInfo if exist in fallback-rest error', done => {
+  it('should promote ErrorInfo if exist in fallback-rest error', async () => {
     const requestObject = {content: 'test-content'};
     // example of an actual google.rpc.Status error message returned by Translate API
     const errorInfo = {
@@ -483,7 +488,8 @@ describe('grpc-fallback', () => {
       }),
     );
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
+    await new Promise<void>((resolve, reject) => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         try {
           assert(err instanceof GoogleError);
@@ -499,9 +505,9 @@ describe('grpc-fallback', () => {
             JSON.stringify(err.errorInfoMetadata),
             JSON.stringify(errorInfo.metadata),
           );
-          done();
-        } catch (err) {
-          done(err);
+          resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });
@@ -525,12 +531,10 @@ describe('grpc-fallback', () => {
     assert.strictEqual(createdAbortControllers[0].abortCalled, true);
   });
 
-  it('should have close method', done => {
+  it('should have close method', async () => {
     setMockFallbackResponse(gaxGrpc, new Response(JSON.stringify({})));
 
-    void gaxGrpc.createStub(echoService, stubOptions).then(stub => {
-      stub.close({}, {}, {}, () => {});
-      done();
-    });
+    const stub = await gaxGrpc.createStub(echoService, stubOptions);
+    stub.close({}, {}, {}, () => {});
   });
 });

--- a/core/packages/gax/test/unit/grpc.ts
+++ b/core/packages/gax/test/unit/grpc.ts
@@ -219,18 +219,17 @@ describe('grpc', () => {
       } as unknown as GrpcClientOptions);
     });
 
-    it('creates a stub', () => {
+    it('creates a stub', async () => {
       const opts = {servicePath: 'foo.example.com', port: 443};
       // @ts-ignore
-      return grpcClient.createStub(DummyStub, opts).then(stub => {
-        assert(stub instanceof DummyStub);
-        assert.strictEqual(stub.address, 'foo.example.com:443');
-        assert.deepStrictEqual(stub.creds, dummyChannelCreds);
-        assert.deepStrictEqual(stub.options, {
-          'grpc.max_receive_message_length': -1,
-          'grpc.max_send_message_length': -1,
-          'grpc.initial_reconnect_backoff_ms': 1000,
-        });
+      const stub = await grpcClient.createStub(DummyStub, opts);
+      assert(stub instanceof DummyStub);
+      assert.strictEqual(stub.address, 'foo.example.com:443');
+      assert.deepStrictEqual(stub.creds, dummyChannelCreds);
+      assert.deepStrictEqual(stub.options, {
+        'grpc.max_receive_message_length': -1,
+        'grpc.max_send_message_length': -1,
+        'grpc.initial_reconnect_backoff_ms': 1000,
       });
     });
 
@@ -258,7 +257,7 @@ describe('grpc', () => {
       );
     });
 
-    it('supports optional parameters', () => {
+    it('supports optional parameters', async () => {
       const opts = {
         servicePath: 'foo.example.com',
         port: 443,
@@ -273,85 +272,79 @@ describe('grpc', () => {
         'grpc-node.max_session_memory': 10,
       };
       // @ts-ignore
-      return grpcClient.createStub(DummyStub, opts).then(stub => {
-        assert(stub instanceof DummyStub);
-        assert.strictEqual(stub.address, 'foo.example.com:443');
-        assert.deepStrictEqual(stub.creds, dummyChannelCreds);
-        [
-          'grpc.max_send_message_length',
-          'grpc.initial_reconnect_backoff_ms',
-          'grpc.max_receive_message_length', // added by createStub
-          'callInvocationTransformer', // note: no grpc. prefix for grpc-gcp options
-          'channelFactoryOverride',
-          'gcpApiConfig',
-          'grpc-node.max_session_memory',
-        ].forEach(k => {
-          assert(stub.options.hasOwnProperty(k));
-        });
-        // check values
-        const dummyStub = stub as unknown as DummyStub;
-        assert.strictEqual(
-          dummyStub.options['grpc.max_send_message_length'],
-          10 * 1024 * 1024,
-        );
-        assert.strictEqual(
-          (dummyStub.options['callInvocationTransformer'] as Function)(),
-          42,
-        );
-        assert.strictEqual(
-          dummyStub.options['grpc-node.max_session_memory'],
-          10,
-        );
-        ['servicePath', 'port', 'other_dummy_options'].forEach(k => {
-          assert.strictEqual(stub.options.hasOwnProperty(k), false);
-        });
+      const stub = await grpcClient.createStub(DummyStub, opts);
+      assert(stub instanceof DummyStub);
+      assert.strictEqual(stub.address, 'foo.example.com:443');
+      assert.deepStrictEqual(stub.creds, dummyChannelCreds);
+      [
+        'grpc.max_send_message_length',
+        'grpc.initial_reconnect_backoff_ms',
+        'grpc.max_receive_message_length', // added by createStub
+        'callInvocationTransformer', // note: no grpc. prefix for grpc-gcp options
+        'channelFactoryOverride',
+        'gcpApiConfig',
+        'grpc-node.max_session_memory',
+      ].forEach(k => {
+        assert(stub.options.hasOwnProperty(k));
+      });
+      // check values
+      const dummyStub = stub as unknown as DummyStub;
+      assert.strictEqual(
+        dummyStub.options['grpc.max_send_message_length'],
+        10 * 1024 * 1024,
+      );
+      assert.strictEqual(
+        (dummyStub.options['callInvocationTransformer'] as Function)(),
+        42,
+      );
+      assert.strictEqual(dummyStub.options['grpc-node.max_session_memory'], 10);
+      ['servicePath', 'port', 'other_dummy_options'].forEach(k => {
+        assert.strictEqual(stub.options.hasOwnProperty(k), false);
       });
     });
 
-    it('supports the older grpc options logic for compatibility', () => {
+    it('supports the older grpc options logic for compatibility', async () => {
       const opts = {
         servicePath: 'foo.example.com',
         port: 443,
         'grpc.grpc.max_send_message_length': 10 * 1024 * 1024,
       };
       // @ts-ignore
-      return grpcClient.createStub(DummyStub, opts).then(stub => {
-        assert(stub instanceof DummyStub);
-        [
-          'grpc.max_send_message_length',
-          'grpc.max_receive_message_length', // added by createStub
-        ].forEach(k => {
-          assert(stub.options.hasOwnProperty(k));
-        });
-        ['servicePath', 'port'].forEach(k => {
-          assert.strictEqual(stub.options.hasOwnProperty(k), false);
-        });
+      const stub = await grpcClient.createStub(DummyStub, opts);
+      assert(stub instanceof DummyStub);
+      [
+        'grpc.max_send_message_length',
+        'grpc.max_receive_message_length', // added by createStub
+      ].forEach(k => {
+        assert(stub.options.hasOwnProperty(k));
+      });
+      ['servicePath', 'port'].forEach(k => {
+        assert.strictEqual(stub.options.hasOwnProperty(k), false);
       });
     });
 
-    it('makes it possible to override grpc.max_receive_message_length', () => {
+    it('makes it possible to override grpc.max_receive_message_length', async () => {
       const opts = {
         servicePath: 'foo.example.com',
         port: 443,
         'grpc.max_receive_message_length': 10 * 1024 * 1024,
       };
       // @ts-ignore
-      return grpcClient.createStub(DummyStub, opts).then(stub => {
-        assert(stub instanceof DummyStub);
-        assert(stub.options.hasOwnProperty('grpc.max_receive_message_length'));
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ['servicePath', 'port'].forEach(k => {
-          assert.strictEqual(stub.options.hasOwnProperty(k), false);
-        });
-        const dummyStub = stub as unknown as DummyStub;
-        assert.strictEqual(
-          dummyStub.options['grpc.max_receive_message_length'],
-          10 * 1024 * 1024,
-        );
+      const stub = await grpcClient.createStub(DummyStub, opts);
+      assert(stub instanceof DummyStub);
+      assert(stub.options.hasOwnProperty('grpc.max_receive_message_length'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ['servicePath', 'port'].forEach(k => {
+        assert.strictEqual(stub.options.hasOwnProperty(k), false);
       });
+      const dummyStub = stub as unknown as DummyStub;
+      assert.strictEqual(
+        dummyStub.options['grpc.max_receive_message_length'],
+        10 * 1024 * 1024,
+      );
     });
 
-    it('uses the passed grpc channel credentials', () => {
+    it('uses the passed grpc channel credentials', async () => {
       const customCreds = {channelCreds: 'custom'};
       const opts = {
         servicePath: 'foo.example.com',
@@ -359,16 +352,15 @@ describe('grpc', () => {
         sslCreds: customCreds,
       };
       // @ts-ignore
-      return grpcClient.createStub(DummyStub, opts).then(stub => {
-        assert(stub instanceof DummyStub);
-        assert.strictEqual(stub.address, 'foo.example.com:443');
-        assert.deepStrictEqual(stub.creds, customCreds);
-        assert.strictEqual(stubAuth.getClient.callCount, 0);
-        const credentials = stubGrpc.credentials;
-        assert.strictEqual(credentials.createSsl.callCount, 0);
-        assert.strictEqual(credentials.combineChannelCredentials.callCount, 0);
-        assert.strictEqual(credentials.createFromGoogleCredential.callCount, 0);
-      });
+      const stub = await grpcClient.createStub(DummyStub, opts);
+      assert(stub instanceof DummyStub);
+      assert.strictEqual(stub.address, 'foo.example.com:443');
+      assert.deepStrictEqual(stub.creds, customCreds);
+      assert.strictEqual(stubAuth.getClient.callCount, 0);
+      const credentials = stubGrpc.credentials;
+      assert.strictEqual(credentials.createSsl.callCount, 0);
+      assert.strictEqual(credentials.combineChannelCredentials.callCount, 0);
+      assert.strictEqual(credentials.createFromGoogleCredential.callCount, 0);
     });
   });
 
@@ -544,52 +536,30 @@ describe('grpc', () => {
     );
 
     describe('use with protobufjs load', () => {
-      it('should not be able to load test file using protobufjs directly', done => {
-        protobuf.load(TEST_FILE).then(
-          () => {
-            done(Error('should not get here'));
-          },
-          () => {
-            done();
-          },
+      it('should not be able to load test file using protobufjs directly', async () => {
+        await assert.rejects(protobuf.load(TEST_FILE));
+      });
+
+      it('should load a test file', async () => {
+        const root = await protobuf.load(TEST_FILE, new GoogleProtoFilesRoot());
+        assert(root instanceof protobuf.Root);
+        assert(
+          root.lookup('google.example.library.v1.LibraryService') instanceof
+            protobuf.Service,
+        );
+        assert(root.lookup('test.TestMessage') instanceof protobuf.Type);
+      });
+
+      it('should fail trying to load a non existent file.', async () => {
+        await assert.rejects(
+          protobuf.load(NON_EXISTENT_FILE, new GoogleProtoFilesRoot()),
         );
       });
 
-      it('should load a test file', done => {
-        protobuf
-          .load(TEST_FILE, new GoogleProtoFilesRoot())
-          .then(root => {
-            assert(root instanceof protobuf.Root);
-            assert(
-              root.lookup('google.example.library.v1.LibraryService') instanceof
-                protobuf.Service,
-            );
-            assert(root.lookup('test.TestMessage') instanceof protobuf.Type);
-            done();
-          })
-          .catch(done);
-      });
-
-      it('should fail trying to load a non existent file.', done => {
-        protobuf
-          .load(NON_EXISTENT_FILE, new GoogleProtoFilesRoot())
-          .then(() => {
-            done(Error('should not get here'));
-          })
-          .catch(() => {
-            done();
-          });
-      });
-
-      it('should fail loading a file with a missing include.', done => {
-        protobuf
-          .load(MISSING_INCLUDE_FILE, new GoogleProtoFilesRoot())
-          .then(() => {
-            done(Error('should not get here'));
-          })
-          .catch(() => {
-            done();
-          });
+      it('should fail loading a file with a missing include.', async () => {
+        await assert.rejects(
+          protobuf.load(MISSING_INCLUDE_FILE, new GoogleProtoFilesRoot()),
+        );
       });
     });
 


### PR DESCRIPTION
Resolves legacy ESLint promise violations in core/packages/gax/test/unit/grpc.ts and grpc-fallback.ts
- Wrapped callback-based RPC calls in Promise constructs
- added async() + await callbacks