### PR TITLE
pubsub: stop creating negative timeouts

### DIFF
--- a/handwritten/pubsub/src/lease-manager.ts
+++ b/handwritten/pubsub/src/lease-manager.ts
@@ -375,7 +375,7 @@ export class LeaseManager extends EventEmitter {
     const deadline = this._subscriber.ackDeadline * 1000;
     const latency = this._subscriber.modAckLatency;
 
-    return (deadline * 0.9 - latency) * jitter;
+    return Math.max(0, deadline * 0.9 - latency) * jitter;
   }
   /**
    * Schedules an deadline extension for all messages.


### PR DESCRIPTION
I didn't create an issue because it had _so many_ required steps for a one-line fix, and those steps weren't applicable in this case.

This code assumes that latency is less than 90% of the deadline, but in our production environment we see that's not always the case. When it isn't, this library tries to create a timeout with negative duration, which throws a node `TimeoutNegativeWarning`.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/{{metadata['repo']['name']}}/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕



