### PR TITLE
perf(spanner): hoist AFE timing check to skip AFE metrics

### DIFF
--- a/handwritten/spanner/src/common.ts
+++ b/handwritten/spanner/src/common.ts
@@ -18,7 +18,6 @@ import {grpc, CallOptions, Operation as GaxOperation} from 'google-gax';
 import {protos} from '@google-cloud/spanner-api';
 import instanceAdmin = protos.google;
 import databaseAdmin = protos.google;
-import {Spanner} from '.';
 
 export type IOperation = instanceAdmin.longrunning.IOperation;
 
@@ -102,6 +101,33 @@ export function addLeaderAwareRoutingHeader(headers: {[k: string]: string}) {
   headers[LEADER_AWARE_ROUTING_HEADER] = 'true';
 }
 
+let isAFEServerTimingEnabledCached: boolean | undefined;
+
+/**
+ * Returns whether AFE (Application Frontend Extension) server timing is enabled.
+ *
+ * This function checks the value of the environment variable
+ * `SPANNER_DISABLE_AFE_SERVER_TIMING`. If the variable is set to the
+ * string `'true'` (case-insensitive), then AFE server timing is considered disabled,
+ * and this function returns `false`. For all other values (including if the variable is unset),
+ * the function returns `true`.
+ *
+ * @returns {boolean} `true` if AFE server timing is enabled; otherwise, `false`.
+ */
+export function isAFEServerTimingEnabled(): boolean {
+  if (isAFEServerTimingEnabledCached === undefined) {
+    isAFEServerTimingEnabledCached =
+      process.env['SPANNER_DISABLE_AFE_SERVER_TIMING']?.toLowerCase() !==
+      'true';
+  }
+  return isAFEServerTimingEnabledCached;
+}
+
+/** Resets the cached value (use in tests if env changes). */
+export function resetAFEServerTimingForTest(): void {
+  isAFEServerTimingEnabledCached = undefined;
+}
+
 /**
  * Returns common headers to add.
  * @param headers Common header list.
@@ -119,7 +145,7 @@ export function getCommonHeaders(
     headers[END_TO_END_TRACING_HEADER] = 'true';
   }
 
-  if (Spanner.isAFEServerTimingEnabled()) {
+  if (isAFEServerTimingEnabled()) {
     headers[AFE_SERVER_TIMING_HEADER] = 'true';
   }
 

--- a/handwritten/spanner/src/index.ts
+++ b/handwritten/spanner/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable import/namespace, promise/catch-or-return, promise/always-return */
+
 import {GrpcService, GrpcServiceConfig} from './common-grpc/service';
 import {PreciseDate} from '@google-cloud/precise-date';
 import {replaceProjectIdToken} from './helper';
@@ -74,6 +76,8 @@ import {
   CLOUD_RESOURCE_HEADER,
   NormalCallback,
   getCommonHeaders,
+  isAFEServerTimingEnabled,
+  resetAFEServerTimingForTest,
 } from './common';
 import {Session} from './session';
 import {SessionPool} from './session-pool';
@@ -329,7 +333,6 @@ class Spanner extends GrpcService {
   private _universeDomain: string;
   private _isInSecureCredentials: boolean;
   private _metricsEnabled = false;
-  private static _isAFEServerTimingEnabled: boolean | undefined;
   readonly _nthClientId: number;
 
   /**
@@ -356,17 +359,11 @@ class Spanner extends GrpcService {
    *
    * @returns {boolean} `true` if AFE server timing is enabled; otherwise, `false`.
    */
-  public static isAFEServerTimingEnabled = (): boolean => {
-    if (this._isAFEServerTimingEnabled === undefined) {
-      this._isAFEServerTimingEnabled =
-        process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'] !== 'true';
-    }
-    return this._isAFEServerTimingEnabled;
-  };
+  public static isAFEServerTimingEnabled = isAFEServerTimingEnabled;
 
   /** Resets the cached value (use in tests if env changes). */
   public static _resetAFEServerTimingForTest(): void {
-    this._isAFEServerTimingEnabled = undefined;
+    resetAFEServerTimingForTest();
   }
 
   /**

--- a/handwritten/spanner/src/metrics/interceptor.ts
+++ b/handwritten/spanner/src/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 import {grpc} from 'google-gax';
 import {MetricsTracerFactory} from './metrics-tracer-factory';
+import {isAFEServerTimingEnabled} from '../common';
 
 /**
  * Interceptor for recording metrics on gRPC calls.
@@ -42,6 +43,7 @@ export const MetricInterceptor = (options, nextCall) => {
       const requestId = metadata.get('x-goog-spanner-request-id')[0] as string;
       const metricsTracer = factory?.getCurrentTracer(requestId);
       metricsTracer?.recordAttemptStart();
+      const afeServerTimingEnabled = isAFEServerTimingEnabled();
       const newListener = {
         onReceiveMetadata: function (metadata, next) {
           // Record GFE/AFE Metrics
@@ -50,11 +52,13 @@ export const MetricInterceptor = (options, nextCall) => {
           if (metricsTracer) {
             const serverTimingHeader = metadata.getMap()['server-timing'];
             const gfeTiming =
-              metricsTracer?.extractGfeLatency(serverTimingHeader);
+              metricsTracer.extractGfeLatency(serverTimingHeader);
             metricsTracer.gfeLatency = gfeTiming ?? null;
-            const afeTiming =
-              metricsTracer?.extractAfeLatency(serverTimingHeader);
-            metricsTracer.afeLatency = afeTiming ?? null;
+            if (afeServerTimingEnabled) {
+              const afeTiming =
+                metricsTracer.extractAfeLatency(serverTimingHeader);
+              metricsTracer.afeLatency = afeTiming ?? null;
+            }
           }
 
           next(metadata);
@@ -65,17 +69,23 @@ export const MetricInterceptor = (options, nextCall) => {
         onReceiveStatus: function (status, next) {
           next(status);
 
-          // Record attempt metric completion
-          metricsTracer?.recordAttemptCompletion(status.code);
-          if (metricsTracer?.gfeLatency) {
-            metricsTracer?.recordGfeLatency(status.code);
-          } else {
-            metricsTracer?.recordGfeConnectivityErrorCount(status.code);
+          if (!metricsTracer) {
+            return;
           }
-          if (metricsTracer?.afeLatency) {
-            metricsTracer?.recordAfeLatency(status.code);
+
+          // Record attempt metric completion
+          metricsTracer.recordAttemptCompletion(status.code);
+          if (typeof metricsTracer.gfeLatency === 'number') {
+            metricsTracer.recordGfeLatency(status.code);
           } else {
-            metricsTracer?.recordAfeConnectivityErrorCount(status.code);
+            metricsTracer.recordGfeConnectivityErrorCount(status.code);
+          }
+          if (afeServerTimingEnabled) {
+            if (typeof metricsTracer.afeLatency === 'number') {
+              metricsTracer.recordAfeLatency(status.code);
+            } else {
+              metricsTracer.recordAfeConnectivityErrorCount(status.code);
+            }
           }
         },
       };

--- a/handwritten/spanner/src/metrics/metrics-tracer.ts
+++ b/handwritten/spanner/src/metrics/metrics-tracer.ts
@@ -21,7 +21,7 @@ import {
   METRIC_LABEL_KEY_STATUS,
   MONITORED_RES_LABEL_KEY_INSTANCE,
 } from './constants';
-import {Spanner} from '..';
+import {isAFEServerTimingEnabled} from '../common';
 
 /**
  * MetricAttemptTracer tracks the start time and status of a single gRPC attempt.
@@ -305,7 +305,7 @@ export class MetricsTracer {
    * @returns The extracted AFE latency in milliseconds, or null if not found.
    */
   public extractAfeLatency(header: string): number | null {
-    if (!Spanner.isAFEServerTimingEnabled()) return null;
+    if (!isAFEServerTimingEnabled()) return null;
     const regex = /afe; dur=([0-9]+).*/;
     if (header === undefined) return null;
     const match = header.match(regex);
@@ -314,12 +314,12 @@ export class MetricsTracer {
   }
 
   /**
-   * Records the provided GFE latency.
-   * @param latency The GFE latency in milliseconds.
+   * Records the GFE latency for this attempt.
+   * @param statusCode The gRPC status code of the attempt.
    */
   public recordGfeLatency(statusCode: Status) {
-    if (!this.enabled) return;
-    if (!this.gfeLatency) {
+    if (!this.enabled || !this._instrumentGfeLatency) return;
+    if (this.gfeLatency === null || this.gfeLatency === undefined) {
       console.error(
         'ERROR: Attempted to record GFE metric with no latency value.',
       );
@@ -329,7 +329,7 @@ export class MetricsTracer {
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
 
-    this._instrumentGfeLatency?.record(this.gfeLatency, attributes);
+    this._instrumentGfeLatency.record(this.gfeLatency, attributes);
     this.gfeLatency = null; // Reset latency value
   }
 
@@ -337,29 +337,41 @@ export class MetricsTracer {
    * Increments the GFE connectivity error count metric.
    */
   public recordGfeConnectivityErrorCount(statusCode: Status) {
-    if (!this.enabled) return;
+    if (!this.enabled || !this._instrumentGfeConnectivityErrorCount) return;
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
-    this._instrumentGfeConnectivityErrorCount?.add(1, attributes);
+    this._instrumentGfeConnectivityErrorCount.add(1, attributes);
   }
 
   /**
    * Increments the AFE connectivity error count metric.
    */
   public recordAfeConnectivityErrorCount(statusCode: Status) {
-    if (!this.enabled || !Spanner.isAFEServerTimingEnabled()) return;
+    if (
+      !this.enabled ||
+      !this._instrumentAfeConnectivityErrorCount ||
+      !isAFEServerTimingEnabled()
+    ) {
+      return;
+    }
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
-    this._instrumentAfeConnectivityErrorCount?.add(1, attributes);
+    this._instrumentAfeConnectivityErrorCount.add(1, attributes);
   }
 
   /**
-   * Records the provided AFE latency.
-   * @param latency The AFE latency in milliseconds.
+   * Records the AFE latency for this attempt.
+   * @param statusCode The gRPC status code of the attempt.
    */
   public recordAfeLatency(statusCode: Status) {
-    if (!this.enabled || !Spanner.isAFEServerTimingEnabled()) return;
-    if (!this.afeLatency) {
+    if (
+      !this.enabled ||
+      !this._instrumentAfeLatency ||
+      !isAFEServerTimingEnabled()
+    ) {
+      return;
+    }
+    if (this.afeLatency === null || this.afeLatency === undefined) {
       console.error(
         'ERROR: Attempted to record AFE metric with no latency value.',
       );
@@ -369,7 +381,7 @@ export class MetricsTracer {
     const attributes = {...this._clientAttributes};
     attributes[METRIC_LABEL_KEY_STATUS] = Status[statusCode];
 
-    this._instrumentAfeLatency?.record(this.afeLatency, attributes);
+    this._instrumentAfeLatency.record(this.afeLatency, attributes);
     this.afeLatency = null; // Reset latency value
   }
 

--- a/handwritten/spanner/test/metrics/interceptor.ts
+++ b/handwritten/spanner/test/metrics/interceptor.ts
@@ -1,4 +1,4 @@
-﻿// Copyright 2025 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import {status as Status} from '@grpc/grpc-js';
 import {MetricsTracerFactory} from '../../src/metrics/metrics-tracer-factory';
 import {MetricsTracer} from '../../src/metrics/metrics-tracer';
 import {MetricInterceptor} from '../../src/metrics/interceptor';
+import {Spanner} from '../../src/index';
 
 describe('MetricInterceptor', () => {
   let sandbox: sinon.SinonSandbox;
@@ -61,10 +62,18 @@ describe('MetricInterceptor', () => {
         return null;
       }) as sinon.SinonStub<[string], number | null>;
     mockMetricsTracer.recordGfeLatency = sandbox.stub<
-      [latency: number],
+      [statusCode: number],
       void
     >();
     mockMetricsTracer.recordGfeConnectivityErrorCount = sandbox.stub<
+      [statusCode: number],
+      void
+    >();
+    mockMetricsTracer.recordAfeLatency = sandbox.stub<
+      [statusCode: number],
+      void
+    >();
+    mockMetricsTracer.recordAfeConnectivityErrorCount = sandbox.stub<
       [statusCode: number],
       void
     >();
@@ -125,6 +134,8 @@ describe('MetricInterceptor', () => {
 
   afterEach(() => {
     sandbox.restore();
+    Spanner._resetAFEServerTimingForTest();
+    delete process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'];
   });
 
   describe('Metrics recorded from interceptor', () => {
@@ -213,6 +224,81 @@ describe('MetricInterceptor', () => {
         mockMetricsTracer.recordAfeConnectivityErrorCount.getCall(0).args,
         Status.OK,
       );
+    });
+
+    it('AFE Metrics - Disabled when AFE server timing is disabled', () => {
+      Spanner._resetAFEServerTimingForTest();
+      process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'] = 'true';
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      capturedListener.onReceiveMetadata(serverTimingMetadata);
+      capturedListener.onReceiveStatus(mockStatus);
+
+      assert.strictEqual(mockMetricsTracer.extractGfeLatency.callCount, 1);
+      assert.strictEqual(mockMetricsTracer.extractAfeLatency.callCount, 0);
+      assert.strictEqual(mockMetricsTracer.recordGfeLatency.callCount, 1);
+      assert.strictEqual(mockMetricsTracer.recordAfeLatency.callCount, 0);
+      assert.strictEqual(
+        mockMetricsTracer.recordAfeConnectivityErrorCount.callCount,
+        0,
+      );
+    });
+
+    it('AFE Metrics - Case-insensitive disabled when set to TRUE', () => {
+      Spanner._resetAFEServerTimingForTest();
+      process.env['SPANNER_DISABLE_AFE_SERVER_TIMING'] = 'TRUE';
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      capturedListener.onReceiveMetadata(serverTimingMetadata);
+      capturedListener.onReceiveStatus(mockStatus);
+
+      assert.strictEqual(mockMetricsTracer.extractGfeLatency.callCount, 1);
+      assert.strictEqual(mockMetricsTracer.extractAfeLatency.callCount, 0);
+      assert.strictEqual(mockMetricsTracer.recordGfeLatency.callCount, 1);
+      assert.strictEqual(mockMetricsTracer.recordAfeLatency.callCount, 0);
+      assert.strictEqual(
+        mockMetricsTracer.recordAfeConnectivityErrorCount.callCount,
+        0,
+      );
+    });
+
+    it('GFE and AFE Metrics - Records 0ms latency without incrementing error count', () => {
+      mockMetricsTracer.extractGfeLatency = sandbox
+        .stub<[string], number | null>()
+        .returns(0);
+      mockMetricsTracer.extractAfeLatency = sandbox
+        .stub<[string], number | null>()
+        .returns(0);
+
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      capturedListener.onReceiveMetadata(emptyMetadata);
+      capturedListener.onReceiveStatus(mockStatus);
+
+      assert.strictEqual(mockMetricsTracer.recordGfeLatency.callCount, 1);
+      assert.strictEqual(
+        mockMetricsTracer.recordGfeConnectivityErrorCount.callCount,
+        0,
+      );
+      assert.strictEqual(mockMetricsTracer.recordAfeLatency.callCount, 1);
+      assert.strictEqual(
+        mockMetricsTracer.recordAfeConnectivityErrorCount.callCount,
+        0,
+      );
+    });
+
+    it('does not throw or record when metricsTracer is null', () => {
+      mockFactory.getCurrentTracer.returns(null);
+      const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
+      interceptingCall.start(testMetadata, mockListener);
+
+      assert.doesNotThrow(() => {
+        capturedListener.onReceiveMetadata(serverTimingMetadata);
+        capturedListener.onReceiveStatus(mockStatus);
+      });
     });
   });
 });

--- a/handwritten/spanner/test/metrics/metrics-tracer.ts
+++ b/handwritten/spanner/test/metrics/metrics-tracer.ts
@@ -200,6 +200,15 @@ describe('MetricsTracer', () => {
       tracer.recordGfeLatency(Status.OK);
       assert.strictEqual(fakeGfeLatency.record.called, false);
     });
+
+    it('should record GFE latency when value is 0', () => {
+      tracer.enabled = true;
+      tracer.gfeLatency = 0;
+      tracer.recordGfeLatency(Status.OK);
+      assert.strictEqual(fakeGfeLatency.record.calledOnce, true);
+      assert.strictEqual(fakeGfeLatency.record.firstCall.args[0], 0);
+      assert.strictEqual(tracer.gfeLatency, null);
+    });
   });
 
   describe('recordGfeConnectivityErrorCount', () => {
@@ -242,6 +251,15 @@ describe('MetricsTracer', () => {
       tracer.afeLatency = 123;
       tracer.recordAfeLatency(Status.OK);
       assert.strictEqual(fakeAfeLatency.record.called, false);
+    });
+
+    it('should record AFE latency when value is 0', () => {
+      tracer.enabled = true;
+      tracer.afeLatency = 0;
+      tracer.recordAfeLatency(Status.OK);
+      assert.strictEqual(fakeAfeLatency.record.calledOnce, true);
+      assert.strictEqual(fakeAfeLatency.record.firstCall.args[0], 0);
+      assert.strictEqual(tracer.afeLatency, null);
     });
   });
 


### PR DESCRIPTION
Hoist isAFEServerTimingEnabled check to MetricInterceptor to completely bypass AFE header parsing and metric recording when AFE server-timing is disabled. Also guard MetricsTracer record methods to avoid attribute allocation when instruments are uninitialized.
