### PR TITLE
chore(firestore): disable promise lint rules in test overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,8 +49,8 @@
     },
     {
       "files": [
-        "handwritten/firestore/dev/test/*.ts",
-        "handwritten/firestore/dev/system-test/*.ts"
+        "handwritten/firestore/dev/test/**/*.ts",
+        "handwritten/firestore/dev/system-test/**/*.ts"
       ],
       "parser": "@typescript-eslint/parser",
       "rules": {
@@ -71,7 +71,9 @@
             "argsIgnorePattern": "^_"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "warn"
+        "@typescript-eslint/no-floating-promises": "warn",
+        "promise/always-return": "off",
+        "promise/catch-or-return": "off"
       }
     },
     {


### PR DESCRIPTION
Expand the Firestore test override glob to match nested test subdirectories and disable `promise/always-return` and `promise/catch-or-return`.
