### PR TITLE
perf(spanner): cache OTel attribute objects in metrics tracer

### DIFF
--- a/handwritten/spanner/src/metrics/metrics-tracer-factory.ts
+++ b/handwritten/spanner/src/metrics/metrics-tracer-factory.ts
@@ -54,6 +54,8 @@ export class MetricsTracerFactory {
   private _projectId: string;
   private _currentOperationTracers = new Map();
   private _currentOperationLastUpdatedMs = new Map();
+  private _attributesCache: Map<string, Map<string, Record<string, string>>> =
+    new Map();
   private _intervalTracerCleanup: NodeJS.Timeout;
   public static enabled = true;
 
@@ -111,7 +113,7 @@ export class MetricsTracerFactory {
       MetricsTracerFactory._instance = new MetricsTracerFactory(projectId);
     }
 
-    return MetricsTracerFactory!._instance;
+    return MetricsTracerFactory._instance;
   }
 
   /**
@@ -153,11 +155,12 @@ export class MetricsTracerFactory {
    */
   public async resetMeterProvider() {
     if (this._meterProvider !== null) {
-      await this._meterProvider!.shutdown();
+      await this._meterProvider.shutdown();
     }
     this._meterProvider = null;
     this._currentOperationTracers = new Map();
     this._currentOperationLastUpdatedMs = new Map();
+    this._attributesCache = new Map();
   }
 
   /**
@@ -238,6 +241,12 @@ export class MetricsTracerFactory {
     }
 
     const {instance, database} = this.getInstanceAttributes(formattedName);
+    const cacheKey = `${instance}/${database}/${method}`;
+    let attributesCache = this._attributesCache.get(cacheKey);
+    if (!attributesCache) {
+      attributesCache = new Map<string, Record<string, string>>();
+      this._attributesCache.set(cacheKey, attributesCache);
+    }
     const tracer = new MetricsTracer(
       this._instrumentAttemptCounter,
       this._instrumentAttemptLatency,
@@ -253,6 +262,7 @@ export class MetricsTracerFactory {
       this._projectId,
       method,
       operationRequest,
+      attributesCache,
     );
     this._currentOperationTracers.set(operationRequest, tracer);
     this._currentOperationLastUpdatedMs.set(operationRequest, Date.now());

--- a/handwritten/spanner/src/metrics/metrics-tracer.ts
+++ b/handwritten/spanner/src/metrics/metrics-tracer.ts
@@ -128,6 +128,12 @@ export class MetricsTracer {
    */
   private _clientAttributes: {[key: string]: string} = {};
 
+  /**
+   * Cached OTel attribute objects keyed by status name, avoiding repeated
+   * object allocations on every metric recording call.
+   */
+  private _attributesByStatus: Map<string, Record<string, string>>;
+
   /*
    * The current GFE latency associated with this tracer.
    */
@@ -166,10 +172,13 @@ export class MetricsTracer {
     private _projectId: string,
     private _methodName: string,
     private _request: string,
+    attributesCache?: Map<string, Record<string, string>>,
   ) {
     this._clientAttributes[METRIC_LABEL_KEY_DATABASE] = _database;
     this._clientAttributes[METRIC_LABEL_KEY_METHOD] = _methodName;
     this._clientAttributes[MONITORED_RES_LABEL_KEY_INSTANCE] = _instance;
+    this._attributesByStatus =
+      attributesCache ?? new Map<string, Record<string, string>>();
   }
 
   /**
@@ -222,8 +231,8 @@ export class MetricsTracer {
    * Increments the attempt count and creates a new MetricAttemptTracer.
    */
   public recordAttemptStart() {
-    if (!this.enabled) return;
-    this.currentOperation!.createNewAttempt();
+    if (!this.enabled || !this.currentOperation) return;
+    this.currentOperation.createNewAttempt();
   }
 
   /**
@@ -232,12 +241,13 @@ export class MetricsTracer {
    * @param status The status code of the attempt (default: Status.OK).
    */
   public recordAttemptCompletion(statusCode: Status = Status.OK) {
-    if (!this.enabled) return;
-    this.currentOperation!.currentAttempt!.status = Status[statusCode];
+    if (!this.enabled || !this.currentOperation?.currentAttempt) return;
+    const currentAttempt = this.currentOperation.currentAttempt;
+    currentAttempt.status = Status[statusCode] ?? Status[Status.UNKNOWN];
     const attemptAttributes = this._createAttemptOtelAttributes();
     const endTime = performance.now();
     const attemptLatencyMilliseconds = this._getMillisecondTimeDifference(
-      this.currentOperation!.currentAttempt!.startTime,
+      currentAttempt.startTime,
       endTime,
     );
     this.instrumentAttemptLatency?.record(
@@ -268,7 +278,7 @@ export class MetricsTracer {
     const endTime = performance.now();
     const operationAttributes = this._createOperationOtelAttributes();
     const operationLatencyMilliseconds = this._getMillisecondTimeDifference(
-      this.currentOperation!.startTime,
+      this.currentOperation.startTime,
       endTime,
     );
 
@@ -277,7 +287,7 @@ export class MetricsTracer {
       operationLatencyMilliseconds,
       operationAttributes,
     );
-    MetricsTracerFactory.getInstance(this._projectId)!.clearCurrentTracer(
+    MetricsTracerFactory.getInstance(this._projectId)?.clearCurrentTracer(
       this._request,
     );
   }
@@ -314,6 +324,35 @@ export class MetricsTracer {
   }
 
   /**
+   * Returns a cached set of OTEL attributes for the given status, avoiding
+   * repeated object cloning on every metric record/add call.
+   *
+   * @param status Optional status code (as numeric Status enum or status name string).
+   * @returns The cached attributes object.
+   */
+  private _getAttributesForStatus(
+    status?: Status | string,
+  ): Record<string, string> {
+    const statusString =
+      typeof status === 'number'
+        ? (Status[status] ?? Status[Status.UNKNOWN])
+        : typeof status === 'string'
+          ? status
+          : undefined;
+    const cacheKey = statusString ?? '';
+    let attributes = this._attributesByStatus.get(cacheKey);
+    if (!attributes) {
+      const newAttributes: Record<string, string> = {...this._clientAttributes};
+      if (statusString !== undefined) {
+        newAttributes[METRIC_LABEL_KEY_STATUS] = statusString;
+      }
+      attributes = Object.freeze(newAttributes);
+      this._attributesByStatus.set(cacheKey, attributes);
+    }
+    return attributes;
+  }
+
+  /**
    * Records the provided GFE latency.
    * @param latency The GFE latency in milliseconds.
    */
@@ -326,8 +365,7 @@ export class MetricsTracer {
       return;
     }
 
-    const attributes = {...this._clientAttributes};
-    attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
+    const attributes = this._getAttributesForStatus(statusCode);
 
     this._instrumentGfeLatency?.record(this.gfeLatency, attributes);
     this.gfeLatency = null; // Reset latency value
@@ -338,8 +376,7 @@ export class MetricsTracer {
    */
   public recordGfeConnectivityErrorCount(statusCode: Status) {
     if (!this.enabled) return;
-    const attributes = {...this._clientAttributes};
-    attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
+    const attributes = this._getAttributesForStatus(statusCode);
     this._instrumentGfeConnectivityErrorCount?.add(1, attributes);
   }
 
@@ -348,8 +385,7 @@ export class MetricsTracer {
    */
   public recordAfeConnectivityErrorCount(statusCode: Status) {
     if (!this.enabled || !Spanner.isAFEServerTimingEnabled()) return;
-    const attributes = {...this._clientAttributes};
-    attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
+    const attributes = this._getAttributesForStatus(statusCode);
     this._instrumentAfeConnectivityErrorCount?.add(1, attributes);
   }
 
@@ -366,8 +402,7 @@ export class MetricsTracer {
       return;
     }
 
-    const attributes = {...this._clientAttributes};
-    attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
+    const attributes = this._getAttributesForStatus(statusCode);
 
     this._instrumentAfeLatency?.record(this.afeLatency, attributes);
     this.afeLatency = null; // Reset latency value
@@ -379,10 +414,9 @@ export class MetricsTracer {
    */
   private _createOperationOtelAttributes() {
     if (!this.enabled) return {};
-    const attributes = {...this._clientAttributes};
-    attributes[METRIC_LABEL_KEY_STATUS] =
-      this.currentOperation!.currentAttempt?.status ?? Status[Status.UNKNOWN];
-    return attributes;
+    const status =
+      this.currentOperation?.currentAttempt?.status ?? Status[Status.UNKNOWN];
+    return this._getAttributesForStatus(status);
   }
 
   /**
@@ -393,11 +427,11 @@ export class MetricsTracer {
    */
   private _createAttemptOtelAttributes() {
     if (!this.enabled) return {};
-    const attributes = {...this._clientAttributes};
-    if (this.currentOperation?.currentAttempt === null) return attributes;
-    attributes[METRIC_LABEL_KEY_STATUS] =
-      this.currentOperation!.currentAttempt.status;
-
-    return attributes;
+    if (!this.currentOperation?.currentAttempt) {
+      return this._getAttributesForStatus();
+    }
+    return this._getAttributesForStatus(
+      this.currentOperation.currentAttempt.status,
+    );
   }
 }

--- a/handwritten/spanner/test/metrics/metrics-tracer-factory.ts
+++ b/handwritten/spanner/test/metrics/metrics-tracer-factory.ts
@@ -18,6 +18,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import {status as Status} from '@grpc/grpc-js';
 import * as Constants from '../../src/metrics/constants';
 import {MetricsTracerFactory} from '../../src/metrics/metrics-tracer-factory';
 import {CloudMonitoringMetricsExporter} from '../../src/metrics/spanner-metrics-exporter';
@@ -193,6 +194,118 @@ describe('MetricsTracerFactory', () => {
       tracer!.clientAttributes[Constants.MONITORED_RES_LABEL_KEY_INSTANCE],
       'instance',
     );
+  });
+
+  it('should share attributes cache across tracers for the same method and resource', () => {
+    const factory = MetricsTracerFactory.getInstance('project-id')!;
+    const tracer1 = factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.1.1',
+    );
+    const tracer2 = factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.2.1',
+    );
+
+    const attributes1 = (tracer1 as any)._getAttributesForStatus(Status.OK);
+    const attributes2 = (tracer2 as any)._getAttributesForStatus(Status.OK);
+
+    assert.strictEqual(attributes1, attributes2);
+    assert.deepStrictEqual(attributes1, {
+      [Constants.METRIC_LABEL_KEY_DATABASE]: 'database',
+      [Constants.METRIC_LABEL_KEY_METHOD]: 'ExecuteSql',
+      [Constants.MONITORED_RES_LABEL_KEY_INSTANCE]: 'instance',
+      [Constants.METRIC_LABEL_KEY_STATUS]: 'OK',
+    });
+  });
+
+  it('should use distinct attributes caches for different methods or resources', () => {
+    const factory = MetricsTracerFactory.getInstance('project-id')!;
+    const sqlTracer = factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.1.1',
+    );
+    const commitTracer = factory.createMetricsTracer(
+      'Commit',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.2.1',
+    );
+
+    const sqlAttributes = (sqlTracer as any)._getAttributesForStatus(Status.OK);
+    const commitAttributes = (commitTracer as any)._getAttributesForStatus(
+      Status.OK,
+    );
+
+    assert.notStrictEqual(sqlAttributes, commitAttributes);
+    assert.strictEqual(
+      sqlAttributes[Constants.METRIC_LABEL_KEY_METHOD],
+      'ExecuteSql',
+    );
+    assert.strictEqual(
+      commitAttributes[Constants.METRIC_LABEL_KEY_METHOD],
+      'Commit',
+    );
+  });
+
+  it('should use distinct attributes caches for different databases', () => {
+    const factory = MetricsTracerFactory.getInstance('project-id')!;
+    const databaseOneTracer = factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database-1',
+      '1.1a2bc3d4.1.1.1.1',
+    );
+    const databaseTwoTracer = factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database-2',
+      '1.1a2bc3d4.1.1.2.1',
+    );
+
+    const databaseOneAttributes = (
+      databaseOneTracer as any
+    )._getAttributesForStatus(Status.OK);
+    const databaseTwoAttributes = (
+      databaseTwoTracer as any
+    )._getAttributesForStatus(Status.OK);
+
+    assert.notStrictEqual(databaseOneAttributes, databaseTwoAttributes);
+    assert.strictEqual(
+      databaseOneAttributes[Constants.METRIC_LABEL_KEY_DATABASE],
+      'database-1',
+    );
+    assert.strictEqual(
+      databaseTwoAttributes[Constants.METRIC_LABEL_KEY_DATABASE],
+      'database-2',
+    );
+  });
+
+  it('should reset attributes cache when resetMeterProvider is called', async () => {
+    const factory = MetricsTracerFactory.getInstance('project-id')!;
+    factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.1.1',
+    );
+    assert.strictEqual(factory['_attributesCache'].size, 1);
+
+    await factory.resetMeterProvider();
+    assert.strictEqual(factory['_attributesCache'].size, 0);
+  });
+
+  it('should reset attributes cache when resetInstance is called', async () => {
+    const factory = MetricsTracerFactory.getInstance('project-id')!;
+    factory.createMetricsTracer(
+      'ExecuteSql',
+      'projects/project/instances/instance/databases/database',
+      '1.1a2bc3d4.1.1.1.1',
+    );
+    assert.strictEqual(factory['_attributesCache'].size, 1);
+
+    await MetricsTracerFactory.resetInstance();
+    const newFactory = MetricsTracerFactory.getInstance('project-id')!;
+    assert.strictEqual(newFactory['_attributesCache'].size, 0);
   });
 });
 

--- a/handwritten/spanner/test/metrics/metrics-tracer.ts
+++ b/handwritten/spanner/test/metrics/metrics-tracer.ts
@@ -133,16 +133,42 @@ describe('MetricsTracer', () => {
       tracer.recordAttemptStart();
       tracer.recordAttemptCompletion(Status.OK);
       assert.strictEqual(fakeAttemptLatency.record.called, false);
+      assert.strictEqual(fakeAttemptCounter.add.called, false);
+    });
+
+    it('should do nothing when currentOperation is null on recordAttemptStart', () => {
+      tracer.currentOperation = null;
+      assert.doesNotThrow(() => {
+        tracer.recordAttemptStart();
+      });
+      assert.strictEqual(tracer.currentOperation, null);
+    });
+
+    it('should do nothing when currentOperation is null on recordAttemptCompletion', () => {
+      tracer.currentOperation = null;
+      assert.doesNotThrow(() => {
+        tracer.recordAttemptCompletion(Status.OK);
+      });
+      assert.strictEqual(fakeAttemptLatency.record.called, false);
+      assert.strictEqual(fakeAttemptCounter.add.called, false);
+    });
+
+    it('should do nothing when currentAttempt is null on recordAttemptCompletion', () => {
+      tracer.recordOperationStart();
+      assert.strictEqual(tracer.currentOperation!.currentAttempt, null);
+      assert.doesNotThrow(() => {
+        tracer.recordAttemptCompletion(Status.OK);
+      });
+      assert.strictEqual(fakeAttemptLatency.record.called, false);
+      assert.strictEqual(fakeAttemptCounter.add.called, false);
     });
   });
 
   describe('recordOperationCompletion', () => {
     it('should record operation and attempt metrics when enabled', () => {
-      const factory = sandbox
-        .stub(MetricsTracerFactory, 'getInstance')
-        .returns({
-          clearCurrentTracer: sinon.spy(),
-        } as any);
+      sandbox.stub(MetricsTracerFactory, 'getInstance').returns({
+        clearCurrentTracer: sinon.spy(),
+      } as any);
       tracer.recordOperationStart();
       assert.ok(tracer.currentOperation!.startTime);
       tracer.recordAttemptStart();
@@ -153,8 +179,11 @@ describe('MetricsTracer', () => {
       assert.strictEqual(fakeAttemptCounter.add.calledOnce, true);
       assert.strictEqual(fakeOperationLatency.record.calledOnce, true);
 
-      const [[_, opAttrs]] = fakeOperationLatency.record.args;
-      assert.strictEqual(opAttrs[Constants.METRIC_LABEL_KEY_STATUS], 'OK');
+      const [[, operationAttributes]] = fakeOperationLatency.record.args;
+      assert.strictEqual(
+        operationAttributes[Constants.METRIC_LABEL_KEY_STATUS],
+        'OK',
+      );
     });
 
     it('should record fractional operation latency with sub-millisecond precision', () => {
@@ -183,6 +212,27 @@ describe('MetricsTracer', () => {
       tracer.recordOperationCompletion();
       assert.strictEqual(fakeOperationCounter.add.called, false);
       assert.strictEqual(fakeOperationLatency.record.called, false);
+    });
+
+    it('should do nothing when currentOperation is null', () => {
+      tracer.currentOperation = null;
+      assert.doesNotThrow(() => {
+        tracer.recordOperationCompletion();
+      });
+      assert.strictEqual(fakeOperationCounter.add.called, false);
+      assert.strictEqual(fakeOperationLatency.record.called, false);
+    });
+
+    it('should handle getInstance returning null when clearing current tracer', () => {
+      sandbox.stub(MetricsTracerFactory, 'getInstance').returns(null);
+      tracer.recordOperationStart();
+      tracer.recordAttemptStart();
+      tracer.recordAttemptCompletion(Status.OK);
+      assert.doesNotThrow(() => {
+        tracer.recordOperationCompletion();
+      });
+      assert.strictEqual(fakeOperationCounter.add.calledOnce, true);
+      assert.strictEqual(fakeOperationLatency.record.calledOnce, true);
     });
   });
 
@@ -330,6 +380,194 @@ describe('MetricsTracer', () => {
       assert.strictEqual(gfeLatency, null);
       const afeLatency = tracer.extractAfeLatency(header);
       assert.strictEqual(afeLatency, 30);
+    });
+  });
+
+  describe('OTel attributes caching', () => {
+    it('should reuse cached attribute objects across metric recording methods for the same status', () => {
+      sandbox.stub(MetricsTracerFactory, 'getInstance').returns({
+        clearCurrentTracer: sinon.spy(),
+      } as any);
+
+      tracer.enabled = true;
+      tracer.gfeLatency = 120;
+      tracer.afeLatency = 45;
+
+      tracer.recordOperationStart();
+      tracer.recordAttemptStart();
+      tracer.recordAttemptCompletion(Status.OK);
+      tracer.recordGfeLatency(Status.OK);
+      tracer.recordAfeLatency(Status.OK);
+      tracer.recordOperationCompletion();
+
+      const [[, attemptAttributes]] = fakeAttemptLatency.record.args;
+      const [[, attemptCounterAttributes]] = fakeAttemptCounter.add.args;
+      const [[, gfeAttributes]] = fakeGfeLatency.record.args;
+      const [[, afeAttributes]] = fakeAfeLatency.record.args;
+      const [[, operationAttributes]] = fakeOperationLatency.record.args;
+      const [[, operationCounterAttributes]] = fakeOperationCounter.add.args;
+
+      assert.strictEqual(attemptAttributes, attemptCounterAttributes);
+      assert.strictEqual(attemptAttributes, gfeAttributes);
+      assert.strictEqual(attemptAttributes, afeAttributes);
+      assert.strictEqual(attemptAttributes, operationAttributes);
+      assert.strictEqual(attemptAttributes, operationCounterAttributes);
+
+      assert.deepStrictEqual(attemptAttributes, {
+        [Constants.METRIC_LABEL_KEY_DATABASE]: DATABASE,
+        [Constants.METRIC_LABEL_KEY_METHOD]: METHOD,
+        [Constants.MONITORED_RES_LABEL_KEY_INSTANCE]: INSTANCE,
+        [Constants.METRIC_LABEL_KEY_STATUS]: 'OK',
+      });
+    });
+
+    it('should cache distinct attribute objects for different status codes', () => {
+      tracer.enabled = true;
+      tracer.recordGfeConnectivityErrorCount(Status.OK);
+      tracer.recordGfeConnectivityErrorCount(Status.UNAVAILABLE);
+
+      const [[, okAttributes]] = fakeGfeCounter.add.args;
+      const [[, unavailableAttributes]] = fakeGfeCounter.add.args.slice(1);
+
+      assert.notStrictEqual(okAttributes, unavailableAttributes);
+      assert.strictEqual(okAttributes[Constants.METRIC_LABEL_KEY_STATUS], 'OK');
+      assert.strictEqual(
+        unavailableAttributes[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNAVAILABLE',
+      );
+    });
+
+    it('should handle undefined status without status label', () => {
+      const attributes = (tracer as any)._getAttributesForStatus();
+      assert.strictEqual(
+        attributes[Constants.METRIC_LABEL_KEY_STATUS],
+        undefined,
+      );
+      assert.strictEqual(
+        attributes[Constants.METRIC_LABEL_KEY_DATABASE],
+        DATABASE,
+      );
+      assert.strictEqual(
+        attributes[Constants.MONITORED_RES_LABEL_KEY_INSTANCE],
+        INSTANCE,
+      );
+      assert.strictEqual(attributes[Constants.METRIC_LABEL_KEY_METHOD], METHOD);
+    });
+
+    it('should handle null status without status label', () => {
+      const attributes = (tracer as any)._getAttributesForStatus(null);
+      assert.strictEqual(
+        attributes[Constants.METRIC_LABEL_KEY_STATUS],
+        undefined,
+      );
+      assert.strictEqual(
+        attributes[Constants.METRIC_LABEL_KEY_DATABASE],
+        DATABASE,
+      );
+    });
+
+    it('should fallback to UNKNOWN for unrecognized numeric status code', () => {
+      const attributes = (tracer as any)._getAttributesForStatus(999);
+      assert.strictEqual(
+        attributes[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNKNOWN',
+      );
+    });
+
+    it('should use external attributes cache map when supplied', () => {
+      const sharedCache = new Map<string, Record<string, string>>();
+      const customTracer = new MetricsTracer(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        DATABASE,
+        INSTANCE,
+        PROJECT_ID,
+        METHOD,
+        REQUEST,
+        sharedCache,
+      );
+
+      const attributes = (customTracer as any)._getAttributesForStatus(
+        Status.OK,
+      );
+      assert.strictEqual(sharedCache.get('OK'), attributes);
+    });
+
+    it('should freeze cached attribute objects to ensure immutability', () => {
+      const attributes = (tracer as any)._getAttributesForStatus(Status.OK);
+      assert.ok(Object.isFrozen(attributes));
+    });
+
+    it('should handle missing currentOperation or currentAttempt in _createAttemptOtelAttributes', () => {
+      tracer.currentOperation = null;
+      const attributesWithoutOperation = (
+        tracer as any
+      )._createAttemptOtelAttributes();
+      assert.strictEqual(
+        attributesWithoutOperation[Constants.METRIC_LABEL_KEY_STATUS],
+        undefined,
+      );
+
+      tracer.recordOperationStart();
+      const attributesWithoutAttempt = (
+        tracer as any
+      )._createAttemptOtelAttributes();
+      assert.strictEqual(
+        attributesWithoutAttempt[Constants.METRIC_LABEL_KEY_STATUS],
+        undefined,
+      );
+    });
+
+    it('should handle missing currentOperation or currentAttempt in _createOperationOtelAttributes', () => {
+      tracer.currentOperation = null;
+      const attributesWithoutOperation = (
+        tracer as any
+      )._createOperationOtelAttributes();
+      assert.strictEqual(
+        attributesWithoutOperation[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNKNOWN',
+      );
+
+      tracer.recordOperationStart();
+      const attributesWithoutAttempt = (
+        tracer as any
+      )._createOperationOtelAttributes();
+      assert.strictEqual(
+        attributesWithoutAttempt[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNKNOWN',
+      );
+    });
+
+    it('should record attempt and operation completion with UNKNOWN status for unrecognized status code', () => {
+      sandbox.stub(MetricsTracerFactory, 'getInstance').returns({
+        clearCurrentTracer: sinon.spy(),
+      } as any);
+
+      tracer.enabled = true;
+      tracer.recordOperationStart();
+      tracer.recordAttemptStart();
+      tracer.recordAttemptCompletion(999 as any);
+      tracer.recordOperationCompletion();
+
+      const [[, attemptAttributes]] = fakeAttemptLatency.record.args;
+      const [[, operationAttributes]] = fakeOperationLatency.record.args;
+
+      assert.strictEqual(
+        attemptAttributes[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNKNOWN',
+      );
+      assert.strictEqual(
+        operationAttributes[Constants.METRIC_LABEL_KEY_STATUS],
+        'UNKNOWN',
+      );
+      assert.strictEqual(attemptAttributes, operationAttributes);
     });
   });
 });


### PR DESCRIPTION
Caches OpenTelemetry metric attribute objects to eliminate repeated object allocations and reverse-enum lookups on hot RPC execution paths:

- Replaces repeated object cloning (`{...this._clientAttributes}`) across attempt, operation, GFE, and AFE metric recordings with a cached lookup keyed by status code.
- Shares the attribute cache across MetricsTracer instances in MetricsTracerFactory per database, instance, and method, ensuring zero attribute object allocations in steady state.
- Freezes cached attribute objects to guarantee immutability across shared references.
- Fixes defensive checks in attempt attribute generation when operations or attempts are uninitialized.
- Ensures consistent fallback to UNKNOWN status across attempt and operation metrics for unrecognized status codes.
