### PR TITLE
test(spanner): handle Node 18 prototype equality in PartialResultStream row assertions

### DIFF
--- a/handwritten/spanner/test/partial-result-stream.ts
+++ b/handwritten/spanner/test/partial-result-stream.ts
@@ -193,7 +193,14 @@ describe('PartialResultStream', () => {
 
     it('should emit rows', done => {
       stream.on('error', done).on('data', row => {
-        assert.deepStrictEqual(row, EXPECTED_ROW);
+        // Node 18's assert.deepStrictEqual strictly requires prototype equality,
+        // which fails when comparing RowImpl (an Array subclass) with a plain Array literal.
+        // Node 20+ relaxed this for Array subclasses with constructor = Array.
+        if (parseInt(process.versions.node.split('.')[0], 10) < 20) {
+          assert.deepStrictEqual([...row], EXPECTED_ROW);
+        } else {
+          assert.deepStrictEqual(row, EXPECTED_ROW);
+        }
         done();
       });
 
@@ -250,7 +257,14 @@ describe('PartialResultStream', () => {
         assert.deepStrictEqual(json, fakeJson);
 
         const [row, options] = stub.lastCall.args;
-        assert.deepStrictEqual(row, EXPECTED_ROW);
+        // Node 18's assert.deepStrictEqual strictly requires prototype equality,
+        // which fails when comparing RowImpl (an Array subclass) with a plain Array literal.
+        // Node 20+ relaxed this for Array subclasses with constructor = Array.
+        if (parseInt(process.versions.node.split('.')[0], 10) < 20) {
+          assert.deepStrictEqual([...row], EXPECTED_ROW);
+        } else {
+          assert.deepStrictEqual(row, EXPECTED_ROW);
+        }
         assert.strictEqual(options, jsonOptions);
         done();
       });


### PR DESCRIPTION
Node 18's `assert.deepStrictEqual` strictly enforces prototype equality (`Object.getPrototypeOf(a) === Object.getPrototypeOf(b)`), which causes assertions comparing `RowImpl` (an Array subclass with `constructor: Array`) against plain Array literals (`EXPECTED_ROW`) to fail with "Values have same structure but are not reference-equal".

Add a Node major version check in `PartialResultStream` row emission unit tests to spread `row` into a standard Array on Node < 20 while asserting `row` directly on Node 20+, keeping tests green across all supported Node versions without altering the `RowImpl` performance optimizations.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/{{metadata['repo']['name']}}/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
