### PR TITLE
feat(gax): attach internalMethodName to otherArgs in constructSettings

### DIFF
--- a/core/packages/gax/src/gax.ts
+++ b/core/packages/gax/src/gax.ts
@@ -804,9 +804,6 @@ export function constructSettings(
   enableTelemetryTracing?: boolean,
   internalTelemetryInfo?: StaticTraceContext,
 ) {
-  otherArgs = internalTelemetryInfo
-    ? {...otherArgs, internalTelemetryInfo}
-    : otherArgs || {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const defaults: any = {};
 

--- a/core/packages/gax/src/gax.ts
+++ b/core/packages/gax/src/gax.ts
@@ -804,6 +804,9 @@ export function constructSettings(
   enableTelemetryTracing?: boolean,
   internalTelemetryInfo?: StaticTraceContext,
 ) {
+  otherArgs = internalTelemetryInfo
+    ? {...otherArgs, internalTelemetryInfo}
+    : otherArgs || {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const defaults: any = {};
 
@@ -860,9 +863,10 @@ export function constructSettings(
       bundleOptions: bundlingConfig
         ? createBundleOptions(bundlingConfig)
         : null,
-      otherArgs: internalTelemetryInfo || enableTelemetryTracing
-        ? { ...otherArgs, internalMethodName: methodName }
-        : otherArgs,
+      otherArgs:
+        internalTelemetryInfo || enableTelemetryTracing
+          ? {...otherArgs, internalMethodName: methodName}
+          : otherArgs,
       apiName,
       enableTelemetryTracing,
     });

--- a/core/packages/gax/src/gax.ts
+++ b/core/packages/gax/src/gax.ts
@@ -863,7 +863,9 @@ export function constructSettings(
       bundleOptions: bundlingConfig
         ? createBundleOptions(bundlingConfig)
         : null,
-      otherArgs,
+      otherArgs: internalTelemetryInfo || enableTelemetryTracing
+        ? { ...otherArgs, internalMethodName: methodName }
+        : otherArgs,
       apiName,
       enableTelemetryTracing,
     });

--- a/core/packages/gax/test/unit/gax.ts
+++ b/core/packages/gax/test/unit/gax.ts
@@ -116,6 +116,7 @@ describe('gax construct settings', () => {
     assert.strictEqual(settings.otherArgs, otherArgs);
     assert.strictEqual(settings.enableTelemetryTracing, undefined);
     assert.strictEqual(settings.otherArgs.internalTelemetryInfo, undefined);
+    assert.strictEqual(settings.otherArgs.internalMethodName, undefined);
 
     settings = defaults.pageStreamingMethod;
     assert.strictEqual(settings.timeout, 30000);
@@ -124,6 +125,7 @@ describe('gax construct settings', () => {
     assert.strictEqual(settings.otherArgs, otherArgs);
     assert.strictEqual(settings.enableTelemetryTracing, undefined);
     assert.strictEqual(settings.otherArgs.internalTelemetryInfo, undefined);
+    assert.strictEqual(settings.otherArgs.internalMethodName, undefined);
   });
 
   it('overrides settings', () => {
@@ -227,12 +229,17 @@ describe('gax construct settings', () => {
       settings.otherArgs.internalTelemetryInfo,
       telemetryInfo,
     );
+    assert.strictEqual(settings.otherArgs.internalMethodName, 'BundlingMethod');
 
     const pageSettings = defaults.pageStreamingMethod;
     assert.strictEqual(pageSettings.enableTelemetryTracing, true);
     assert.deepStrictEqual(
       pageSettings.otherArgs.internalTelemetryInfo,
       telemetryInfo,
+    );
+    assert.strictEqual(
+      pageSettings.otherArgs.internalMethodName,
+      'PageStreamingMethod',
     );
   });
 
@@ -258,6 +265,7 @@ describe('gax construct settings', () => {
       settings.otherArgs.internalTelemetryInfo,
       telemetryInfo,
     );
+    assert.strictEqual(settings.otherArgs.internalMethodName, 'BundlingMethod');
   });
 
   it('creates settings with enableTelemetryTracing set to false', () => {
@@ -272,6 +280,7 @@ describe('gax construct settings', () => {
     const settings = defaults.bundlingMethod;
     assert.strictEqual(settings.enableTelemetryTracing, false);
     assert.strictEqual(settings.otherArgs.internalTelemetryInfo, undefined);
+    assert.strictEqual(settings.otherArgs.internalMethodName, undefined);
   });
 
   describe('CallSettings telemetry fields', () => {

--- a/core/packages/gax/test/unit/grpc-fallback.ts
+++ b/core/packages/gax/test/unit/grpc-fallback.ts
@@ -253,6 +253,7 @@ describe('grpc-fallback', () => {
     const metadataBuilder = settings.echo.otherArgs.metadataBuilder;
     const headers = metadataBuilder();
     assert(headers['x-goog-api-client'][0].match('grpc-web/'));
+    assert.strictEqual(settings.echo.otherArgs.internalMethodName, undefined);
   });
 
   it('constructSettings should accept enableTelemetryTracing and internalTelemetryInfo', () => {
@@ -288,6 +289,7 @@ describe('grpc-fallback', () => {
       settings.echo.otherArgs.internalTelemetryInfo,
       telemetryInfo,
     );
+    assert.strictEqual(settings.echo.otherArgs.internalMethodName, 'Echo');
   });
 
   it('should make a request', async () => {

--- a/core/packages/gax/test/unit/grpc.ts
+++ b/core/packages/gax/test/unit/grpc.ts
@@ -155,6 +155,10 @@ describe('grpc', () => {
         settings.method.otherArgs.internalTelemetryInfo,
         undefined,
       );
+      assert.strictEqual(
+        settings.method.otherArgs.internalMethodName,
+        undefined,
+      );
     });
 
     it('constructs settings with enableTelemetryTracing and internalTelemetryInfo', () => {
@@ -177,6 +181,10 @@ describe('grpc', () => {
       assert.deepStrictEqual(
         settings.method.otherArgs.internalTelemetryInfo,
         telemetryInfo,
+      );
+      assert.strictEqual(
+        settings.method.otherArgs.internalMethodName,
+        'method',
       );
     });
   });


### PR DESCRIPTION
Update constructSettings() to pass through the method name to `google-gax`
