### PR TITLE
chore(spanner): resolve prettier and eslint lint errors

### DIFF
--- a/handwritten/spanner/src/database.ts
+++ b/handwritten/spanner/src/database.ts
@@ -2381,7 +2381,8 @@ class Database extends common.GrpcServiceObject {
   ): void;
   async getOperations(
     optionsOrCallback?:
-      GetDatabaseOperationsOptions | GetDatabaseOperationsCallback,
+      | GetDatabaseOperationsOptions
+      | GetDatabaseOperationsCallback,
   ): Promise<GetDatabaseOperationsResponse> {
     const options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};

--- a/handwritten/spanner/src/index.ts
+++ b/handwritten/spanner/src/index.ts
@@ -373,7 +373,8 @@ class Spanner extends GrpcService {
    * Gets the configured Spanner emulator host from an environment variable.
    */
   static getSpannerEmulatorHost():
-    {endpoint: string; port?: number} | undefined {
+    | {endpoint: string; port?: number}
+    | undefined {
     const endpointWithPort = process.env.SPANNER_EMULATOR_HOST;
     if (endpointWithPort) {
       if (
@@ -1562,7 +1563,8 @@ class Spanner extends GrpcService {
   ): void;
   getInstanceConfigOperations(
     optionsOrCallback?:
-      GetInstanceConfigOperationsOptions | GetInstanceConfigOperationsCallback,
+      | GetInstanceConfigOperationsOptions
+      | GetInstanceConfigOperationsCallback,
     cb?: GetInstanceConfigOperationsCallback,
   ): void | Promise<GetInstanceConfigOperationsResponse> {
     const callback =

--- a/handwritten/spanner/src/instance-config.ts
+++ b/handwritten/spanner/src/instance-config.ts
@@ -403,7 +403,8 @@ class InstanceConfig extends common.GrpcServiceObject {
   ): void;
   delete(
     optionsOrCallback?:
-      DeleteInstanceConfigRequest | DeleteInstanceConfigCallback,
+      | DeleteInstanceConfigRequest
+      | DeleteInstanceConfigCallback,
     cb?: DeleteInstanceConfigCallback,
   ): void | Promise<DeleteInstanceConfigResponse> {
     const config =

--- a/handwritten/spanner/src/instance.ts
+++ b/handwritten/spanner/src/instance.ts
@@ -128,7 +128,9 @@ export type GetDatabaseOperationsCallback = RequestCallback<
   databaseAdmin.spanner.admin.database.v1.IListDatabaseOperationsResponse
 >;
 export interface GetInstanceConfig
-  extends GetConfig, CreateInstanceRequest, GetInstanceMetadataOptions {}
+  extends GetConfig,
+    CreateInstanceRequest,
+    GetInstanceMetadataOptions {}
 
 interface InstanceRequest {
   (
@@ -595,7 +597,8 @@ class Instance extends common.GrpcServiceObject {
    */
   getBackupOperations(
     optionsOrCallback?:
-      GetBackupOperationsOptions | GetBackupOperationsCallback,
+      | GetBackupOperationsOptions
+      | GetBackupOperationsCallback,
     cb?: GetBackupOperationsCallback,
   ): void | Promise<GetBackupOperationsResponse> {
     const callback =
@@ -721,7 +724,8 @@ class Instance extends common.GrpcServiceObject {
    */
   getDatabaseOperations(
     optionsOrCallback?:
-      GetDatabaseOperationsOptions | GetDatabaseOperationsCallback,
+      | GetDatabaseOperationsOptions
+      | GetDatabaseOperationsCallback,
     cb?: GetDatabaseOperationsCallback,
   ): void | Promise<GetDatabaseOperationsResponse> {
     const callback =
@@ -1520,7 +1524,8 @@ class Instance extends common.GrpcServiceObject {
   ): void;
   getMetadata(
     optionsOrCallback?:
-      GetInstanceMetadataOptions | GetInstanceMetadataCallback,
+      | GetInstanceMetadataOptions
+      | GetInstanceMetadataCallback,
     cb?: GetInstanceMetadataCallback,
   ): Promise<GetInstanceMetadataResponse> | void {
     const callback =

--- a/handwritten/spanner/src/transaction.ts
+++ b/handwritten/spanner/src/transaction.ts
@@ -1852,7 +1852,9 @@ export class Snapshot extends EventEmitter {
    */
   protected _getDirectedReadOptions(
     directedReadOptions:
-      google.spanner.v1.IDirectedReadOptions | null | undefined,
+      | google.spanner.v1.IDirectedReadOptions
+      | null
+      | undefined,
   ) {
     if (
       !directedReadOptions &&
@@ -2909,7 +2911,8 @@ export class Transaction extends Dml {
   ): void;
   rollback(
     gaxOptionsOrCallback?:
-      CallOptions | spannerClient.spanner.v1.Spanner.RollbackCallback,
+      | CallOptions
+      | spannerClient.spanner.v1.Spanner.RollbackCallback,
     cb?: spannerClient.spanner.v1.Spanner.RollbackCallback,
   ): void | Promise<void> {
     let gaxOpts =

--- a/handwritten/spanner/system-test/spanner.ts
+++ b/handwritten/spanner/system-test/spanner.ts
@@ -7023,8 +7023,8 @@ describe('Spanner', () => {
           err.message.includes('UNIMPLEMENTED')
         ) {
           gsqlQueueSupported = false;
-        } else if (err.code == 6) { 
-          // ALREADY_EXISTS. Continue testing. 
+        } else if (err.code === 6) {
+          // ALREADY_EXISTS. Continue testing.
           gsqlQueueSupported = true;
         } else {
           throw err;
@@ -7046,8 +7046,8 @@ describe('Spanner', () => {
           err.message.includes('UNIMPLEMENTED')
         ) {
           pgQueueSupported = false;
-        } else if (err.code == 6) {
-          // ALREADY_EXISTS. Continue testing. 
+        } else if (err.code === 6) {
+          // ALREADY_EXISTS. Continue testing.
           pgQueueSupported = true;
         } else {
           throw err;
@@ -7207,7 +7207,7 @@ describe('Spanner', () => {
       if (gsqlQueueSupported) {
         try {
           const [gsqlOperation] = await DATABASE.updateSchema(
-            "DROP QUEUE " + QUEUE_NAME
+            'DROP QUEUE ' + QUEUE_NAME,
           );
           await gsqlOperation.promise();
         } catch (err) {
@@ -7217,7 +7217,7 @@ describe('Spanner', () => {
       if (pgQueueSupported) {
         try {
           const [pgOperation] = await PG_DATABASE.updateSchema(
-            "DROP QUEUE " + QUEUE_NAME
+            'DROP QUEUE ' + QUEUE_NAME,
           );
           await pgOperation.promise();
         } catch (err) {

--- a/handwritten/spanner/test/mockserver/mockspanner.ts
+++ b/handwritten/spanner/test/mockserver/mockspanner.ts
@@ -108,7 +108,9 @@ export class ReadRequestResult {
   }
 
   private readonly _resultSet:
-    protobuf.ResultSet | protobuf.PartialResultSet[] | null;
+    | protobuf.ResultSet
+    | protobuf.PartialResultSet[]
+    | null;
 
   /**
    * The result set associated with the result, if any.
@@ -175,7 +177,9 @@ export class StatementResult {
     throw new Error('The StatementResult does not contain an Error');
   }
   private readonly _resultSet:
-    protobuf.ResultSet | protobuf.PartialResultSet[] | null;
+    | protobuf.ResultSet
+    | protobuf.PartialResultSet[]
+    | null;
   get resultSet(): protobuf.ResultSet | protobuf.PartialResultSet[] {
     if (this._resultSet) {
       return this._resultSet;
@@ -855,7 +859,9 @@ export class MockSpanner {
 
   private static emptyPartialResultSet(
     precommitToken:
-      protobuf.IMultiplexedSessionPrecommitToken | null | undefined,
+      | protobuf.IMultiplexedSessionPrecommitToken
+      | null
+      | undefined,
     resumeToken: Uint8Array,
   ): protobuf.PartialResultSet {
     return protobuf.PartialResultSet.create({
@@ -866,7 +872,9 @@ export class MockSpanner {
 
   private static toPartialResultSet(
     precommitToken:
-      protobuf.IMultiplexedSessionPrecommitToken | null | undefined,
+      | protobuf.IMultiplexedSessionPrecommitToken
+      | null
+      | undefined,
     rowCount: number,
   ): protobuf.PartialResultSet {
     const stats = {


### PR DESCRIPTION
## Description
Fixes nightly Kokoro build failures in `cloud-devrel/client-libraries/nodejs/nightly/googleapis/nodejs-spanner/node18/lint` (Build #522, invocation 1f0888dd-081f-4f6f-a2df-5d1ca1671d30).

### Root Cause
PR #9200 introduced 24 ESLint and Prettier formatting errors across Spanner source and test files:
- Prettier multiline union and interface extension formatting in `database.ts`, `index.ts`, `instance-config.ts`, `instance.ts`, `transaction.ts`, and `mockspanner.ts`
- Loose equality comparisons (`err.code == 6`), trailing spaces, and double-quoted strings in `system-test/spanner.ts`

### Changes
- Ran `gts fix` across `handwritten/spanner` to resolve all 22 automated formatting errors.
- Updated `err.code == 6` to strict equality `err.code === 6` and cleaned up trailing spaces in `system-test/spanner.ts`.
- Verified that ESLint passes cleanly with 0 errors across all affected files.