### PR TITLE
http2: Fix issue where slow requests are terminated prematurely

### DIFF
--- a/core/packages/nodejs-googleapis-common/test/test.http2.ts
+++ b/core/packages/nodejs-googleapis-common/test/test.http2.ts
@@ -42,6 +42,9 @@ class FakeClient extends EventEmitter {
     callback();
   };
   destroy = () => {};
+  setTimeout = (timeout: number, callback: () => {}) => {
+    setTimeout(callback, timeout);
+  };
 }
 
 describe('http2', () => {


### PR DESCRIPTION
Ported over from https://github.com/googleapis/google-cloud-node-core/pull/879

This PR fixes an issue where http2 requests taking longer than 500ms will be terminated prematurely, with `http2.request` silently resolving with truncated responses instead of rejecting with an error.

The issue comes from starting the idle shutdown timer (500ms) immediately after the beginning of the latest request on the session, and not detecting that the session is still actively transferring data before forcefully terminating the session.

This PR fixes that by switching the connection idle shutdown timer to `session.setTimeout` instead of `setTimeout`.

I've also verified that this fix makes the client in https://github.com/hyperair/google-http2-bug-demo work correctly (more info [here](https://github.com/googleapis/google-cloud-node/issues/7750#issuecomment-3714064284)):
- all requests return the correct untruncated data
- client process shuts down properly after all requests are done

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/{{metadata['repo']['name']}}/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #7750 🦕
