### PR TITLE
perf(spanner): optimize query option merging and prevent in-place mutation

### DIFF
--- a/handwritten/spanner/src/metrics/interceptor.ts
+++ b/handwritten/spanner/src/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 import {grpc} from 'google-gax';
 import {MetricsTracerFactory} from './metrics-tracer-factory';
+import {Spanner} from '../index';
 
 /**
  * Interceptor for recording metrics on gRPC calls.
@@ -42,6 +43,7 @@ export const MetricInterceptor = (options, nextCall) => {
       const requestId = metadata.get('x-goog-spanner-request-id')[0] as string;
       const metricsTracer = factory?.getCurrentTracer(requestId);
       metricsTracer?.recordAttemptStart();
+      const isAfeServerTimingEnabled = Spanner.isAFEServerTimingEnabled();
       const newListener = {
         onReceiveMetadata: function (metadata, next) {
           // Record GFE/AFE Metrics
@@ -52,9 +54,11 @@ export const MetricInterceptor = (options, nextCall) => {
             const gfeTiming =
               metricsTracer?.extractGfeLatency(serverTimingHeader);
             metricsTracer.gfeLatency = gfeTiming ?? null;
-            const afeTiming =
-              metricsTracer?.extractAfeLatency(serverTimingHeader);
-            metricsTracer.afeLatency = afeTiming ?? null;
+            if (isAfeServerTimingEnabled) {
+              const afeTiming =
+                metricsTracer?.extractAfeLatency(serverTimingHeader);
+              metricsTracer.afeLatency = afeTiming ?? null;
+            }
           }
 
           next(metadata);
@@ -72,10 +76,12 @@ export const MetricInterceptor = (options, nextCall) => {
           } else {
             metricsTracer?.recordGfeConnectivityErrorCount(status.code);
           }
-          if (metricsTracer?.afeLatency) {
-            metricsTracer?.recordAfeLatency(status.code);
-          } else {
-            metricsTracer?.recordAfeConnectivityErrorCount(status.code);
+          if (isAfeServerTimingEnabled) {
+            if (metricsTracer?.afeLatency) {
+              metricsTracer?.recordAfeLatency(status.code);
+            } else {
+              metricsTracer?.recordAfeConnectivityErrorCount(status.code);
+            }
           }
         },
       };

--- a/handwritten/spanner/src/metrics/metrics-tracer.ts
+++ b/handwritten/spanner/src/metrics/metrics-tracer.ts
@@ -318,7 +318,7 @@ export class MetricsTracer {
    * @param latency The GFE latency in milliseconds.
    */
   public recordGfeLatency(statusCode: Status) {
-    if (!this.enabled) return;
+    if (!this.enabled || !this._instrumentGfeLatency) return;
     if (!this.gfeLatency) {
       console.error(
         'ERROR: Attempted to record GFE metric with no latency value.',
@@ -329,7 +329,7 @@ export class MetricsTracer {
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
 
-    this._instrumentGfeLatency?.record(this.gfeLatency, attributes);
+    this._instrumentGfeLatency.record(this.gfeLatency, attributes);
     this.gfeLatency = null; // Reset latency value
   }
 
@@ -337,20 +337,26 @@ export class MetricsTracer {
    * Increments the GFE connectivity error count metric.
    */
   public recordGfeConnectivityErrorCount(statusCode: Status) {
-    if (!this.enabled) return;
+    if (!this.enabled || !this._instrumentGfeConnectivityErrorCount) return;
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
-    this._instrumentGfeConnectivityErrorCount?.add(1, attributes);
+    this._instrumentGfeConnectivityErrorCount.add(1, attributes);
   }
 
   /**
    * Increments the AFE connectivity error count metric.
    */
   public recordAfeConnectivityErrorCount(statusCode: Status) {
-    if (!this.enabled || !Spanner.isAFEServerTimingEnabled()) return;
+    if (
+      !this.enabled ||
+      !this._instrumentAfeConnectivityErrorCount ||
+      !Spanner.isAFEServerTimingEnabled()
+    ) {
+      return;
+    }
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
-    this._instrumentAfeConnectivityErrorCount?.add(1, attributes);
+    this._instrumentAfeConnectivityErrorCount.add(1, attributes);
   }
 
   /**
@@ -358,7 +364,13 @@ export class MetricsTracer {
    * @param latency The AFE latency in milliseconds.
    */
   public recordAfeLatency(statusCode: Status) {
-    if (!this.enabled || !Spanner.isAFEServerTimingEnabled()) return;
+    if (
+      !this.enabled ||
+      !this._instrumentAfeLatency ||
+      !Spanner.isAFEServerTimingEnabled()
+    ) {
+      return;
+    }
     if (!this.afeLatency) {
       console.error(
         'ERROR: Attempted to record AFE metric with no latency value.',
@@ -369,7 +381,7 @@ export class MetricsTracer {
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
 
-    this._instrumentAfeLatency?.record(this.afeLatency, attributes);
+    this._instrumentAfeLatency.record(this.afeLatency, attributes);
     this.afeLatency = null; // Reset latency value
   }
 

--- a/handwritten/spanner/test/metrics/interceptor.ts
+++ b/handwritten/spanner/test/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import {status as Status} from '@grpc/grpc-js';
 import {MetricsTracerFactory} from '../../src/metrics/metrics-tracer-factory';
 import {MetricsTracer} from '../../src/metrics/metrics-tracer';
 import {MetricInterceptor} from '../../src/metrics/interceptor';
+import {Spanner} from '../../src/index';
 
 describe('MetricInterceptor', () => {
   let sandbox: sinon.SinonSandbox;
@@ -65,6 +66,14 @@ describe('MetricInterceptor', () => {
       void
     >();
     mockMetricsTracer.recordGfeConnectivityErrorCount = sandbox.stub<
+      [statusCode: number],
+      void
+    >();
+    mockMetricsTracer.recordAfeLatency = sandbox.stub<
+      [latency: number],
+      void
+    >();
+    mockMetricsTracer.recordAfeConnectivityErrorCount = sandbox.stub<
       [statusCode: number],
       void
     >();
@@ -125,6 +134,8 @@ describe('MetricInterceptor', () => {
 
   afterEach(() => {
     sandbox.restore();
+    Spanner._resetAFEServerTimingForTest();
+    delete process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'];
   });
 
   describe('Metrics recorded from interceptor', () => {
@@ -212,6 +223,23 @@ describe('MetricInterceptor', () => {
       assert.equal(
         mockMetricsTracer.recordAfeConnectivityErrorCount.getCall(0).args,
         Status.OK,
+      );
+    });
+
+    it('AFE Metrics - Disabled when AFE server timing is disabled', () => {
+      Spanner._resetAFEServerTimingForTest();
+      process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'] = 'true';
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      capturedListener.onReceiveMetadata(emptyMetadata);
+      capturedListener.onReceiveStatus(mockStatus);
+
+      assert.strictEqual(mockMetricsTracer.extractAfeLatency.callCount, 0);
+      assert.strictEqual(mockMetricsTracer.recordAfeLatency.callCount, 0);
+      assert.strictEqual(
+        mockMetricsTracer.recordAfeConnectivityErrorCount.callCount,
+        0,
       );
     });
   });


### PR DESCRIPTION
Short-circuit query option merging when options are unset to eliminate allocations on the hot path, make field handling generic, and merge into a fresh protobuf to avoid in-place mutation of base options.
