### PR TITLE
perf(spanner): eliminate throwaway transactions

### DIFF
--- a/handwritten/spanner/observability-test/observability.ts
+++ b/handwritten/spanner/observability-test/observability.ts
@@ -318,6 +318,11 @@ describe('getActiveOrNoopSpan', () => {
     assert.strictEqual(!span, false, 'the span MUST not be null regardless');
     span.updateName('aSpan should not crash');
     span.setStatus({message: 'done here'});
+    assert.strictEqual(
+      span,
+      getActiveOrNoopSpan(),
+      'repeated calls to getActiveOrNoopSpan must return the same singleton NOOP_SPAN instance',
+    );
   });
 
   it('with a started span should return the currently active one', () => {

--- a/handwritten/spanner/src/database.ts
+++ b/handwritten/spanner/src/database.ts
@@ -25,6 +25,7 @@ import {
 const common = require('./common-grpc/service-object');
 import {promisify, promisifyAll, callbackifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
+// eslint-disable-next-line import/namespace
 import * as r from 'teeny-request';
 import * as streamEvents from 'stream-events';
 import * as through from 'through2';
@@ -3341,69 +3342,96 @@ class Database extends common.GrpcServiceObject {
         ...this._traceConfig,
         transactionTag: options.requestOptions?.transactionTag,
       },
-      span => {
-        this.sessionFactory_.getSessionForReadWrite(
-          (err, session?, transaction?) => {
-            if (err) {
-              setSpanError(span, err);
-            }
+      span => this._runTransaction(span, options, runFn!),
+    );
+  }
 
-            if (err && isSessionNotFoundError(err as grpc.ServiceError)) {
-              span.addEvent('No session available', {
-                'session.id': session?.id,
-              });
-              span.end();
-              this.runTransaction(options, runFn!);
-              return;
-            }
-
-            if (err) {
-              span.end();
-              runFn!(err as grpc.ServiceError);
-              return;
-            }
-
-            transaction!._observabilityOptions = this._observabilityOptions;
-
-            transaction!.requestOptions = Object.assign(
-              transaction!.requestOptions || {},
-              options.requestOptions,
-            );
-
-            transaction!.setReadWriteTransactionOptions(
-              options as RunTransactionOptions,
-            );
-
-            const release = () => {
-              this.sessionFactory_.release(session!);
-              span.end();
-            };
-
-            const runner = new TransactionRunner(
-              session!,
-              transaction!,
-              runFn!,
-              options,
-            );
-
-            runner.run().then(release, err => {
-              setSpanError(span, err!);
-
-              if (isSessionNotFoundError(err)) {
-                span.addEvent('No session available', {
-                  'session.id': session?.id,
-                });
-                release();
-                this.runTransaction(options, runFn!);
-              } else {
-                setImmediate(runFn!, err);
-                release();
-              }
+  private _runTransaction(
+    span: Span,
+    options: RunTransactionOptions,
+    runFn: RunTransactionCallback,
+  ): void {
+    this.sessionFactory_.getSessionForReadWrite(
+      (err, session?, transaction?) => {
+        if (err) {
+          setSpanError(span, err);
+          if (isSessionNotFoundError(err as grpc.ServiceError)) {
+            span.addEvent('No session available', {
+              'session.id': session?.id,
             });
-          },
+            span.end();
+            this.runTransaction(options, runFn);
+            return;
+          }
+          span.end();
+          runFn(err as grpc.ServiceError);
+          return;
+        }
+
+        this._executeTransactionRunner(
+          session!,
+          transaction!,
+          span,
+          options,
+          runFn,
         );
       },
     );
+  }
+
+  private _executeTransactionRunner(
+    session: Session,
+    transaction: Transaction,
+    span: Span,
+    options: RunTransactionOptions,
+    runFn: RunTransactionCallback,
+  ): void {
+    transaction._observabilityOptions = this._observabilityOptions;
+
+    transaction.requestOptions = Object.assign(
+      transaction.requestOptions || {},
+      options.requestOptions,
+    );
+
+    transaction.setReadWriteTransactionOptions(
+      options as RunTransactionOptions,
+    );
+
+    const release = () => {
+      this.sessionFactory_.release(session);
+      span.end();
+    };
+
+    const runner = new TransactionRunner(session, transaction, runFn, options);
+
+    runner
+      .run()
+      .then(
+        () => {
+          release();
+          return null;
+        },
+        err => {
+          setSpanError(span, err!);
+
+          if (isSessionNotFoundError(err)) {
+            span.addEvent('No session available', {
+              'session.id': session.id,
+            });
+            release();
+            this.runTransaction(options, runFn);
+          } else {
+            setImmediate(runFn, err);
+            release();
+          }
+          return null;
+        },
+      )
+      .catch(err => {
+        process.nextTick(() => {
+          throw err;
+        });
+      });
   }
 
   runTransactionAsync<T = {}>(
@@ -3782,13 +3810,22 @@ class Database extends common.GrpcServiceObject {
           return;
         }
         span.addEvent('Using Session', {'session.id': session?.id});
-        this._releaseOnEnd(session!, transaction!, span);
+        const activeTransaction =
+          transaction ?? session?.transaction(this.queryOptions_);
+        if (!activeTransaction) {
+          const error = new Error('No transaction available to commit');
+          setSpanError(span, error);
+          span.end();
+          cb!(error as grpc.ServiceError);
+          return;
+        }
+        this._releaseOnEnd(session!, activeTransaction, span);
         try {
-          transaction!.setReadWriteTransactionOptions(
+          activeTransaction.setReadWriteTransactionOptions(
             options as RunTransactionOptions,
           );
-          transaction?.setQueuedMutations(mutations.proto());
-          return transaction?.commit(options, (err, resp) => {
+          activeTransaction.setQueuedMutations(mutations.proto());
+          return activeTransaction.commit(options, (err, resp) => {
             if (err) {
               setSpanError(span, err);
             }

--- a/handwritten/spanner/src/database.ts
+++ b/handwritten/spanner/src/database.ts
@@ -3428,9 +3428,9 @@ class Database extends common.GrpcServiceObject {
         },
       )
       .catch(err => {
-        process.nextTick(() => {
-          throw err;
-        });
+        setSpanErrorAndException(span, err as Error);
+        span.end();
+        this.emit('error', err);
       });
   }
 

--- a/handwritten/spanner/src/instrument.ts
+++ b/handwritten/spanner/src/instrument.ts
@@ -197,7 +197,7 @@ export function startTrace<T>(
   cb: (span: Span) => T,
 ): T {
   if (!isTracingEnabled(config?.opts)) {
-    return cb(new noopSpan());
+    return cb(NOOP_SPAN);
   }
 
   if (!config) {
@@ -317,18 +317,18 @@ export function getActiveOrNoopSpan(): Span {
   if (span) {
     return span;
   }
-  return new noopSpan();
+  return NOOP_SPAN;
 }
 
 /**
- * noopSpan is a pass-through Span that does nothing and shall not
+ * NoopSpan is a pass-through Span that does nothing and shall not
  * be exported, nor added into any context. It serves as a placeholder
  * to allow calls in sensitive areas like sessionPools to transparently
  * add attributes to spans without lots of ugly null checks.
  *
  * It exists because OpenTelemetry-JS does not seem to export the NoopSpan.
  */
-class noopSpan implements Span {
+class NoopSpan implements Span {
   constructor() {}
 
   spanContext(): SpanContext {
@@ -371,3 +371,5 @@ class noopSpan implements Span {
     return this;
   }
 }
+
+const NOOP_SPAN: Span = new NoopSpan();

--- a/handwritten/spanner/src/multiplexed-session.ts
+++ b/handwritten/spanner/src/multiplexed-session.ts
@@ -95,10 +95,11 @@ export class MultiplexedSession
     this._createSession()
       .then(() => {
         this._maintain();
+        return null;
       })
       // Ignore errors here. If this fails, the next user request will
       // automatically trigger a retry via `_getSession`.
-      .catch(err => {});
+      .catch(() => {});
   }
 
   /**
@@ -196,6 +197,9 @@ export class MultiplexedSession
 
   /**
    * Retrieves a session asynchronously and invokes a callback with the session details.
+   * Note: The callback receives `(null, session)`. To prevent unnecessary allocations on
+   * read query paths, a `Transaction` is not created here. Callers requiring a read-write
+   * transaction should use `SessionFactory.prototype.getSessionForReadWrite`.
    *
    * @param {GetSessionCallback} callback - The callback to be invoked once the session is acquired or an error occurs.
    *
@@ -203,15 +207,30 @@ export class MultiplexedSession
    *
    */
   getSession(callback: GetSessionCallback): void {
-    this._getSession().then(
-      session =>
-        callback(
-          null,
-          session,
-          session!.transaction((session!.parent as Database).queryOptions_),
-        ),
-      callback,
-    );
+    if (this._multiplexedSession !== null) {
+      const session = this._multiplexedSession;
+      const span = getActiveOrNoopSpan();
+      span.addEvent('Cache hit: has usable multiplexed session');
+      // Use process.nextTick to guarantee asynchronous callback execution ("never release Zalgo").
+      // This avoids microtask and Promise allocation overhead while preventing race conditions
+      // where callers (such as Database.prototype.runStream) need to return their stream and
+      // register lifecycle listeners before the session callback executes.
+      process.nextTick(() => {
+        callback(null, session);
+      });
+      return;
+    }
+
+    this._getSession()
+      .then(session => {
+        callback(null, session);
+        return null;
+      }, callback)
+      .catch(err => {
+        process.nextTick(() => {
+          throw err;
+        });
+      });
   }
 
   /**

--- a/handwritten/spanner/src/session-factory.ts
+++ b/handwritten/spanner/src/session-factory.ts
@@ -31,8 +31,10 @@ const common = require('./common-grpc/service-object');
 /**
  * @callback GetSessionCallback
  * @param {?Error} error Request error, if any.
- * @param {Session} session The read-write session.
- * @param {Transaction} transaction The transaction object.
+ * @param {Session} [session] The session object.
+ * @param {Transaction} [transaction] The transaction object, if applicable.
+ *   Omitted for read-only multiplexed session acquisitions to prevent throwaway
+ *   allocations. Provided by getSessionForReadWrite or when using regular session pools.
  */
 export interface GetSessionCallback {
   (
@@ -216,9 +218,20 @@ export class SessionFactory
    * @param {GetSessionCallback} callback The callback function.
    */
   getSessionForReadWrite(callback: GetSessionCallback): void {
-    this.isMultiplexedRW
-      ? this.getSession(callback)
-      : this.pool_.getSession(callback);
+    if (this.isMultiplexedRW) {
+      this.getSession((error, session, transaction) => {
+        if (error || !session) {
+          callback(error ?? new Error('No session found'), null);
+          return;
+        }
+        const database = session.parent as Database;
+        const activeTransaction =
+          transaction ?? session.transaction(database.queryOptions_);
+        callback(null, session, activeTransaction);
+      });
+    } else {
+      this.pool_.getSession(callback);
+    }
   }
 
   /**

--- a/handwritten/spanner/test/database.ts
+++ b/handwritten/spanner/test/database.ts
@@ -3254,16 +3254,7 @@ describe('Database', () => {
       });
     });
 
-    let restoreProcessListeners: (() => void) | null = null;
-
-    afterEach(() => {
-      if (restoreProcessListeners) {
-        restoreProcessListeners();
-        restoreProcessListeners = null;
-      }
-    });
-
-    it('should not treat an error in release as a transaction runner failure', done => {
+    it('should emit an error on database when session release fails after successful run', done => {
       const releaseError = new Error('release failed');
       const releaseStub = (
         sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
@@ -3275,31 +3266,64 @@ describe('Database', () => {
 
       const runFunction = sandbox.spy();
 
-      const originalListeners = process.listeners('uncaughtException');
-      process.removeAllListeners('uncaughtException');
-      restoreProcessListeners = () => {
-        process.removeAllListeners('uncaughtException');
-        for (const listener of originalListeners) {
-          process.on('uncaughtException', listener);
-        }
-      };
-
-      process.once('uncaughtException', (error: Error) => {
-        if (restoreProcessListeners) {
-          restoreProcessListeners();
-          restoreProcessListeners = null;
-        }
+      database.on('error', error => {
         try {
           assert.strictEqual(error, releaseError);
           assert.strictEqual(releaseStub.callCount, 1);
           sinon.assert.notCalled(runFunction);
           done();
-        } catch (err) {
-          done(err);
+        } catch (assertionError) {
+          done(assertionError);
         }
       });
 
       database.runTransaction(runFunction);
+    });
+
+    it('should emit an error on database when session release fails after runner failure', done => {
+      const runnerError = new Error('transaction failed');
+      const releaseError = new Error('release failed');
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      )
+        .withArgs(SESSION)
+        .throws(releaseError);
+
+      sandbox.stub(FakeTransactionRunner.prototype, 'run').rejects(runnerError);
+
+      let databaseErrorReceived = false;
+      let runnerCallbackReceived = false;
+
+      const checkBoth = () => {
+        if (databaseErrorReceived && runnerCallbackReceived) {
+          try {
+            assert.strictEqual(releaseStub.callCount, 1);
+            done();
+          } catch (assertionError) {
+            done(assertionError);
+          }
+        }
+      };
+
+      database.on('error', error => {
+        try {
+          assert.strictEqual(error, releaseError);
+          databaseErrorReceived = true;
+          checkBoth();
+        } catch (assertionError) {
+          done(assertionError);
+        }
+      });
+
+      database.runTransaction(error => {
+        try {
+          assert.strictEqual(error, runnerError);
+          runnerCallbackReceived = true;
+          checkBoth();
+        } catch (assertionError) {
+          done(assertionError);
+        }
+      });
     });
   });
 

--- a/handwritten/spanner/test/database.ts
+++ b/handwritten/spanner/test/database.ts
@@ -3253,6 +3253,54 @@ describe('Database', () => {
         done();
       });
     });
+
+    let restoreProcessListeners: (() => void) | null = null;
+
+    afterEach(() => {
+      if (restoreProcessListeners) {
+        restoreProcessListeners();
+        restoreProcessListeners = null;
+      }
+    });
+
+    it('should not treat an error in release as a transaction runner failure', done => {
+      const releaseError = new Error('release failed');
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      )
+        .withArgs(SESSION)
+        .throws(releaseError);
+
+      sandbox.stub(FakeTransactionRunner.prototype, 'run').resolves();
+
+      const runFunction = sandbox.spy();
+
+      const originalListeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      restoreProcessListeners = () => {
+        process.removeAllListeners('uncaughtException');
+        for (const listener of originalListeners) {
+          process.on('uncaughtException', listener);
+        }
+      };
+
+      process.once('uncaughtException', (error: Error) => {
+        if (restoreProcessListeners) {
+          restoreProcessListeners();
+          restoreProcessListeners = null;
+        }
+        try {
+          assert.strictEqual(error, releaseError);
+          assert.strictEqual(releaseStub.callCount, 1);
+          sinon.assert.notCalled(runFunction);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      database.runTransaction(runFunction);
+    });
   });
 
   describe('runTransactionAsync', () => {

--- a/handwritten/spanner/test/multiplexed-session.ts
+++ b/handwritten/spanner/test/multiplexed-session.ts
@@ -21,7 +21,6 @@ import * as sinon from 'sinon';
 import {Database} from '../src/database';
 import {Session} from '../src/session';
 import {MultiplexedSession} from '../src/multiplexed-session';
-import {Transaction} from '../src/transaction';
 import {FakeTransaction} from './session-pool';
 import {grpc} from 'google-gax';
 
@@ -171,6 +170,15 @@ describe('MultiplexedSession', () => {
   });
 
   describe('getSession', () => {
+    let restoreProcessListeners: (() => void) | null = null;
+
+    afterEach(() => {
+      if (restoreProcessListeners) {
+        restoreProcessListeners();
+        restoreProcessListeners = null;
+      }
+    });
+
     it('should acquire a session', done => {
       sandbox.stub(multiplexedSession, '_getSession').resolves(fakeMuxSession);
       multiplexedSession.getSession((err, session) => {
@@ -189,16 +197,66 @@ describe('MultiplexedSession', () => {
       });
     });
 
-    it('should pass back the session and txn with affinity key', done => {
+    it('should pass back the session', done => {
       sandbox.stub(multiplexedSession, '_getSession').resolves(fakeMuxSession);
-      multiplexedSession.getSession((err, session, txn) => {
-        assert.ifError(err);
+      multiplexedSession.getSession((error, session) => {
+        assert.ifError(error);
         assert.strictEqual(session, fakeMuxSession);
-        assert(txn);
-        assert(txn._affinityKey);
-        assert.strictEqual(typeof txn._affinityKey, 'string');
-        assert(txn._affinityKey.length > 0);
         done();
+      });
+    });
+
+    it('should asynchronously return session when session is cached', done => {
+      multiplexedSession._multiplexedSession = fakeMuxSession;
+      const getSessionStub = sandbox.stub(multiplexedSession, '_getSession');
+      let callbackInvoked = false;
+
+      multiplexedSession.getSession((error, session) => {
+        assert.ifError(error);
+        assert.strictEqual(session, fakeMuxSession);
+        callbackInvoked = true;
+        sinon.assert.notCalled(getSessionStub);
+        done();
+      });
+
+      assert.strictEqual(
+        callbackInvoked,
+        false,
+        'callback should be invoked asynchronously on nextTick even on cache hit',
+      );
+    });
+
+    it('should not invoke callback twice if callback throws synchronously', done => {
+      sandbox.stub(multiplexedSession, '_getSession').resolves(fakeMuxSession);
+      let callbackInvocationCount = 0;
+      const callbackError = new Error('error in user callback');
+
+      const originalListeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      restoreProcessListeners = () => {
+        process.removeAllListeners('uncaughtException');
+        for (const listener of originalListeners) {
+          process.on('uncaughtException', listener);
+        }
+      };
+
+      process.once('uncaughtException', (error: Error) => {
+        if (restoreProcessListeners) {
+          restoreProcessListeners();
+          restoreProcessListeners = null;
+        }
+        try {
+          assert.strictEqual(error, callbackError);
+          assert.strictEqual(callbackInvocationCount, 1);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      multiplexedSession.getSession(() => {
+        callbackInvocationCount++;
+        throw callbackError;
       });
     });
   });

--- a/handwritten/spanner/test/session-factory.ts
+++ b/handwritten/spanner/test/session-factory.ts
@@ -289,9 +289,10 @@ describe('SessionFactory', () => {
             'getSession',
           ) as sinon.SinonStub
         ).callsFake(callback => callback(null, fakeMuxSession));
-        sessionFactory.getSessionForReadWrite((err, resp) => {
+        sessionFactory.getSessionForReadWrite((err, resp, txn) => {
           assert.strictEqual(err, null);
           assert.strictEqual(resp, fakeMuxSession);
+          assert(txn instanceof FakeTransaction);
           assert.strictEqual(resp?.metadata.multiplexed, true);
           assert.strictEqual(fakeMuxSession.metadata.multiplexed, true);
           done();
@@ -309,6 +310,22 @@ describe('SessionFactory', () => {
         sessionFactory.getSessionForReadWrite((err, resp) => {
           assert.strictEqual(err, fakeError);
           assert.strictEqual(resp, null);
+          done();
+        });
+      });
+
+      it('should return a fallback error when session is null and no error was provided', done => {
+        (
+          sandbox.stub(
+            sessionFactory.multiplexedSession_,
+            'getSession',
+          ) as sinon.SinonStub
+        ).callsFake(callback => callback(null, null));
+        sessionFactory.getSessionForReadWrite((err, session, transaction) => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.message, 'No session found');
+          assert.strictEqual(session, null);
+          assert.strictEqual(transaction, undefined);
           done();
         });
       });


### PR DESCRIPTION
- Reuse a singleton NOOP_SPAN instead of allocating on every untraced span lookup
- Dispatch cached multiplexed sessions via process.nextTick to avoid Promise churn
- Stop instantiating unused Transaction objects on read queries in MultiplexedSession.getSession
- Defer Transaction creation to SessionFactory.getSessionForReadWrite for read-write operations
