### PR TITLE
perf(spanner): avoid cloning metadata map in metrics interceptor

### DIFF
--- a/handwritten/spanner/src/metrics/interceptor.ts
+++ b/handwritten/spanner/src/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,11 @@ export const MetricInterceptor = (options, nextCall) => {
           // GFE/AFE latency if available,
           // or else increase the GFE/AFE connectivity error count
           if (metricsTracer) {
-            const serverTimingHeader = metadata.getMap()['server-timing'];
+            const serverTimingEntries = metadata.get('server-timing');
+            const serverTimingHeader =
+              serverTimingEntries.length > 0
+                ? String(serverTimingEntries[0])
+                : undefined;
             const gfeTiming =
               metricsTracer?.extractGfeLatency(serverTimingHeader);
             metricsTracer.gfeLatency = gfeTiming ?? null;

--- a/handwritten/spanner/test/metrics/interceptor.ts
+++ b/handwritten/spanner/test/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,6 +213,19 @@ describe('MetricInterceptor', () => {
         mockMetricsTracer.recordAfeConnectivityErrorCount.getCall(0).args,
         Status.OK,
       );
+    });
+
+    it('reads server-timing header using metadata.get without calling metadata.getMap', () => {
+      const getMapSpy = sandbox.spy(serverTimingMetadata, 'getMap');
+      const getSpy = sandbox.spy(serverTimingMetadata, 'get');
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      capturedListener.onReceiveMetadata(serverTimingMetadata);
+
+      assert.strictEqual(getMapSpy.callCount, 0);
+      assert.strictEqual(getSpy.calledWith('server-timing'), true);
+      assert.strictEqual(mockMetricsTracer.extractGfeLatency.calledOnce, true);
     });
   });
 });


### PR DESCRIPTION
MetricInterceptor previously called metadata.getMap() to read the server-timing response header. getMap() constructs a fresh object and copies every response header, creating unnecessary allocations and iteration overhead on every RPC attempt.

This change replaces getMap() with a direct metadata.get('server-timing') lookup, reading the header value without cloning the entire metadata dictionary.
