### PR TITLE
perf(spanner): bypass gRPC message interception in metrics interceptor

### DIFF
--- a/handwritten/spanner/src/metrics/interceptor.ts
+++ b/handwritten/spanner/src/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {grpc} from 'google-gax';
+import {InterceptingListener, Metadata, StatusObject} from '@grpc/grpc-js';
 import {MetricsTracerFactory} from './metrics-tracer-factory';
 
 /**
@@ -42,8 +43,9 @@ export const MetricInterceptor = (options, nextCall) => {
       const requestId = metadata.get('x-goog-spanner-request-id')[0] as string;
       const metricsTracer = factory?.getCurrentTracer(requestId);
       metricsTracer?.recordAttemptStart();
-      const newListener = {
-        onReceiveMetadata: function (metadata, next) {
+
+      const interceptingListener: InterceptingListener = {
+        onReceiveMetadata: function (metadata: Metadata) {
           // Record GFE/AFE Metrics
           // GFE/AFE latency if available,
           // or else increase the GFE/AFE connectivity error count
@@ -57,13 +59,13 @@ export const MetricInterceptor = (options, nextCall) => {
             metricsTracer.afeLatency = afeTiming ?? null;
           }
 
-          next(metadata);
+          listener.onReceiveMetadata(metadata);
         },
-        onReceiveMessage: function (message, next) {
-          next(message);
+        onReceiveMessage: function (message: unknown) {
+          listener.onReceiveMessage(message);
         },
-        onReceiveStatus: function (status, next) {
-          next(status);
+        onReceiveStatus: function (status: StatusObject) {
+          listener.onReceiveStatus(status);
 
           // Record attempt metric completion
           metricsTracer?.recordAttemptCompletion(status.code);
@@ -79,18 +81,8 @@ export const MetricInterceptor = (options, nextCall) => {
           }
         },
       };
-      next(metadata, newListener);
-    },
-    sendMessage: function (message, next) {
-      next(message);
-    },
 
-    halfClose: function (next) {
-      next();
-    },
-
-    cancel: function (next) {
-      next();
+      next(metadata, interceptingListener);
     },
   });
 };

--- a/handwritten/spanner/test/metrics/interceptor.ts
+++ b/handwritten/spanner/test/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,92 @@ describe('MetricInterceptor', () => {
   });
 
   describe('Metrics recorded from interceptor', () => {
+    it('does not define redundant requester hooks and passes a direct InterceptingListener to next()', () => {
+      const originalInterceptingCall = grpc.InterceptingCall;
+      let capturedRequester: grpc.Requester | undefined;
+
+      Object.defineProperty(grpc, 'InterceptingCall', {
+        value: class extends originalInterceptingCall {
+          constructor(nextCall: Function, requester: grpc.Requester) {
+            super(nextCall as unknown as grpc.InterceptingCall, requester);
+            capturedRequester = requester;
+          }
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+
+        // Verify that custom sendMessage, halfClose, or cancel hooks are NOT defined on the requester
+        assert.strictEqual(capturedRequester?.sendMessage, undefined);
+        assert.strictEqual(capturedRequester?.halfClose, undefined);
+        assert.strictEqual(capturedRequester?.cancel, undefined);
+        assert.strictEqual(typeof capturedRequester?.start, 'function');
+
+        // Verify that the listener passed to next() conforms to InterceptingListener (methods take 1 argument)
+        interceptingCall.start(testMetadata, mockListener);
+
+        // capturedListener is what nextCall.start received; since it is an InterceptingListener,
+        // @grpc/grpc-js bypasses InterceptingListenerImpl and forwards it directly
+        assert.strictEqual(capturedListener.onReceiveMetadata.length, 1);
+        assert.strictEqual(capturedListener.onReceiveMessage.length, 1);
+        assert.strictEqual(capturedListener.onReceiveStatus.length, 1);
+
+        // Verify that incoming messages forward directly to mockListener
+        const message = {test: 'row-data'};
+        capturedListener.onReceiveMessage(message);
+        assert.strictEqual(mockListener.onReceiveMessage.callCount, 1);
+        assert.strictEqual(
+          mockListener.onReceiveMessage.firstCall.args[0],
+          message,
+        );
+      } finally {
+        Object.defineProperty(grpc, 'InterceptingCall', {
+          value: originalInterceptingCall,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
+    it('transparently passes through messages, halfClose, and cancelWithStatus to the underlying call', () => {
+      const mockUnderlyingCall = {
+        start: sandbox.stub(),
+        sendMessageWithContext: sandbox.stub(),
+        halfClose: sandbox.stub(),
+        cancelWithStatus: sandbox.stub(),
+      };
+      const mockNextCallFn = sandbox.stub().returns(mockUnderlyingCall);
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCallFn);
+
+      const message = {values: ['test-row']};
+      interceptingCall.sendMessage(message);
+      assert.strictEqual(
+        mockUnderlyingCall.sendMessageWithContext.callCount,
+        1,
+      );
+      assert.strictEqual(
+        mockUnderlyingCall.sendMessageWithContext.firstCall.args[1],
+        message,
+      );
+
+      interceptingCall.halfClose();
+      assert.strictEqual(mockUnderlyingCall.halfClose.callCount, 1);
+
+      interceptingCall.cancelWithStatus(Status.CANCELLED, 'cancelled');
+      assert.strictEqual(mockUnderlyingCall.cancelWithStatus.callCount, 1);
+      assert.strictEqual(
+        mockUnderlyingCall.cancelWithStatus.firstCall.args[0],
+        Status.CANCELLED,
+      );
+      assert.strictEqual(
+        mockUnderlyingCall.cancelWithStatus.firstCall.args[1],
+        'cancelled',
+      );
+    });
+
     it('AttemptMetrics', () => {
       const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
 


### PR DESCRIPTION
MetricInterceptor previously defined pass-through requester hooks (sendMessage, halfClose, cancel) and used a 2-argument Listener interface. This caused @grpc/grpc-js to wrap every call in an InterceptingListenerImpl, adding a closure allocation and state machine bookkeeping for every streamed chunk.

This change implements InterceptingListener directly and removes the redundant requester hooks. Because the listener methods now take a single argument, @grpc/grpc-js recognizes the listener as synchronous and forwards incoming streaming messages directly to downstream handlers.
